### PR TITLE
feat: `ProcessingStageProcessor` and `EndpointProcessor` support `DropProcessor`

### DIFF
--- a/dynatrace/api/openpipeline/settings/processor.go
+++ b/dynatrace/api/openpipeline/settings/processor.go
@@ -10,6 +10,7 @@ const (
 	FieldsAddProcessorType    = "fieldsAdd"
 	FieldsRemoveProcessorType = "fieldsRemove"
 	FieldsRenameProcessorType = "fieldsRename"
+	DropProcessorType         = "drop"
 
 	CounterMetricProcessorType = "counterMetric"
 	ValueMetricProcessorType   = "valueMetric"
@@ -294,6 +295,27 @@ func (f *FieldsRenameItem) UnmarshalHCL(decoder hcl.Decoder) error {
 		"from_name": &f.FromName,
 		"to_name":   &f.ToName,
 	})
+}
+
+type DropProcessor struct {
+	Processor
+}
+
+func (p *DropProcessor) Schema() map[string]*schema.Schema {
+	return p.Processor.Schema()
+}
+
+func (p *DropProcessor) MarshalHCL(properties hcl.Properties) error {
+	return p.Processor.MarshalHCL(properties)
+}
+
+func (p *DropProcessor) UnmarshalHCL(decoder hcl.Decoder) error {
+	return p.Processor.UnmarshalHCL(decoder)
+}
+
+func (ep DropProcessor) MarshalJSON() ([]byte, error) {
+	type dropProcessor DropProcessor
+	return MarshalAsJSONWithType((dropProcessor)(ep), DropProcessorType)
 }
 
 type FieldExtraction struct {


### PR DESCRIPTION
This PR addresses #704, and add support for `drop_processor` blocks inside `processor` blocks in endpoint and processing stage `processors`:
```
resource "dynatrace_openpipeline_logs" "logs" {
  pipelines {
    pipeline {
      ...
      processing {
        processor {
          drop_processor {
            description = "test"
            enabled     = true
            id          = "processor_test_7805"
            matcher     = "true"
          }
        }
      }
    }
    ...
```