### PR TITLE
fix: Fixed platform bucket deletion failing - issue #592

### DIFF
--- a/dynatrace/api/platform/buckets/service.go
+++ b/dynatrace/api/platform/buckets/service.go
@@ -220,7 +220,9 @@ func (me *service) Delete(ctx context.Context, id string) error {
 		if shutdown.System.Stopped() {
 			return nil
 		}
-
+		if response.StatusCode == 404 {
+			return nil
+		}
 		time.Sleep(5 * time.Second)
 	}
 	return err


### PR DESCRIPTION
Fixed platform bucket delete failing when GET request returns 404.