### PR TITLE
feat: Added `SettingPermissions` struct and HCL schema

### DIFF
--- a/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
@@ -31,7 +31,7 @@ func (_ *Groups) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
-			Description: "",
+			Description: "Group that is to be granted read or write permissions",
 			Elem:        &schema.Resource{Schema: new(GroupAccessor).Schema()},
 		},
 	}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
@@ -28,7 +28,7 @@ type Groups []*GroupAccessor
 func (_ *Groups) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"group": {
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 			Required:    true,
 			MinItems:    1,
 			Description: "Group that is to be granted read or write permissions",

--- a/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
@@ -46,13 +46,13 @@ func (g *Groups) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type GroupAccessor struct {
-	GroupID string
-	Access  string
+	ID     string
+	Access string
 }
 
 func (_ *GroupAccessor) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"group_id": {
+		"id": {
 			Type:        schema.TypeString,
 			Description: "The UUID of the group, conveniently retrieved via the `id` attribute provided by the data source `dynatrace_iam_group",
 			Required:    true,
@@ -68,14 +68,14 @@ func (_ *GroupAccessor) Schema() map[string]*schema.Schema {
 
 func (ga *GroupAccessor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"group_id": ga.GroupID,
-		"access":   ga.Access,
+		"id":     ga.ID,
+		"access": ga.Access,
 	})
 }
 
 func (ga *GroupAccessor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"group_id": &ga.GroupID,
-		"access":   &ga.Access,
+		"id":     &ga.ID,
+		"access": &ga.Access,
 	})
 }

--- a/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type Groups []*GroupAccessor
+
+func (_ *Groups) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"group": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(GroupAccessor).Schema()},
+		},
+	}
+}
+
+func (g *Groups) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("group", g)
+}
+
+func (g *Groups) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("group", g)
+}
+
+type GroupAccessor struct {
+	GroupID string
+	Access  string
+}
+
+func (_ *GroupAccessor) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"group_id": {
+			Type:        schema.TypeString,
+			Description: "The UUID of the group, conveniently retrieved via the `id` attribute provided by the data source `dynatrace_iam_group",
+			Required:    true,
+		},
+		"access": {
+			Type:         schema.TypeString,
+			Description:  "Valid values: read, write",
+			Required:     true,
+			ValidateFunc: validation.StringInSlice([]string{"read", "write"}, false),
+		},
+	}
+}
+
+func (ga *GroupAccessor) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"group_id": ga.GroupID,
+		"access":   ga.Access,
+	})
+}
+
+func (ga *GroupAccessor) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"group_id": &ga.GroupID,
+		"access":   &ga.Access,
+	})
+}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
@@ -33,11 +33,13 @@ type SettingPermissions struct {
 func (_ *SettingPermissions) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"settings_object_id": {
-			Type:     schema.TypeString,
-			Required: true,
+			Type:        schema.TypeString,
+			Description: "The ID of the settings object for which access is to be granted. Here, you can use the `id` attribute of the respective settings object resource",
+			Required:    true,
 		},
 		"all_users": {
 			Type:         schema.TypeString,
+			Description:  "Defines the default access level granted to all users in this environment. Allowed values are `read`, `write`, or `none`",
 			Optional:     true,
 			ValidateFunc: validation.StringInSlice([]string{"read", "write", "none"}, false),
 		},

--- a/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
@@ -44,11 +44,13 @@ func (_ *SettingPermissions) Schema() map[string]*schema.Schema {
 		"users": {
 			Type:     schema.TypeList,
 			Optional: true,
+			MaxItems: 1,
 			Elem:     &schema.Resource{Schema: new(Users).Schema()},
 		},
 		"groups": {
 			Type:     schema.TypeList,
 			Optional: true,
+			MaxItems: 1,
 			Elem:     &schema.Resource{Schema: new(Groups).Schema()},
 		},
 	}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
@@ -1,0 +1,73 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type SettingPermissions struct {
+	SettingsObjectID string
+	AllUsers         string
+	Users            Users
+	Groups           Groups
+}
+
+func (_ *SettingPermissions) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"settings_object_id": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"all_users": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"read", "write", "none"}, false),
+		},
+		"users": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Resource{Schema: new(Users).Schema()},
+		},
+		"groups": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Resource{Schema: new(Groups).Schema()},
+		},
+	}
+}
+
+func (sp *SettingPermissions) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"settings_object_id": sp.SettingsObjectID,
+		"all_users":          sp.AllUsers,
+		"users":              sp.Users,
+		"groups":             sp.Groups,
+	})
+}
+
+func (sp *SettingPermissions) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"settings_object_id": &sp.SettingsObjectID,
+		"all_users":          &sp.AllUsers,
+		"users":              &sp.Users,
+		"groups":             &sp.Groups,
+	})
+}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
@@ -46,13 +46,13 @@ func (u *Users) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type UserAccessor struct {
-	UserID string
+	UID    string
 	Access string
 }
 
 func (_ *UserAccessor) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"user_id": {
+		"uid": {
 			Type:        schema.TypeString,
 			Description: "The UUID of the user, conveniently retrieved via the `uid` attribute provided by the data source `dynatrace_iam_user`",
 			Required:    true,
@@ -68,14 +68,14 @@ func (_ *UserAccessor) Schema() map[string]*schema.Schema {
 
 func (ua *UserAccessor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"user_id": ua.UserID,
-		"access":  ua.Access,
+		"uid":    ua.UID,
+		"access": ua.Access,
 	})
 }
 
 func (ua *UserAccessor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"user_id": &ua.UserID,
-		"access":  &ua.Access,
+		"uid":    &ua.UID,
+		"access": &ua.Access,
 	})
 }

--- a/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type Users []*UserAccessor
+
+func (_ *Users) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"user": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(UserAccessor).Schema()},
+		},
+	}
+}
+
+func (u *Users) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("user", u)
+}
+
+func (u *Users) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("user", u)
+}
+
+type UserAccessor struct {
+	UserID string
+	Access string
+}
+
+func (_ *UserAccessor) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"user_id": {
+			Type:        schema.TypeString,
+			Description: "The UUID of the user, conveniently retrieved via the `uid` attribute provided by the data source `dynatrace_iam_user`",
+			Required:    true,
+		},
+		"access": {
+			Type:         schema.TypeString,
+			Description:  "Valid values: read, write",
+			Required:     true,
+			ValidateFunc: validation.StringInSlice([]string{"read", "write"}, false),
+		},
+	}
+}
+
+func (ua *UserAccessor) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"user_id": ua.UserID,
+		"access":  ua.Access,
+	})
+}
+
+func (ua *UserAccessor) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"user_id": &ua.UserID,
+		"access":  &ua.Access,
+	})
+}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
@@ -28,7 +28,7 @@ type Users []*UserAccessor
 func (_ *Users) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"user": {
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 			Required:    true,
 			MinItems:    1,
 			Description: "User that is to be granted read or write permissions",

--- a/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
@@ -31,7 +31,7 @@ func (_ *Users) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
-			Description: "",
+			Description: "User that is to be granted read or write permissions",
 			Elem:        &schema.Resource{Schema: new(UserAccessor).Schema()},
 		},
 	}

--- a/dynatrace/api/v2/settings/objects/permissions/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v2/settings/objects/permissions/testdata/terraform/example_a.tf
@@ -15,17 +15,17 @@ resource "dynatrace_setting_permissions" "github_connection_access" {
   all_users = "none"
   users {
     user {
-        user_id = data.dynatrace_iam_user.user_a.uid
+        uid = data.dynatrace_iam_user.user_a.uid
         access = "write"
     }
     user {
-        user_id = data.dynatrace_iam_user.user_b.uid
+        uid = data.dynatrace_iam_user.user_b.uid
         access = "read"
     }
   }
   groups {
     group {
-        group_id = data.dynatrace_iam_group.example_group.id
+        id = data.dynatrace_iam_group.example_group.id
         access = "write"
     }
   }

--- a/dynatrace/api/v2/settings/objects/permissions/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v2/settings/objects/permissions/testdata/terraform/example_a.tf
@@ -1,9 +1,9 @@
 data "dynatrace_iam_user" "user_a" {
-  email = "a@home.com"
+  email = "a@example.com"
 }
 
 data "dynatrace_iam_user" "user_b" {
-  email = "b@home.com"
+  email = "b@example.com"
 }
 
 data "dynatrace_iam_group" "example_group" {

--- a/dynatrace/api/v2/settings/objects/permissions/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v2/settings/objects/permissions/testdata/terraform/example_a.tf
@@ -1,0 +1,32 @@
+data "dynatrace_iam_user" "user_a" {
+  email = "a@home.com"
+}
+
+data "dynatrace_iam_user" "user_b" {
+  email = "b@home.com"
+}
+
+data "dynatrace_iam_group" "example_group" {
+  name = "Terraform Example"
+}
+
+resource "dynatrace_setting_permissions" "github_connection_access" {
+  settings_object_id = dynatrace_github_connection.example_connection.id
+  all_users = "none"
+  users {
+    user {
+        user_id = data.dynatrace_iam_user.user_a.uid
+        access = "write"
+    }
+    user {
+        user_id = data.dynatrace_iam_user.user_b.uid
+        access = "read"
+    }
+  }
+  groups {
+    group {
+        group_id = data.dynatrace_iam_group.example_group.id
+        access = "write"
+    }
+  }
+}

--- a/dynatrace/api/v2/settings/objects/permissions/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v2/settings/objects/permissions/testdata/terraform/example_a.tf
@@ -10,6 +10,12 @@ data "dynatrace_iam_group" "example_group" {
   name = "Terraform Example"
 }
 
+resource "dynatrace_github_connection" "example_connection"{
+  name    = "GitHub connection"
+  type     = "pat"
+  token   = "azAZ09"
+}
+
 resource "dynatrace_setting_permissions" "github_connection_access" {
   settings_object_id = dynatrace_github_connection.example_connection.id
   all_users = "none"

--- a/templates/data-sources/alerting_profiles.md.tmpl
+++ b/templates/data-sources/alerting_profiles.md.tmpl
@@ -21,10 +21,10 @@ resource "dynatrace_notification" "#name#" {
     name             = "#name#"
     active           = true
     alerting_profile = data.dynatrace_alerting_profiles.Test[0].id
-    bcc_receivers    = ["they@home.com", "me@home.com", "you@home.com", "we@home.com", "us@home.com"]
+    bcc_receivers    = ["they@example.com", "me@example.com", "you@example.com", "we@example.com", "us@example.com"]
     body             = "{ProblemDetailsHTML}"
-    cc_receivers     = ["they@home.com", "you@home.com", "me@home.com", "we@home.com"]
-    receivers        = ["they@home.com", "you@home.com", "me@home.com", "we@home.com"]
+    cc_receivers     = ["they@example.com", "you@example.com", "me@example.com", "we@example.com"]
+    receivers        = ["they@example.com", "you@example.com", "me@example.com", "we@example.com"]
     subject          = "{State} Problem {ProblemID}: {ImpactedEntity}"
   }
 }

--- a/templates/data-sources/iam_user.md.tmpl
+++ b/templates/data-sources/iam_user.md.tmpl
@@ -18,7 +18,7 @@ This data source allows you to specify the email address of the user and produce
 
 ```terraform
 data "dynatrace_iam_user" "user_a" {
-  email = "me@home.com"
+  email = "me@example.com"
 }
 
 output "groups" {

--- a/templates/resources/json_dashboard_base.md.tmpl
+++ b/templates/resources/json_dashboard_base.md.tmpl
@@ -21,7 +21,7 @@ resource "dynatrace_json_dashboard" "dashboard-a" {
   contents = jsonencode({
       "dashboardMetadata": {
         "name": "dashboard-a",
-        "owner": "me@home.com"
+        "owner": "me@example.com"
       },
       "tiles": [
         {
@@ -44,7 +44,7 @@ resource "dynatrace_json_dashboard" "dashboard-b" {
   contents = jsonencode({
       "dashboardMetadata": {
         "name": "dashboard-b",
-        "owner": "me@home.com"
+        "owner": "me@example.com"
       },
       "tiles": [
         {
@@ -113,7 +113,7 @@ resource "dynatrace_json_dashboard" "dashboard-a" {
   contents = jsonencode({
       "dashboardMetadata": {
         "name": "dashboard-a",
-        "owner": "me@home.com"
+        "owner": "me@example.com"
       },
       "tiles": [
         {
@@ -140,7 +140,7 @@ resource "dynatrace_json_dashboard" "dashboard-b" {
   contents = jsonencode({
       "dashboardMetadata": {
         "name": "dashboard-b",
-        "owner": "me@home.com"
+        "owner": "me@example.com"
       },
       "tiles": [
         {

--- a/templates/resources/user.md.tmpl
+++ b/templates/resources/user.md.tmpl
@@ -41,11 +41,11 @@ resource "dynatrace_user_group" "terraform" {
 }
 
 resource "dynatrace_user" "terraform" {
-  email      = "me@home.com"
+  email      = "me@example.com"
   first_name = "John"
   groups     = [dynatrace_user_group.terraform.id]
   last_name  = "Doe"
-  user_name  = "me@home.com"
+  user_name  = "me@example.com"
 }
 
 resource "dynatrace_policy" "terraform_cluster" {

--- a/templates/resources/user_group.md.tmpl
+++ b/templates/resources/user_group.md.tmpl
@@ -41,11 +41,11 @@ resource "dynatrace_user_group" "terraform" {
 }
 
 resource "dynatrace_user" "terraform" {
-  email      = "me@home.com"
+  email      = "me@example.com"
   first_name = "John"
   groups     = [dynatrace_user_group.terraform.id]
   last_name  = "Doe"
-  user_name  = "me@home.com"
+  user_name  = "me@example.com"
 }
 
 resource "dynatrace_policy" "terraform_cluster" {


### PR DESCRIPTION
This PR introduces the structure of the `dynatrace_setting_permissions` resource and its HCL representation. Accordingly, `Schema()`, `MarshalHCL()` and `UnmarshalHCL()` functions are implemented, and an example config is given in `example_a.tf`.

In the following example, a permission resource is defined for the settings object ID of another Terraform resource `example_connection` of type `dynatrace_github_connection`.

It specifically grants **no access** to arbitrary users.
The user `user_id_1` gets write access and the user `user_id_2` gets read access.
Additionally, users of group `group_id_2` get write access.

Permissions for groups and users not defined in the resource will be **revoked**!

```
resource "dynatrace_setting_permissions" "github_connection_access" {
  settings_object_id = dynatrace_github_connection.example_connection.id
  all_users = "none" # possible values: none, read, write - default: none
  users { # default: empty
    user {
        user_id = "user_id_1"
        access = "write" # possible values: read, write
    }
    user {
        user_id = "user_id_2"
        access = "read" # possible values: read, write
    }
  }
  groups { # default: empty
    group {
        group_id = "group_id_2"
        access = "write" # possible values: read, write
    }
  }
}
```