### PR TITLE
Feat: Add basic debug support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ test.log
 *.sh
 .vscode/*
 .DS_Store
+.env
+__debug_bin*

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace"
@@ -104,6 +105,10 @@ import (
 // }
 
 func main() {
+	var debug bool
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	// if tf2json(os.Args) {
 	// 	return
 	// }
@@ -114,6 +119,8 @@ func main() {
 	}
 
 	plugin.Serve(&plugin.ServeOpts{
+		Debug:        debug,
+		ProviderAddr: "registry.terraform.io/dynatrace-oss/dynatrace",
 		ProviderFunc: func() *schema.Provider {
 			return provider.Provider()
 		},


### PR DESCRIPTION
This PR:
- Adds [the standard debug flag to the provider as described in Terraform documentation](https://developer.hashicorp.com/terraform/plugin/sdkv2/debugging)
- Updates `.gitignore` to prevent executables and credentials etc. in environment variables specific to the debug build being committed
