### PR TITLE
Fixing some -export crashes

### DIFF
--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -145,7 +145,11 @@ func (me *Module) Resource(id string) *Resource {
 	return res
 }
 
+var mkdirMutex = new(sync.Mutex)
+
 func (me *Module) MkdirAll(flawed bool) error {
+	mkdirMutex.Lock()
+	defer mkdirMutex.Unlock()
 	if flawed {
 		return os.MkdirAll(me.GetFlawedFolder(), os.ModePerm)
 	}

--- a/dynatrace/export/unique_names.go
+++ b/dynatrace/export/unique_names.go
@@ -20,6 +20,7 @@ package export
 import (
 	"fmt"
 	"strings"
+	"sync"
 )
 
 type ReplaceFunc func(s string, cnt int) string
@@ -38,12 +39,13 @@ type UniqueNamer interface {
 }
 
 func NewUniqueNamer() UniqueNamer {
-	return &nameCounter{m: map[string]int{}}
+	return &nameCounter{m: map[string]int{}, mutex: new(sync.Mutex)}
 }
 
 type nameCounter struct {
 	m       map[string]int
 	replace ReplaceFunc
+	mutex   *sync.Mutex
 }
 
 func (me *nameCounter) Replace(replace ReplaceFunc) UniqueNamer {
@@ -52,6 +54,8 @@ func (me *nameCounter) Replace(replace ReplaceFunc) UniqueNamer {
 }
 
 func (me *nameCounter) Name(name string) string {
+	me.mutex.Lock()
+	defer me.mutex.Unlock()
 	cnt, found := me.m[strings.ToLower(name)]
 	if !found {
 		me.m[strings.ToLower(name)] = 0


### PR DESCRIPTION
My -export was crashing on:
- a thread locked for MkDir
- concurrent get and set of the unique names map