### PR TITLE
docs: Fix `scope` & `scopes` documentation of the `dynatrace_credenti…

### DIFF
--- a/dynatrace/api/v2/credentials/vault/settings/credentials.go
+++ b/dynatrace/api/v2/credentials/vault/settings/credentials.go
@@ -74,13 +74,13 @@ func (me *Credentials) Schema() map[string]*schema.Schema {
 		},
 		"scope": {
 			Type:        schema.TypeString,
-			Description: "The scope of the credentials set. Possible values are `ALL`, `EXTENSION` and `SYNTHETIC`",
+			Description: "The scope of the credentials set. Possible values are `ALL`, `APP_ENGINE`, `EXTENSION` and `SYNTHETIC`",
 			Optional:    true,
 			Deprecated:  "Deprecated(v279), please use `scopes` instead.",
 		},
 		"scopes": {
 			Type:        schema.TypeSet,
-			Description: "The set of scopes of the credentials set. Possible values are `ALL`, `EXTENSION` and `SYNTHETIC`",
+			Description: "The set of scopes of the credentials set. Possible values are `APP_ENGINE` and `SYNTHETIC`",
 			Optional:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},


### PR DESCRIPTION
…als` resource.

When using the `dynatrace_credentials` resource, I was confused because the UI settings didn't match the Terraform scope parameters. Therefore, I tried a few combinations and tested which values are actually valid for the `scope` and `scopes` fields.