### PR TITLE
doc: fix resource and cloud provider references

### DIFF
--- a/docs/resources/aws_service.md
+++ b/docs/resources/aws_service.md
@@ -24,7 +24,7 @@ If you want to configure a different set of metrics for a specific service, a se
 Just be aware of the fact, that Dynatrace enforces for most services a recommended set of metrics. All of them need to be part of your configuration in order to end up with a non-empty plan.
 
 ```terraform
-resource "dynatrace_aws_service" "TERRAFORM_SAMPLE" {
+resource "dynatrace_aws_credentials" "TERRAFORM_SAMPLE" {
   label          = "TERRAFORM-TEST-001"
   partition_type = "AWS_DEFAULT"
   tagged_only    = false
@@ -39,7 +39,7 @@ data "dynatrace_aws_supported_services" "supported_services" {
 
 resource "dynatrace_aws_service" "TERRAFORM_SAMPLE_services" {
   for_each = data.dynatrace_aws_supported_services.supported_services.services
-  credentials_id = dynatrace_aws_service.TERRAFORM_SAMPLE.id
+  credentials_id = dynatrace_aws_credentials.TERRAFORM_SAMPLE.id
   use_recommended_metrics = true
   name           = each.key
 }
@@ -50,7 +50,7 @@ resource "dynatrace_aws_service" "TERRAFORM_SAMPLE_services" {
 
 ### Required
 
-- `credentials_id` (String) the ID of the azure credentials this supported service belongs to
+- `credentials_id` (String) the ID of the AWS credentials this supported service belongs to
 
 ### Optional
 


### PR DESCRIPTION
Minor documentation fixes - an incorrectly named resource and reference to cloud provider for the `dynatrace_aws_service` resource documentation.