### PR TITLE
fix: Correct the description for `technology_id` field in schema technology processor

### DIFF
--- a/dynatrace/api/openpipeline/settings/processor.go
+++ b/dynatrace/api/openpipeline/settings/processor.go
@@ -527,7 +527,7 @@ func (p *TechnologyProcessor) Schema() map[string]*schema.Schema {
 	s := p.Processor.Schema()
 	s["technology_id"] = &schema.Schema{
 		Type:        schema.TypeString,
-		Description: "Identifier of the processor. Must be unique within a stage.",
+		Description: "The reference identifier to a specific technology. This technology is applied on the record.",
 		Required:    true,
 	}
 


### PR DESCRIPTION
The description is updated to match the current Dynatrace documentation https://docs.dynatrace.com/docs/discover-dynatrace/platform/openpipeline/reference/openpipeline-api/preview-api/post-processor#technology-processor