### PR TITLE
Fix the schema definition after the type change

### DIFF
--- a/dynatrace/api/v2/synthetic/monitors/settings/thresholds.go
+++ b/dynatrace/api/v2/synthetic/monitors/settings/thresholds.go
@@ -75,7 +75,7 @@ func (me *Threshold) Schema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 		"threshold": {
-			Type:        schema.TypeInt,
+			Type:        schema.TypeFloat,
 			Description: "Notify if monitor request takes longer than X milliseconds to execute",
 			Optional:    true,
 		},


### PR DESCRIPTION
I have been too quick to ship an attempt at fixing the schema, and there are no tests for this particular component that could catch the issue.

The error when running the provider clearly states `panic: interface conversion: interface {} is int, not float64` which indicates that there is a misalignment between the schema and the struct.