### PR TITLE
feat: create public documents

### DIFF
--- a/dynatrace/api/documents/document/settings/document.go
+++ b/dynatrace/api/documents/document/settings/document.go
@@ -29,6 +29,7 @@ const SchemaVersion = 3
 type Document struct {
 	Name          string `json:"name" maxlength:"200"`
 	Content       string `json:"content,omitempty"`
+	IsPrivate     bool   `json:"isPrivate,omitempty"`
 	Type          string `json:"type"`
 	Actor         string `json:"actor,omitempty" maxlength:"36" format:"uuid"`
 	Owner         string `json:"owner,omitempty" format:"uuid"`
@@ -43,6 +44,12 @@ func (me *Document) Schema() map[string]*schema.Schema {
 			Description:      "The name/name of the document",
 			Required:         true,
 			ValidateDiagFunc: ValidateMaxLength(200),
+		},
+		"private": {
+			Type:        schema.TypeBool,
+			Description: "Specifies whether the document is private or readable by everybody",
+			Optional:    true,
+			Default:     false,
 		},
 		"type": {
 			Type:             schema.TypeString,
@@ -81,6 +88,7 @@ func (me *Document) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
 		"name":    me.Name,
 		"content": me.Content,
+		"private": me.IsPrivate,
 		"type":    me.Type,
 		"actor":   me.Actor,
 		"owner":   me.Owner,
@@ -92,6 +100,7 @@ func (me *Document) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
 		"name":    &me.Name,
 		"content": &me.Content,
+		"private": &me.IsPrivate,
 		"type":    &me.Type,
 		"actor":   &me.Actor,
 		"owner":   &me.Owner,
@@ -103,6 +112,7 @@ func (me *Document) MarshalJSON() ([]byte, error) {
 	d := struct {
 		Name          string `json:"name"`
 		Content       string `json:"content,omitempty"`
+		Private       bool   `json:"isPrivate,omitempty"`
 		Type          string `json:"type"`
 		Actor         string `json:"actor,omitempty"`
 		Owner         string `json:"owner,omitempty"`
@@ -111,6 +121,7 @@ func (me *Document) MarshalJSON() ([]byte, error) {
 	}{
 		SchemaVersion: SchemaVersion,
 		Name:          me.Name,
+		Private:       me.IsPrivate,
 		Content:       me.Content,
 		Type:          me.Type,
 		Actor:         me.Actor,

--- a/monaco/pkg/client/document/documents/client.go
+++ b/monaco/pkg/client/document/documents/client.go
@@ -29,13 +29,14 @@ import (
 )
 
 type Response struct {
-	ID      string `json:"id"`
-	Actor   string `json:"actor"`
-	Owner   string `json:"owner"`
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	Content string `json:"content"`
-	Version int    `json:"version"`
+	ID        string `json:"id"`
+	Actor     string `json:"actor"`
+	Owner     string `json:"owner"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	IsPrivate bool   `json:"isPrivate"`
+	Content   string `json:"content"`
+	Version   int    `json:"version"`
 }
 
 type listResponse struct {


### PR DESCRIPTION
This PR adds a `private`field to the document resource to be able to create public documents.

Creating "public" document require (per design) two API calls. 
* First, a private document needs to be created (using the HTTP `POST` endpoint) 
* Second, the crated document needs to be updated (using the HTTP `PATCH` endpoint) to be public.