### PR TITLE
added possible metrics values to dynatrace_disk_anomalies resource documentation

### DIFF
--- a/docs/resources/disk_anomalies.md
+++ b/docs/resources/disk_anomalies.md
@@ -18,7 +18,7 @@ description: |-
 ### Required
 
 - **enabled** (Boolean) Disk event rule enabled/disabled
-- **metric** (String) The metric to monitor
+- **metric** (String) The metric to monitor. Possible values are: `LOW_DISK_SPACE`, `LOW_INODES`, `READ_TIME_EXCEEDING` and `WRITE_TIME_EXCEEDING`
 - **name** (String) The name of the disk event rule
 - **samples** (Number) The number of samples to evaluate
 - **threshold** (Number) The threshold to trigger disk event.   * A percentage for `LowDiskSpace` or `LowInodes` metrics.   * In milliseconds for `ReadTimeExceeding` or `WriteTimeExceeding` metrics


### PR DESCRIPTION
This update is intended to address issue #78 by providing the names of the metrics that can be specified when defining a dynatrace_disk_anomalies resource.  The values were pulled from the Dynatrace API documentation at <https://www.dynatrace.com/support/help/dynatrace-api/configuration-api/anomaly-detection-api/anomaly-detection-api-disk-events/post-event/#expand-the-element-can-hold-these-values-1488>.