### PR TITLE
Update synthetic monitor type to fit with the swagger documentation

### DIFF
--- a/dynatrace/api/v2/synthetic/monitors/settings/thresholds.go
+++ b/dynatrace/api/v2/synthetic/monitors/settings/thresholds.go
@@ -48,7 +48,7 @@ type Threshold struct {
 	DealertingSamples *int32       `json:"dealertingSamples,omitempty"` // Number of most recent non-violating request executions that closes the problem
 	Samples           *int32       `json:"samples,omitempty"`           // Number of request executions in analyzed sliding window (sliding window size)
 	StepIndex         *int32       `json:"stepIndex,omitempty"`         // Specify the step's index to which a threshold applies
-	Threshold         *int32       `json:"threshold,omitempty"`         // Notify if monitor request takes longer than X milliseconds to execute
+	Threshold         *float64     `json:"threshold,omitempty"`         // Notify if monitor request takes longer than X milliseconds to execute
 	ViolatingSamples  *int32       `json:"violatingSamples,omitempty"`  // Number of violating request executions in analyzed sliding window
 }
 


### PR DESCRIPTION
Seems like the type for threshold is number($double) and that does not match with int32 in GO.

![image](https://github.com/user-attachments/assets/83cbd679-9be6-444c-8f75-218d819c5319)

In order to fix this, we will have to change this into a float64.

Closes #676 