### PR TITLE
refactor: Update services to use latest version of `github.com/dynatace/dynatrace-configuration-as-code-core`

### DIFF
--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -155,15 +155,16 @@ func (me *service) createPrivate(ctx context.Context, v *documents.Document) (st
 	response, err := c.Create(ctx, v.Name, v.IsPrivate, "", []byte(v.Content), docclient.DocumentType(v.Type))
 	if err != nil {
 		if apiError, ok := err.(docapi.APIError); ok {
-			return nil, rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
+			return nil, rest.Error{Code: apiError.StatusCode, Message: string(apiError.Body)}
 		}
 		return nil, err
 	}
-	if response.IsSuccess() {
-		json.Unmarshal(response.Data, &stub)
-		return stub, nil
+
+	if err := json.Unmarshal(response.Data, &stub); err != nil {
+		return nil, err
 	}
-	return nil, rest.Error{Code: response.StatusCode, Message: string(response.Data)}
+	return stub, nil
+
 }
 
 func (me *service) Update(ctx context.Context, id string, v *documents.Document) (err error) {
@@ -175,18 +176,15 @@ func (me *service) update(ctx context.Context, id string, v *documents.Document)
 	if err != nil {
 		return err
 	}
-	response, err := c.Update(ctx, id, v.Name, v.IsPrivate, []byte(v.Content), docclient.DocumentType(v.Type))
+	_, err = c.Update(ctx, id, v.Name, v.IsPrivate, []byte(v.Content), docclient.DocumentType(v.Type))
 	if err != nil {
 		if apiError, ok := err.(docapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
+			return rest.Error{Code: apiError.StatusCode, Message: string(apiError.Body)}
 		}
 		return err
 	}
-	if response.IsSuccess() {
-		return nil
-	}
 
-	return rest.Error{Code: response.StatusCode, Message: string(response.Data)}
+	return nil
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
@@ -194,18 +192,15 @@ func (me *service) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	response, err := client.Delete(ctx, id)
+	_, err = client.Delete(ctx, id)
 	if err != nil {
 		if apiError, ok := err.(docapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
+			return rest.Error{Code: apiError.StatusCode, Message: string(apiError.Body)}
 		}
 		return err
 	}
-	if response.IsSuccess() {
-		return nil
-	}
 
-	return rest.Error{Code: response.StatusCode, Message: string(response.Data)}
+	return nil
 }
 
 func (me *service) New() *documents.Document {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/dlclark/regexp2 v1.11.4
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250306093342-97cc482e553f
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250514143234-94fb2ef0c525
 	github.com/go-logr/logr v1.4.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/zclconf/go-cty v1.15.1
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
-	golang.org/x/oauth2 v0.28.0
+	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.11.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250306093342-97cc482e553f h1:K9VZsTTg1nLm1cKolkEBAtS8jLouxRS2iysZxjvZi5Y=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.7.1-0.20250306093342-97cc482e553f/go.mod h1:kzQOH0pVd+I+2CXo+owRwAu78xC10GO35iC6FmXhhhw=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250514143234-94fb2ef0c525 h1:e6D3nNyX0yC5m8p5mU1iehCFkCmg8PKJS+XGsm3sT9A=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.8.1-0.20250514143234-94fb2ef0c525/go.mod h1:3cRc4TbyVxH62R7GwIvvOgOoOQ4R2EnZa6wWjOD7jCQ=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
@@ -446,8 +446,8 @@ go.opentelemetry.io/otel/sdk/metric v1.31.0 h1:i9hxxLJF/9kkvfHppyLL55aW7iIJz4Jjx
 go.opentelemetry.io/otel/sdk/metric v1.31.0/go.mod h1:CRInTMVvNhUKgSAMbKyTMxqOBC0zgyxzW55lZzX43Y8=
 go.opentelemetry.io/otel/trace v1.31.0 h1:ffjsj1aRouKewfr85U2aGagJ46+MvodynlQ1HYdmJys=
 go.opentelemetry.io/otel/trace v1.31.0/go.mod h1:TXZkRk7SM2ZQLtR6eoAWQFIHPvzQ06FJAsO1tJg480A=
-go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
-go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
+go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
+go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -539,8 +539,8 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
-golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
This PR:
- updates `github.com/dynatrace/dynatrace-configuration-as-code-core` to the latest version/commit at time of writing `v0.8.1-0.20250514143234-94fb2ef0c525`. This includes [`fix: Prevent concurrent reads and writes of client header map`](https://github.com/Dynatrace/dynatrace-configuration-as-code-core/commit/94fb2ef0c525eb9fe665cfd0c5fbfb346a4cf853).
- updates processing of errors returned from the core lib to reflect the fact that non-success responses are now returned as an `APIError` rather than a response with a non-success status code.