### PR TITLE
add an env. var. to ignore changes done

### DIFF
--- a/dynatrace/api/builtin/cloud/cloudfoundry/settings/settings.go
+++ b/dynatrace/api/builtin/cloud/cloudfoundry/settings/settings.go
@@ -18,6 +18,7 @@
 package cloudfoundry
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -74,15 +75,18 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 }
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeAll(map[string]any{
-		"active_gate_group": me.ActiveGateGroup,
-		"api_url":           me.ApiUrl,
-		"enabled":           me.Enabled,
-		"label":             me.Label,
-		"login_url":         me.LoginUrl,
-		"password":          "${state.secret_value}",
-		"username":          me.Username,
-	})
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"active_gate_group": me.ActiveGateGroup,
+			"api_url":           me.ApiUrl,
+			"enabled":           me.Enabled,
+			"label":             me.Label,
+			"login_url":         me.LoginUrl,
+			"password":          "${state.secret_value}",
+			"username":          me.Username,
+		},
+	))
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/cloud/kubernetes/settings/settings.go
+++ b/dynatrace/api/builtin/cloud/kubernetes/settings/settings.go
@@ -20,6 +20,7 @@ package kubernetes
 import (
 	"fmt"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -167,26 +168,28 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 }
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeAll(map[string]any{
-		"active_gate_group":                  me.ActiveGateGroup,
-		"auth_token":                         me.AuthToken,
-		"certificate_check_enabled":          me.CertificateCheckEnabled,
-		"cloud_application_pipeline_enabled": me.CloudApplicationPipelineEnabled,
-		"cluster_id":                         me.ClusterID,
-		"cluster_id_enabled":                 me.ClusterIdEnabled,
-		"enabled":                            me.Enabled,
-		"endpoint_url":                       me.EndpointUrl,
-		"event_patterns":                     me.EventPatterns,
-		"event_processing_active":            me.EventProcessingActive,
-		"filter_events":                      me.FilterEvents,
-		"hostname_verification_enabled":      me.HostnameVerificationEnabled,
-		"include_all_fdi_events":             me.IncludeAllFdiEvents,
-		"label":                              me.Label,
-		"open_metrics_builtin_enabled":       me.OpenMetricsBuiltinEnabled,
-		"open_metrics_pipeline_enabled":      me.OpenMetricsPipelineEnabled,
-		"pvc_monitoring_enabled":             me.PvcMonitoringEnabled,
-		"scope":                              me.Scope,
-	})
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(), map[string]any{
+			"active_gate_group":                  me.ActiveGateGroup,
+			"auth_token":                         me.AuthToken,
+			"certificate_check_enabled":          me.CertificateCheckEnabled,
+			"cloud_application_pipeline_enabled": me.CloudApplicationPipelineEnabled,
+			"cluster_id":                         me.ClusterID,
+			"cluster_id_enabled":                 me.ClusterIdEnabled,
+			"enabled":                            me.Enabled,
+			"endpoint_url":                       me.EndpointUrl,
+			"event_patterns":                     me.EventPatterns,
+			"event_processing_active":            me.EventProcessingActive,
+			"filter_events":                      me.FilterEvents,
+			"hostname_verification_enabled":      me.HostnameVerificationEnabled,
+			"include_all_fdi_events":             me.IncludeAllFdiEvents,
+			"label":                              me.Label,
+			"open_metrics_builtin_enabled":       me.OpenMetricsBuiltinEnabled,
+			"open_metrics_pipeline_enabled":      me.OpenMetricsPipelineEnabled,
+			"pvc_monitoring_enabled":             me.PvcMonitoringEnabled,
+			"scope":                              me.Scope,
+		},
+	))
 }
 
 func (me *Settings) HandlePreconditions() error {

--- a/dynatrace/api/builtin/issuetracking/integration/settings/settings.go
+++ b/dynatrace/api/builtin/issuetracking/integration/settings/settings.go
@@ -18,6 +18,7 @@
 package integration
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -93,17 +94,19 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 }
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeAll(map[string]any{
-		"enabled":            me.Enabled,
-		"issuelabel":         me.Issuelabel,
-		"issuequery":         me.Issuequery,
-		"issuetheme":         me.Issuetheme,
-		"issuetrackersystem": me.Issuetrackersystem,
-		"password":           me.Password,
-		"token":              "${state.secret_value}",
-		"url":                me.Url,
-		"username":           me.Username,
-	})
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(), map[string]any{
+			"enabled":            me.Enabled,
+			"issuelabel":         me.Issuelabel,
+			"issuequery":         me.Issuequery,
+			"issuetheme":         me.Issuetheme,
+			"issuetrackersystem": me.Issuetrackersystem,
+			"password":           me.Password,
+			"token":              "${state.secret_value}",
+			"url":                me.Url,
+			"username":           me.Username,
+		},
+	))
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/problem/notifications/ansible/settings/ansible_tower.go
+++ b/dynatrace/api/builtin/problem/notifications/ansible/settings/ansible_tower.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -103,17 +104,20 @@ func (me *AnsibleTower) MarshalHCL(properties hcl.Properties) error { // The pas
 	// The Dynatrace Settings 2.0 API delivers a scrambled version of any previously stored password here
 	// Evaluation at this point would lead to that scrambled version to make it into the Terraform State
 	// As a result any plans would be non-empty
-	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"active":  me.Enabled,
-		"profile": me.ProfileID,
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"name":    me.Name,
+			"active":  me.Enabled,
+			"profile": me.ProfileID,
 
-		"insecure":         me.Insecure,
-		"custom_message":   me.CustomMessage,
-		"job_template_url": me.JobTemplateURL,
-		"password":         me.Password,
-		"username":         me.Username,
-	})
+			"insecure":         me.Insecure,
+			"custom_message":   me.CustomMessage,
+			"job_template_url": me.JobTemplateURL,
+			"password":         me.Password,
+			"username":         me.Username,
+		},
+	))
 }
 
 func (me *AnsibleTower) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/problem/notifications/http/header.go
+++ b/dynatrace/api/builtin/problem/notifications/http/header.go
@@ -20,6 +20,7 @@ package http
 import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -126,6 +127,12 @@ func (me *Header) MarshalHCL(properties hcl.Properties) error {
 			return err
 		}
 		if err := properties.Encode("value", ""); err != nil {
+			return err
+		}
+		if err := sensitive.ConditionalIgnoreChangesSingle(
+			me.Schema(),
+			&properties,
+		); err != nil {
 			return err
 		}
 	} else {

--- a/dynatrace/api/builtin/problem/notifications/jira/settings/jira.go
+++ b/dynatrace/api/builtin/problem/notifications/jira/settings/jira.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -115,19 +116,22 @@ func (me *Jira) MarshalHCL(properties hcl.Properties) error { // The api_token f
 	// The Dynatrace Settings 2.0 API delivers a scrambled version of any previously stored api_token here
 	// Evaluation at this point would lead to that scrambled version to make it into the Terraform State
 	// As a result any plans would be non-empty
-	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"active":  me.Enabled,
-		"profile": me.ProfileID,
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"name":    me.Name,
+			"active":  me.Enabled,
+			"profile": me.ProfileID,
 
-		"url":         me.URL,
-		"username":    me.Username,
-		"project_key": me.ProjectKey,
-		"issue_type":  me.IssueType,
-		"summary":     me.Summary,
-		"description": me.Description,
-		"api_token":   me.APIToken,
-	})
+			"url":         me.URL,
+			"username":    me.Username,
+			"project_key": me.ProjectKey,
+			"issue_type":  me.IssueType,
+			"summary":     me.Summary,
+			"description": me.Description,
+			"api_token":   me.APIToken,
+		},
+	))
 }
 
 func (me *Jira) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/problem/notifications/opsgenie/settings/ops_genie.go
+++ b/dynatrace/api/builtin/problem/notifications/opsgenie/settings/ops_genie.go
@@ -20,6 +20,7 @@ package notifications
 import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -94,15 +95,18 @@ func (me *OpsGenie) MarshalHCL(properties hcl.Properties) error { // The api_key
 	// The Dynatrace Settings 2.0 API delivers a scrambled version of any previously stored api_key here
 	// Evaluation at this point would lead to that scrambled version to make it into the Terraform State
 	// As a result any plans would be non-empty
-	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"active":  me.Enabled,
-		"profile": me.ProfileID,
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"name":    me.Name,
+			"active":  me.Enabled,
+			"profile": me.ProfileID,
 
-		"domain":  me.Domain,
-		"message": me.Message,
-		"api_key": me.APIKey,
-	})
+			"domain":  me.Domain,
+			"message": me.Message,
+			"api_key": me.APIKey,
+		},
+	))
 }
 
 func (me *OpsGenie) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/problem/notifications/pagerduty/settings/pager_duty.go
+++ b/dynatrace/api/builtin/problem/notifications/pagerduty/settings/pager_duty.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -92,15 +93,18 @@ func (me *PagerDuty) MarshalHCL(properties hcl.Properties) error { // The api_ke
 	// The Dynatrace Settings 2.0 API delivers a scrambled version of any previously stored api_key here
 	// Evaluation at this point would lead to that scrambled version to make it into the Terraform State
 	// As a result any plans would be non-empty
-	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"active":  me.Enabled,
-		"profile": me.ProfileID,
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"name":    me.Name,
+			"active":  me.Enabled,
+			"profile": me.ProfileID,
 
-		"account": me.Account,
-		"service": me.ServiceName,
-		"api_key": me.APIKey,
-	})
+			"account": me.Account,
+			"service": me.ServiceName,
+			"api_key": me.APIKey,
+		},
+	))
 }
 
 func (me *PagerDuty) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/problem/notifications/servicenow/settings/service_now.go
+++ b/dynatrace/api/builtin/problem/notifications/servicenow/settings/service_now.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -122,20 +123,23 @@ func (me *ServiceNow) MarshalHCL(properties hcl.Properties) error { // The passw
 	// The Dynatrace Settings 2.0 API delivers a scrambled version of any previously stored password here
 	// Evaluation at this point would lead to that scrambled version to make it into the Terraform State
 	// As a result any plans would be non-empty
-	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"active":  me.Enabled,
-		"profile": me.ProfileID,
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"name":    me.Name,
+			"active":  me.Enabled,
+			"profile": me.ProfileID,
 
-		"format_problem_details_as_text": me.FormatProblemDetailsAsText,
-		"events":                         me.SendEvents,
-		"incidents":                      me.SendIncidents,
-		"url":                            me.URL,
-		"username":                       me.Username,
-		"instance":                       me.InstanceName,
-		"message":                        me.Message,
-		"password":                       me.Password,
-	})
+			"format_problem_details_as_text": me.FormatProblemDetailsAsText,
+			"events":                         me.SendEvents,
+			"incidents":                      me.SendIncidents,
+			"url":                            me.URL,
+			"username":                       me.Username,
+			"instance":                       me.InstanceName,
+			"message":                        me.Message,
+			"password":                       me.Password,
+		},
+	))
 }
 
 func (me *ServiceNow) HandlePreconditions() error {

--- a/dynatrace/api/builtin/problem/notifications/slack/settings/slack.go
+++ b/dynatrace/api/builtin/problem/notifications/slack/settings/slack.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -92,15 +93,18 @@ func (me *Slack) MarshalHCL(properties hcl.Properties) error { // The url field 
 	// The Dynatrace Settings 2.0 API delivers a scrambled version of any previously stored url here
 	// Evaluation at this point would lead to that scrambled version to make it into the Terraform State
 	// As a result any plans would be non-empty
-	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"active":  me.Enabled,
-		"profile": me.ProfileID,
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"name":    me.Name,
+			"active":  me.Enabled,
+			"profile": me.ProfileID,
 
-		"message": me.Message,
-		"channel": me.Channel,
-		"url":     me.URL,
-	})
+			"message": me.Message,
+			"channel": me.Channel,
+			"url":     me.URL,
+		},
+	))
 }
 
 func (me *Slack) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/problem/notifications/trello/settings/trello.go
+++ b/dynatrace/api/builtin/problem/notifications/trello/settings/trello.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -115,19 +116,23 @@ func (me *Trello) MarshalHCL(properties hcl.Properties) error { // The authoriza
 	// The Dynatrace Settings 2.0 API delivers a scrambled version of any previously stored authorization_token here
 	// Evaluation at this point would lead to that scrambled version to make it into the Terraform State
 	// As a result any plans would be non-empty
-	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"active":  me.Enabled,
-		"profile": me.ProfileID,
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMapPlus(
+		me.Schema(),
+		map[string]any{
+			"name":    me.Name,
+			"active":  me.Enabled,
+			"profile": me.ProfileID,
 
-		"resolved_list_id":    me.ResolvedListID,
-		"text":                me.Text,
-		"application_key":     me.ApplicationKey,
-		"board_id":            me.BoardID,
-		"description":         me.Description,
-		"list_id":             me.ListID,
-		"authorization_token": me.AuthorizationToken,
-	})
+			"resolved_list_id":    me.ResolvedListID,
+			"text":                me.Text,
+			"application_key":     me.ApplicationKey,
+			"board_id":            me.BoardID,
+			"description":         me.Description,
+			"list_id":             me.ListID,
+			"authorization_token": me.AuthorizationToken,
+		},
+		[]string{"authorization_token"},
+	))
 }
 
 func (me *Trello) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/problem/notifications/victorops/settings/victor_ops.go
+++ b/dynatrace/api/builtin/problem/notifications/victorops/settings/victor_ops.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -92,15 +93,18 @@ func (me *VictorOps) MarshalHCL(properties hcl.Properties) error { // The api_ke
 	// The Dynatrace Settings 2.0 API delivers a scrambled version of any previously stored api_key here
 	// Evaluation at this point would lead to that scrambled version to make it into the Terraform State
 	// As a result any plans would be non-empty
-	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"active":  me.Enabled,
-		"profile": me.ProfileID,
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"name":    me.Name,
+			"active":  me.Enabled,
+			"profile": me.ProfileID,
 
-		"message":     me.Message,
-		"routing_key": me.RoutingKey,
-		"api_key":     me.APIKey,
-	})
+			"message":     me.Message,
+			"routing_key": me.RoutingKey,
+			"api_key":     me.APIKey,
+		},
+	))
 }
 
 func (me *VictorOps) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/problem/notifications/webhook/settings/oauth_2_credentials.go
+++ b/dynatrace/api/builtin/problem/notifications/webhook/settings/oauth_2_credentials.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -56,12 +57,16 @@ func (me *OAuth2Credentials) Schema() map[string]*schema.Schema {
 }
 
 func (me *OAuth2Credentials) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeAll(map[string]any{
-		"access_token_url": me.AccessTokenUrl,
-		"client_id":        me.ClientID,
-		"client_secret":    "${state.secret_value}",
-		"scope":            me.Scope,
-	})
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMapPlus(
+		me.Schema(),
+		map[string]any{
+			"access_token_url": me.AccessTokenUrl,
+			"client_id":        me.ClientID,
+			"client_secret":    "${state.secret_value}",
+			"scope":            me.Scope,
+		},
+		[]string{"client_secret"},
+	))
 }
 
 func (me *OAuth2Credentials) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/remote/environment/settings/settings.go
+++ b/dynatrace/api/builtin/remote/environment/settings/settings.go
@@ -18,6 +18,7 @@
 package environment
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -56,12 +57,15 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 }
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeAll(map[string]any{
-		"name":          me.Name,
-		"network_scope": me.NetworkScope,
-		"token":         "${state.secret_value}",
-		"uri":           me.Uri,
-	})
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"name":          me.Name,
+			"network_scope": me.NetworkScope,
+			"token":         "${state.secret_value}",
+			"uri":           me.Uri,
+		},
+	))
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/virtualization/vmware/settings/settings.go
+++ b/dynatrace/api/builtin/virtualization/vmware/settings/settings.go
@@ -18,6 +18,7 @@
 package vmware
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -68,14 +69,17 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 }
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeAll(map[string]any{
-		"enabled":   me.Enabled,
-		"filter":    me.Filter,
-		"ipaddress": me.Ipaddress,
-		"label":     me.Label,
-		"password":  "${state.secret_value}",
-		"username":  me.Username,
-	})
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"enabled":   me.Enabled,
+			"filter":    me.Filter,
+			"ipaddress": me.Ipaddress,
+			"label":     me.Label,
+			"password":  "${state.secret_value}",
+			"username":  me.Username,
+		},
+	))
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/v1/config/credentials/aws/settings/aws_authentication_data.go
+++ b/dynatrace/api/v1/config/credentials/aws/settings/aws_authentication_data.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -130,6 +131,13 @@ func (aad *AWSAuthenticationData) MarshalHCL(properties hcl.Properties) error {
 		if err := properties.Encode("secret_key", "${state.secret_value}"); err != nil {
 			return err
 		}
+		if err := sensitive.ConditionalIgnoreChangesSingle(
+			aad.Schema(),
+			&properties,
+		); err != nil {
+			return err
+		}
+
 	}
 	if aad.RoleBasedAuthentication != nil {
 		if err := properties.Encode("account_id", aad.RoleBasedAuthentication.AccountID); err != nil {

--- a/dynatrace/api/v1/config/credentials/azure/settings/azure_credentials.go
+++ b/dynatrace/api/v1/config/credentials/azure/settings/azure_credentials.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -350,6 +351,13 @@ func (ac *AzureCredentials) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Encode("supporting_services_managed_in_dynatrace", true); err != nil {
 		return err
 	}
+	if err := sensitive.ConditionalIgnoreChangesSingle(
+		ac.Schema(),
+		&properties,
+	); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/dynatrace/api/v1/config/credentials/cloudfoundry/settings/cloud_foundry_credentials.go
+++ b/dynatrace/api/v1/config/credentials/cloudfoundry/settings/cloud_foundry_credentials.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/xjson"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
@@ -89,15 +90,18 @@ func (me *CloudFoundryCredentials) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(me.Unknowns); err != nil {
 		return err
 	}
-	return properties.EncodeAll(map[string]any{
-		"login_url": me.LoginURL,
-		"api_url":   me.APIURL,
-		"password":  "${state.secret_value}",
-		"active":    me.Active,
-		"name":      me.Name,
-		"username":  me.Username,
-		"unknowns":  me.Unknowns,
-	})
+	return properties.EncodeAll(sensitive.ConditionalIgnoreChangesMap(
+		me.Schema(),
+		map[string]any{
+			"login_url": me.LoginURL,
+			"api_url":   me.APIURL,
+			"password":  "${state.secret_value}",
+			"active":    me.Active,
+			"name":      me.Name,
+			"username":  me.Username,
+			"unknowns":  me.Unknowns,
+		},
+	))
 }
 
 func (me *CloudFoundryCredentials) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/v1/config/credentials/kubernetes/settings/kubernetes_credentials.go
+++ b/dynatrace/api/v1/config/credentials/kubernetes/settings/kubernetes_credentials.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -181,6 +182,12 @@ func (kc *KubernetesCredentials) MarshalHCL(properties hcl.Properties) error {
 		return err
 	}
 	if err := properties.Encode("events_field_selectors", kc.EventsFieldSelectors); err != nil {
+		return err
+	}
+	if err := sensitive.ConditionalIgnoreChangesSingle(
+		kc.Schema(),
+		&properties,
+	); err != nil {
 		return err
 	}
 	return nil

--- a/dynatrace/api/v2/credentials/vault/settings/credentials.go
+++ b/dynatrace/api/v2/credentials/vault/settings/credentials.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/credentials/vault/settings/externalvault"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export/sensitive"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
@@ -145,6 +146,13 @@ func (me *Credentials) EnsurePredictableOrder() {
 
 func (me *Credentials) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Encode("name", me.Name); err != nil {
+		return err
+	}
+	if err := sensitive.ConditionalIgnoreChangesSinglePlus(
+		me.Schema(),
+		&properties,
+		[]string{"certificate", "format"},
+	); err != nil {
 		return err
 	}
 	if me.Description != nil && len(*me.Description) > 0 {

--- a/dynatrace/export/helpers.go
+++ b/dynatrace/export/helpers.go
@@ -90,6 +90,11 @@ func toTerraformName(s string) string {
 			result = result + "_"
 		}
 	}
+
+	if len(result) == 0 {
+		result = "unnamed"
+	}
+
 	first := []rune(result)[0]
 	if !unicode.IsLetter(first) && first != '_' {
 		result = "_" + result

--- a/dynatrace/export/sensitive/ignore_changes_sensitive.go
+++ b/dynatrace/export/sensitive/ignore_changes_sensitive.go
@@ -1,0 +1,91 @@
+/**
+* @license
+* Copyright 2023 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package sensitive
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Avoid overwriting password that the user has changed manually with known bad data
+var IGNORE_CHANGES_REQUIRES_ATTENTION = os.Getenv("DYNATRACE_IGNORE_CHANGES_REQUIRES_ATTENTION") == "true"
+
+func ConditionalIgnoreChangesMap(schema map[string]*schema.Schema, itemsToEncode map[string]any) map[string]any {
+	return ConditionalIgnoreChangesMapPlus(schema, itemsToEncode, []string{})
+}
+func ConditionalIgnoreChangesMapPlus(schema map[string]*schema.Schema, itemsToEncode map[string]any, additionalIgnoreFields []string) map[string]any {
+	if IGNORE_CHANGES_REQUIRES_ATTENTION {
+
+		lifeCycleIgnoreChanges := buildIgnoreSensitiveFromSchema(schema, additionalIgnoreFields)
+
+		currentlifeCycle, lifeCycleFound := itemsToEncode["lifecycle"]
+		if lifeCycleFound {
+			fmt.Printf("ERROR: Ignore Changes: lifecycle already exists: %v, overwriting with: %v", currentlifeCycle, lifeCycleIgnoreChanges)
+		}
+		itemsToEncode["lifecycle"] = &lifeCycleIgnoreChanges
+	}
+
+	return itemsToEncode
+}
+
+func ConditionalIgnoreChangesSingle(schema map[string]*schema.Schema, properties *hcl.Properties) error {
+	return ConditionalIgnoreChangesSinglePlus(schema, properties, []string{})
+}
+
+func ConditionalIgnoreChangesSinglePlus(schema map[string]*schema.Schema, properties *hcl.Properties, additionalIgnoreFields []string) error {
+	lifeCycleIgnoreChanges := buildIgnoreSensitiveFromSchema(schema, additionalIgnoreFields)
+
+	if IGNORE_CHANGES_REQUIRES_ATTENTION {
+		if err := properties.Encode("lifecycle", &lifeCycleIgnoreChanges); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func buildIgnoreSensitiveFromSchema(schema map[string]*schema.Schema, additionalIgnoreFields []string) settings.LifeCycle {
+	sensitiveFields := []string{}
+
+	sensitiveFields = append(sensitiveFields, additionalIgnoreFields...)
+
+	for schemaKey, schemaField := range schema {
+		if schemaField.Sensitive {
+			sensitiveFields = appendIfNotExists(sensitiveFields, schemaKey)
+		}
+	}
+
+	lifeCycleIgnoreChanges := settings.LifeCycle{
+		IgnoreChanges: sensitiveFields,
+	}
+	return lifeCycleIgnoreChanges
+}
+
+func appendIfNotExists(slice []string, element string) []string {
+	for _, existingElement := range slice {
+		if existingElement == element {
+			return slice
+		}
+	}
+
+	return append(slice, element)
+}

--- a/dynatrace/settings/life_cycle.go
+++ b/dynatrace/settings/life_cycle.go
@@ -1,0 +1,30 @@
+/**
+* @license
+* Copyright 2023 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings
+
+import "github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+
+type LifeCycle struct {
+	IgnoreChanges []string
+}
+
+func (me *LifeCycle) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"ignore_changes": me.IgnoreChanges,
+	})
+}

--- a/terraform/hclgen/primitive_entry.go
+++ b/terraform/hclgen/primitive_entry.go
@@ -71,6 +71,7 @@ func finalizeString(s string, indent string) string {
 	finalString = strings.ReplaceAll(finalString, "${dynatrace_", "DOLLAR_DYNATRACE")
 
 	finalString = strings.ReplaceAll(finalString, "${", "$${")
+	finalString = strings.ReplaceAll(finalString, "%{", "%%{")
 
 	finalString = strings.ReplaceAll(finalString, "DOLLAR_DATA_DOT", "${data.")
 	finalString = strings.ReplaceAll(finalString, "DOLLAR_DYNATRACE", "${dynatrace_")


### PR DESCRIPTION
For the -export functionality
Using DYNATRACE_IGNORE_CHANGES_REQUIRES_ATTENTION = true

All values set by FillDemoValues will get an ignore_changes lifecycle Meta-Argument

This way, when using the DT Config Manager
If the client has pushed a password through terraform or through the UI
Then that password will not be overwritten by a fake password, like "#########" for example

Most of the fields are not hardcoded, they are extracted from the "Sensitive = true" from on module Schemas
But some of them had to hardcoded to match FillDemoValues