### PR TITLE
feat: add settings permission service

### DIFF
--- a/dynatrace/api/v2/settings/objects/permissions/convert/convert.go
+++ b/dynatrace/api/v2/settings/objects/permissions/convert/convert.go
@@ -1,0 +1,52 @@
+package convert
+
+import (
+	"slices"
+
+	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+)
+
+func DTOToHCL(permissionObjects permissions.PermissionObjects, objectID string) *permissions.SettingPermissions {
+	groups := make(permissions.Groups, 0)
+	users := make(permissions.Users, 0)
+	allUsers := permissions.HCLAccessorNone
+
+	for _, permissionObject := range permissionObjects.Accessors {
+		access := convertDTOToHCLPermission(permissionObject.Permissions)
+		switch permissionObject.Accessor.Type {
+		case permissions.Group:
+			groups = append(groups, &permissions.GroupAccessor{
+				ID:     permissionObject.Accessor.ID,
+				Access: access,
+			})
+		case permissions.User:
+			users = append(users, &permissions.UserAccessor{
+				UID:    permissionObject.Accessor.ID,
+				Access: access,
+			})
+		case permissions.AllUsers:
+			allUsers = access
+		}
+	}
+	return &permissions.SettingPermissions{
+		SettingsObjectID: objectID,
+		Users:            users,
+		Groups:           groups,
+		AllUsers:         allUsers,
+	}
+}
+
+// convertDTOToHCLPermission converts the permissions from the DTO format to the HCL format.
+func convertDTOToHCLPermission(pms []permissions.TypePermissions) permissions.HCLAccessor {
+	if slices.Contains(pms, permissions.Write) {
+		return permissions.HCLAccessorWrite
+	}
+	return permissions.HCLAccessorRead
+}
+
+func HCLToDTOPermission(access permissions.HCLAccessor) []permissions.TypePermissions {
+	if access == permissions.HCLAccessorWrite {
+		return []permissions.TypePermissions{permissions.Read, permissions.Write}
+	}
+	return []permissions.TypePermissions{permissions.Read}
+}

--- a/dynatrace/api/v2/settings/objects/permissions/convert/convert_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/convert/convert_test.go
@@ -1,0 +1,132 @@
+package convert_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/convert"
+	permissions2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDTOToHCL(t *testing.T) {
+	t.Run("Maps DTO read permissions to HCL format", func(t *testing.T) {
+		dtoPermissions := permissions2.PermissionObjects{
+			Accessors: []permissions2.PermissionObject{
+				{
+					Accessor: permissions2.Accessor{
+						Type: permissions2.Group,
+						ID:   "group-id",
+					},
+					Permissions: []permissions2.TypePermissions{permissions2.Read},
+				},
+				{
+					Accessor: permissions2.Accessor{
+						Type: permissions2.User,
+						ID:   "user-id",
+					},
+					Permissions: []permissions2.TypePermissions{permissions2.Read},
+				},
+				{
+					Accessor: permissions2.Accessor{
+						Type: permissions2.AllUsers,
+					},
+					Permissions: []permissions2.TypePermissions{permissions2.Read},
+				},
+			},
+		}
+
+		hclPermissions := convert.DTOToHCL(dtoPermissions, "object-id")
+
+		assert.Equal(t, &permissions2.SettingPermissions{
+			SettingsObjectID: "object-id",
+			AllUsers:         permissions2.HCLAccessorRead,
+			Users: permissions2.Users{
+				{
+					UID:    "user-id",
+					Access: permissions2.HCLAccessorRead,
+				},
+			},
+			Groups: permissions2.Groups{
+				{
+					ID:     "group-id",
+					Access: permissions2.HCLAccessorRead,
+				},
+			},
+		}, hclPermissions)
+	})
+
+	t.Run("Maps DTO write permissions to HCL format", func(t *testing.T) {
+		dtoPermissions := permissions2.PermissionObjects{
+			Accessors: []permissions2.PermissionObject{
+				{
+					Accessor: permissions2.Accessor{
+						Type: permissions2.Group,
+						ID:   "group-id",
+					},
+					Permissions: []permissions2.TypePermissions{permissions2.Read, permissions2.Write},
+				},
+				{
+					Accessor: permissions2.Accessor{
+						Type: permissions2.User,
+						ID:   "user-id",
+					},
+					Permissions: []permissions2.TypePermissions{permissions2.Read, permissions2.Write},
+				},
+				{
+					Accessor: permissions2.Accessor{
+						Type: permissions2.AllUsers,
+					},
+					Permissions: []permissions2.TypePermissions{permissions2.Read, permissions2.Write},
+				},
+			},
+		}
+
+		hclPermissions := convert.DTOToHCL(dtoPermissions, "object-id")
+
+		assert.Equal(t, &permissions2.SettingPermissions{
+			SettingsObjectID: "object-id",
+			AllUsers:         permissions2.HCLAccessorWrite,
+			Users: permissions2.Users{
+				{
+					UID:    "user-id",
+					Access: permissions2.HCLAccessorWrite,
+				},
+			},
+			Groups: permissions2.Groups{
+				{
+					ID:     "group-id",
+					Access: permissions2.HCLAccessorWrite,
+				},
+			},
+		}, hclPermissions)
+	})
+
+	t.Run("Maps empty DTO permissions to HCL format", func(t *testing.T) {
+		dtoPermissions := permissions2.PermissionObjects{
+			Accessors: []permissions2.PermissionObject{},
+		}
+
+		hclPermissions := convert.DTOToHCL(dtoPermissions, "object-id")
+
+		assert.Equal(t, &permissions2.SettingPermissions{
+			SettingsObjectID: "object-id",
+			AllUsers:         permissions2.HCLAccessorNone,
+			Users:            permissions2.Users{},
+			Groups:           permissions2.Groups{},
+		}, hclPermissions)
+	})
+}
+
+func TestHCLToDTOPermission(t *testing.T) {
+	t.Run("Maps DTO read permissions to HCL format", func(t *testing.T) {
+		hclPermission := convert.HCLToDTOPermission(permissions2.HCLAccessorRead)
+
+		assert.Equal(t, []permissions2.TypePermissions{permissions2.Read}, hclPermission)
+	})
+
+	t.Run("Maps DTO write permissions to HCL format", func(t *testing.T) {
+		hclPermission := convert.HCLToDTOPermission(permissions2.HCLAccessorWrite)
+
+		assert.Equal(t, []permissions2.TypePermissions{permissions2.Read, permissions2.Write}, hclPermission)
+	})
+}

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/all_users.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/all_users.go
@@ -1,0 +1,53 @@
+package reconcile
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/convert"
+	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+)
+
+func compareAndUpdateAllUsers(ctx context.Context, client permissions.AllUsersClient, objectID string, currentAllUsers, desiredAllUsers string) error {
+	if currentAllUsers == desiredAllUsers {
+		return nil
+	}
+
+	if desiredAllUsers == permissions.HCLAccessorNone {
+		_, err := client.DeleteAllUsersAccessor(ctx, objectID, false)
+		return err
+	}
+
+	if currentAllUsers == permissions.HCLAccessorNone {
+		return createAllUsers(ctx, client, objectID, desiredAllUsers)
+	}
+
+	return updateAllUsers(ctx, client, objectID, desiredAllUsers)
+}
+
+func createAllUsers(ctx context.Context, client permissions.AllUsersClient, objectID string, desiredAllUsers string) error {
+	body, err := json.Marshal(permissions.PermissionObject{
+		Accessor: permissions.Accessor{
+			Type: permissions.AllUsers,
+		},
+		Permissions: convert.HCLToDTOPermission(desiredAllUsers),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Create(ctx, objectID, false, body)
+	return err
+}
+
+func updateAllUsers(ctx context.Context, client permissions.AllUsersClient, objectID string, desiredAllUsers string) error {
+	body, err := json.Marshal(permissions.PermissionObjectUpdate{
+		Permissions: convert.HCLToDTOPermission(desiredAllUsers),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = client.UpdateAllUsersAccessor(ctx, objectID, false, body)
+	return err
+}

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/groups.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/groups.go
@@ -9,34 +9,46 @@ import (
 	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
 )
 
-func compareAndUpdateGroups(ctx context.Context, client permissions.AccessorClient, objectID string, currentGroups, desiredGroups permissions.Groups) error {
+func getGroupUpserts(ctx context.Context, client permissions.AccessorClient, objectID string, currentGroups, desiredGroups permissions.Groups) ([]func(adminAccess bool) error, error) {
 	errs := make([]error, 0)
+	updates := make([]func(adminAccess bool) error, 0)
 	// update and create groups
 	for _, group := range desiredGroups {
 		var err error
+		var fn func(adminAccess bool) error
 		if exists, isEqual := containsGroups(currentGroups, group); !exists {
-			err = createGroup(ctx, client, objectID, group)
+			fn, err = getGroupCreate(ctx, client, objectID, group)
 		} else if !isEqual {
-			err = updateGroup(ctx, client, objectID, group)
+			fn, err = getGroupUpdate(ctx, client, objectID, group)
+		} else {
+			// group already exists and is equal, no action needed
+			continue
 		}
+
 		if err != nil {
 			errs = append(errs, err)
+			continue
 		}
+		updates = append(updates, fn)
 	}
 
 	// delete groups that are not in desiredGroups (HCL)
 	for _, group := range currentGroups {
 		if exists, _ := containsGroups(desiredGroups, group); !exists {
-			_, err := client.DeleteAccessor(ctx, objectID, permissions.Group, group.ID, false)
-			if err != nil {
-				errs = append(errs, err)
-			}
+			updates = append(updates, func(adminAccess bool) error {
+				_, err := client.DeleteAccessor(ctx, objectID, permissions.Group, group.ID, adminAccess)
+				return err
+			})
 		}
 	}
-	return errors.Join(errs...)
+	joinErr := errors.Join(errs...)
+	if joinErr != nil {
+		return nil, joinErr
+	}
+	return updates, nil
 }
 
-func createGroup(ctx context.Context, client permissions.AccessorClient, objectID string, group *permissions.GroupAccessor) error {
+func getGroupCreate(ctx context.Context, client permissions.AccessorClient, objectID string, group *permissions.GroupAccessor) (func(adminAccess bool) error, error) {
 	body, err := json.Marshal(permissions.PermissionObject{
 		Accessor: permissions.Accessor{
 			Type: permissions.Group,
@@ -46,29 +58,33 @@ func createGroup(ctx context.Context, client permissions.AccessorClient, objectI
 	})
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = client.Create(ctx, objectID, false, body)
-	return err
+	return func(adminAccess bool) error {
+		_, err = client.Create(ctx, objectID, adminAccess, body)
+		return err
+	}, nil
 }
 
-func updateGroup(ctx context.Context, client permissions.AccessorClient, objectID string, group *permissions.GroupAccessor) error {
+func getGroupUpdate(ctx context.Context, client permissions.AccessorClient, objectID string, group *permissions.GroupAccessor) (func(adminAccess bool) error, error) {
 	body, err := json.Marshal(permissions.PermissionObjectUpdate{
 		Permissions: convert.HCLToDTOPermission(group.Access),
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = client.UpdateAccessor(ctx, objectID, permissions.Group, group.ID, false, body)
-	return err
+	return func(adminAccess bool) error {
+		_, err = client.UpdateAccessor(ctx, objectID, permissions.Group, group.ID, adminAccess, body)
+		return err
+	}, nil
 }
 
 func containsGroups(groups permissions.Groups, group *permissions.GroupAccessor) (exists, equals bool) {
-	for _, u := range groups {
-		if u.ID == group.ID {
-			return true, u.Access == group.Access
+	for _, g := range groups {
+		if g.ID == group.ID {
+			return true, g.Access == group.Access
 		}
 	}
 	return false, false

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/groups.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/groups.go
@@ -1,0 +1,75 @@
+package reconcile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/convert"
+	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+)
+
+func compareAndUpdateGroups(ctx context.Context, client permissions.AccessorClient, objectID string, currentGroups, desiredGroups permissions.Groups) error {
+	errs := make([]error, 0)
+	// update and create groups
+	for _, group := range desiredGroups {
+		var err error
+		if exists, isEqual := containsGroups(currentGroups, group); !exists {
+			err = createGroup(ctx, client, objectID, group)
+		} else if !isEqual {
+			err = updateGroup(ctx, client, objectID, group)
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// delete groups that are not in desiredGroups (HCL)
+	for _, group := range currentGroups {
+		if exists, _ := containsGroups(desiredGroups, group); !exists {
+			_, err := client.DeleteAccessor(ctx, objectID, permissions.Group, group.ID, false)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func createGroup(ctx context.Context, client permissions.AccessorClient, objectID string, group *permissions.GroupAccessor) error {
+	body, err := json.Marshal(permissions.PermissionObject{
+		Accessor: permissions.Accessor{
+			Type: permissions.Group,
+			ID:   group.ID,
+		},
+		Permissions: convert.HCLToDTOPermission(group.Access),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Create(ctx, objectID, false, body)
+	return err
+}
+
+func updateGroup(ctx context.Context, client permissions.AccessorClient, objectID string, group *permissions.GroupAccessor) error {
+	body, err := json.Marshal(permissions.PermissionObjectUpdate{
+		Permissions: convert.HCLToDTOPermission(group.Access),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = client.UpdateAccessor(ctx, objectID, permissions.Group, group.ID, false, body)
+	return err
+}
+
+func containsGroups(groups permissions.Groups, group *permissions.GroupAccessor) (exists, equals bool) {
+	for _, u := range groups {
+		if u.ID == group.ID {
+			return true, u.Access == group.Access
+		}
+	}
+	return false, false
+}

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile.go
@@ -3,14 +3,47 @@ package reconcile
 import (
 	"context"
 	"errors"
+	"slices"
+	"sync"
 
 	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
 )
 
 func CompareAndUpdate(ctx context.Context, cl permissions.PermissionUpdateClient, current *permissions.SettingPermissions, desired *permissions.SettingPermissions) error {
-	groupErr := compareAndUpdateGroups(ctx, cl, current.SettingsObjectID, current.Groups, desired.Groups)
-	userErr := compareAndUpdateUsers(ctx, cl, current.SettingsObjectID, current.Users, desired.Users)
-	allUserEr := compareAndUpdateAllUsers(ctx, cl, current.SettingsObjectID, current.AllUsers, desired.AllUsers)
+	groupUpserts, groupErr := getGroupUpserts(ctx, cl, current.SettingsObjectID, current.Groups, desired.Groups)
+	userUpserts, userErr := getUserUpserts(ctx, cl, current.SettingsObjectID, current.Users, desired.Users)
+	allUserUpsert, allUserErr := getAllUserUpsert(ctx, cl, current.SettingsObjectID, current.AllUsers, desired.AllUsers)
 
-	return errors.Join(groupErr, userErr, allUserEr)
+	prepareErrs := errors.Join(groupErr, userErr, allUserErr)
+
+	if prepareErrs != nil {
+		return prepareErrs
+	}
+
+	upserts := slices.Concat(groupUpserts, userUpserts)
+	if allUserUpsert != nil {
+		upserts = append(upserts, allUserUpsert)
+	}
+	return executeUpserts(upserts)
+}
+
+func executeUpserts(upserts []func(adminAccess bool) error) error {
+	errChan := make(chan error, len(upserts))
+
+	var wg sync.WaitGroup
+	wg.Add(len(upserts))
+	for _, upsert := range upserts {
+		go func() {
+			defer wg.Done()
+			errChan <- upsert(false)
+		}()
+	}
+	wg.Wait()
+	close(errChan)
+
+	errs := make([]error, len(upserts))
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile.go
@@ -1,0 +1,16 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+
+	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+)
+
+func CompareAndUpdate(ctx context.Context, cl permissions.PermissionUpdateClient, current *permissions.SettingPermissions, desired *permissions.SettingPermissions) error {
+	groupErr := compareAndUpdateGroups(ctx, cl, current.SettingsObjectID, current.Groups, desired.Groups)
+	userErr := compareAndUpdateUsers(ctx, cl, current.SettingsObjectID, current.Users, desired.Users)
+	allUserEr := compareAndUpdateAllUsers(ctx, cl, current.SettingsObjectID, current.AllUsers, desired.AllUsers)
+
+	return errors.Join(groupErr, userErr, allUserEr)
+}

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile_test.go
@@ -1,0 +1,409 @@
+package reconcile_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/reconcile"
+	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+)
+
+type clientStub struct {
+	create                 func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error)
+	updateAccessor         func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (api.Response, error)
+	deleteAccessor         func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (api.Response, error)
+	updateAllUsersAccessor func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error)
+	deleteAllUsersAccessor func(ctx context.Context, objectID string, adminAccess bool) (api.Response, error)
+}
+
+func (c clientStub) Create(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+	return c.create(ctx, objectID, adminAccess, body)
+}
+
+func (c clientStub) UpdateAccessor(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (api.Response, error) {
+	return c.updateAccessor(ctx, objectID, accessorType, accessorID, adminAccess, body)
+}
+
+func (c clientStub) DeleteAccessor(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (api.Response, error) {
+	return c.deleteAccessor(ctx, objectID, accessorType, accessorID, adminAccess)
+}
+
+func (c clientStub) UpdateAllUsersAccessor(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+	return c.updateAllUsersAccessor(ctx, objectID, adminAccess, body)
+}
+
+func (c clientStub) DeleteAllUsersAccessor(ctx context.Context, objectID string, adminAccess bool) (api.Response, error) {
+	return c.deleteAllUsersAccessor(ctx, objectID, adminAccess)
+}
+
+func TestCompareAndUpdate(t *testing.T) {
+	t.Run("Successful users operations", func(t *testing.T) {
+		t.Run("Create new user", func(t *testing.T) {
+			createCalls := 0
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					// Simulate successful creation
+					createCalls++
+					return api.Response{StatusCode: 201, Data: []byte("{}")}, nil
+				},
+			}
+
+			current := &permissions.SettingPermissions{
+				Users: permissions.Users{},
+			}
+			desired := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, createCalls, "Expected one user to be created")
+		})
+
+		t.Run("Update existing user", func(t *testing.T) {
+			updateCalls := 0
+			client := clientStub{
+				updateAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (api.Response, error) {
+					// Simulate successful update
+					updateCalls++
+					return api.Response{StatusCode: 200, Data: []byte("{}")}, nil
+				},
+			}
+
+			current := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			desired := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorRead},
+				},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, updateCalls, "Expected one user to be updated")
+		})
+
+		t.Run("Delete existing user", func(t *testing.T) {
+			deleteCalls := 0
+			client := clientStub{
+				deleteAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (api.Response, error) {
+					deleteCalls++
+					return api.Response{StatusCode: 204, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			desired := &permissions.SettingPermissions{
+				Users: permissions.Users{},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, deleteCalls, "Expected one user to be deleted")
+		})
+
+		t.Run("Does not update user if not changed", func(t *testing.T) {
+			client := clientStub{
+				updateAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (api.Response, error) {
+					t.FailNow() // Should not be called
+					return api.Response{}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			desired := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("Successful groups operations", func(t *testing.T) {
+		t.Run("Create new group", func(t *testing.T) {
+			createCalls := 0
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					createCalls++
+					return api.Response{StatusCode: 201, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Groups: permissions.Groups{},
+			}
+			desired := &permissions.SettingPermissions{
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, createCalls, "Expected one group to be created")
+		})
+
+		t.Run("Update existing group", func(t *testing.T) {
+			updateCalls := 0
+			client := clientStub{
+				updateAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (api.Response, error) {
+					updateCalls++
+					return api.Response{StatusCode: 200, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			desired := &permissions.SettingPermissions{
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorRead},
+				},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, updateCalls, "Expected one group to be updated")
+		})
+
+		t.Run("Delete existing group", func(t *testing.T) {
+			deleteCalls := 0
+			client := clientStub{
+				deleteAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (api.Response, error) {
+					deleteCalls++
+					return api.Response{StatusCode: 204, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			desired := &permissions.SettingPermissions{
+				Groups: permissions.Groups{},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, deleteCalls, "Expected one group to be deleted")
+		})
+
+		t.Run("Does not update group if not changed", func(t *testing.T) {
+			client := clientStub{
+				updateAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (api.Response, error) {
+					t.FailNow() // Should not be called
+					return api.Response{}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			desired := &permissions.SettingPermissions{
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("Successful allUser operations", func(t *testing.T) {
+		t.Run("Create allUser", func(t *testing.T) {
+			createCalls := 0
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					createCalls++
+					return api.Response{StatusCode: 201, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorNone,
+			}
+			desired := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, createCalls, "Expected allUser to be created")
+		})
+
+		t.Run("Update allUser", func(t *testing.T) {
+			updateCalls := 0
+			client := clientStub{
+				updateAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					updateCalls++
+					return api.Response{StatusCode: 200, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorRead,
+			}
+			desired := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, updateCalls, "Expected allUser to be updated")
+		})
+
+		t.Run("Delete allUser", func(t *testing.T) {
+			deleteCalls := 0
+			client := clientStub{
+				deleteAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool) (api.Response, error) {
+					deleteCalls++
+					return api.Response{StatusCode: 204, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			desired := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorNone,
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, deleteCalls, "Expected allUser to be deleted")
+		})
+
+		t.Run("Does not update allUser if not changed", func(t *testing.T) {
+			client := clientStub{
+				updateAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					t.FailNow() // Should not be called
+					return api.Response{}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			desired := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("Handles errors correctly", func(t *testing.T) {
+		t.Run("Continues if one user errors", func(t *testing.T) {
+			createCalls := 0
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					createCalls++
+					if createCalls == 1 {
+						return api.Response{}, assert.AnError
+					}
+					return api.Response{StatusCode: 201, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Users: permissions.Users{},
+			}
+			desired := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
+					&permissions.UserAccessor{UID: "user2", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.Error(t, err)
+			assert.Equal(t, 2, createCalls, "Should attempt both users")
+		})
+
+		t.Run("Continues if one group errors", func(t *testing.T) {
+			createCalls := 0
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					createCalls++
+					if createCalls == 1 {
+						return api.Response{}, assert.AnError
+					}
+					return api.Response{StatusCode: 201, Data: []byte("{}")}, nil
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Groups: permissions.Groups{},
+			}
+			desired := &permissions.SettingPermissions{
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
+					&permissions.GroupAccessor{ID: "group2", Access: permissions.HCLAccessorWrite},
+				},
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.Error(t, err)
+			assert.Equal(t, 2, createCalls, "Should attempt both groups")
+		})
+
+		t.Run("Continues if one allUser errors", func(t *testing.T) {
+			calls := 0
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					calls++
+					return api.Response{}, assert.AnError
+				},
+			}
+			current := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorNone,
+			}
+			desired := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.Error(t, err)
+			assert.Equal(t, 1, calls, "Should attempt allUser")
+		})
+
+		t.Run("Returns error if all operations fail", func(t *testing.T) {
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					return api.Response{}, assert.AnError
+				},
+				updateAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (api.Response, error) {
+					return api.Response{}, assert.AnError
+				},
+				deleteAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (api.Response, error) {
+					return api.Response{}, assert.AnError
+				},
+				updateAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					return api.Response{}, assert.AnError
+				},
+				deleteAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool) (api.Response, error) {
+					return api.Response{}, assert.AnError
+				},
+			}
+			current := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorRead},
+				},
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorRead},
+				},
+				AllUsers: permissions.HCLAccessorRead,
+			}
+			desired := &permissions.SettingPermissions{
+				Users: permissions.Users{
+					&permissions.UserAccessor{UID: "user2", Access: permissions.HCLAccessorWrite},
+				},
+				Groups: permissions.Groups{
+					&permissions.GroupAccessor{ID: "group2", Access: permissions.HCLAccessorWrite},
+				},
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			assert.Error(t, err)
+		})
+	})
+}

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/users.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/users.go
@@ -1,0 +1,75 @@
+package reconcile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/convert"
+	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+)
+
+func compareAndUpdateUsers(ctx context.Context, client permissions.AccessorClient, objectID string, currentUsers, desiredUsers permissions.Users) error {
+	errs := make([]error, 0)
+	// update and create users
+	for _, user := range desiredUsers {
+		var err error
+		if exists, isEqual := containsUser(currentUsers, user); !exists {
+			err = createUser(ctx, client, objectID, user)
+		} else if !isEqual {
+			err = updateUser(ctx, client, objectID, user)
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// delete users that are not in desiredUsers (HCL)
+	for _, user := range currentUsers {
+		if exists, _ := containsUser(desiredUsers, user); !exists {
+			_, err := client.DeleteAccessor(ctx, objectID, permissions.User, user.UID, false)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func createUser(ctx context.Context, client permissions.AccessorClient, objectID string, user *permissions.UserAccessor) error {
+	body, err := json.Marshal(permissions.PermissionObject{
+		Accessor: permissions.Accessor{
+			Type: permissions.User,
+			ID:   user.UID,
+		},
+		Permissions: convert.HCLToDTOPermission(user.Access),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Create(ctx, objectID, false, body)
+	return err
+}
+
+func updateUser(ctx context.Context, client permissions.AccessorClient, objectID string, user *permissions.UserAccessor) error {
+	body, err := json.Marshal(permissions.PermissionObjectUpdate{
+		Permissions: convert.HCLToDTOPermission(user.Access),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = client.UpdateAccessor(ctx, objectID, permissions.User, user.UID, false, body)
+	return err
+}
+
+func containsUser(users permissions.Users, user *permissions.UserAccessor) (exists, equals bool) {
+	for _, u := range users {
+		if u.UID == user.UID {
+			return true, u.Access == user.Access
+		}
+	}
+	return false, false
+}

--- a/dynatrace/api/v2/settings/objects/permissions/service.go
+++ b/dynatrace/api/v2/settings/objects/permissions/service.go
@@ -1,0 +1,115 @@
+package permissions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/convert"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/reconcile"
+	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+
+	permissions2 "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/settings/permissions"
+)
+
+func Service(credentials *rest.Credentials) settings.CRUDService[*permissions.SettingPermissions] {
+	return &ServiceImpl{Credentials: credentials}
+}
+
+type ServiceImpl struct {
+	Credentials *rest.Credentials
+	Client      permissions.PermissionClient
+}
+
+func (me *ServiceImpl) getClient(ctx context.Context) (permissions.PermissionClient, error) {
+	if me.Client != nil {
+		return me.Client, nil
+	}
+	restClient, err := rest.CreatePlatformClient(ctx, me.Credentials.OAuth.EnvironmentURL, me.Credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	me.Client = permissions2.NewClient(restClient)
+	return me.Client, nil
+}
+
+func (me *ServiceImpl) Get(ctx context.Context, objectID string, v *permissions.SettingPermissions) error {
+	currentPermissions, err := me.get(ctx, objectID)
+	if err != nil {
+		return err
+	}
+
+	v.SettingsObjectID = objectID
+	v.Users = currentPermissions.Users
+	v.Groups = currentPermissions.Groups
+	v.AllUsers = currentPermissions.AllUsers
+	return nil
+}
+
+func (me *ServiceImpl) get(ctx context.Context, objectID string) (*permissions.SettingPermissions, error) {
+	client, err := me.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	req, err := client.GetAllAccessors(ctx, objectID, false)
+	if err != nil {
+		return nil, err
+	}
+	var permissionObjects permissions.PermissionObjects
+	err = json.Unmarshal(req.Data, &permissionObjects)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal permissions response: %w", err)
+	}
+	return convert.DTOToHCL(permissionObjects, objectID), nil
+}
+
+func (me *ServiceImpl) SchemaID() string {
+	return "settings:permissions"
+}
+
+func (me *ServiceImpl) List(ctx context.Context) (api.Stubs, error) {
+	return api.Stubs{}, nil
+}
+
+func (me *ServiceImpl) Upsert(ctx context.Context, v *permissions.SettingPermissions) (*api.Stub, error) {
+	client, err := me.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	data, err := me.get(ctx, v.SettingsObjectID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = reconcile.CompareAndUpdate(ctx, client, data, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.Stub{ID: v.SettingsObjectID}, nil
+}
+
+func (me *ServiceImpl) Create(ctx context.Context, v *permissions.SettingPermissions) (*api.Stub, error) {
+	return me.Upsert(ctx, v)
+}
+
+func (me *ServiceImpl) Update(ctx context.Context, _ string, v *permissions.SettingPermissions) error {
+	_, err := me.Upsert(ctx, v)
+	return err
+}
+
+func (me *ServiceImpl) Delete(ctx context.Context, id string) error {
+	// via the Upsert we can delete the permissions by passing an empty permissions object
+	emptyPermissions := &permissions.SettingPermissions{
+		SettingsObjectID: id,
+		Users:            nil,
+		Groups:           nil,
+		AllUsers:         permissions.HCLAccessorNone,
+	}
+	_, err := me.Upsert(ctx, emptyPermissions)
+	return err
+}

--- a/dynatrace/api/v2/settings/objects/permissions/service_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/service_test.go
@@ -1,0 +1,296 @@
+package permissions_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	permissionService "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions"
+	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coreApi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+)
+
+type clientStub struct {
+	getAllAccessor         func(context.Context, string, bool) (coreApi.Response, error)
+	create                 func(ctx context.Context, objectID string, adminAccess bool, body []byte) (coreApi.Response, error)
+	updateAccessor         func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (coreApi.Response, error)
+	deleteAccessor         func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (coreApi.Response, error)
+	updateAllUsersAccessor func(ctx context.Context, objectID string, adminAccess bool, body []byte) (coreApi.Response, error)
+	deleteAllUsersAccessor func(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error)
+}
+
+func (c *clientStub) GetAllAccessors(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+	return c.getAllAccessor(ctx, objectID, adminAccess)
+}
+
+func (c *clientStub) Create(ctx context.Context, objectID string, adminAccess bool, body []byte) (coreApi.Response, error) {
+	return c.create(ctx, objectID, adminAccess, body)
+}
+
+func (c *clientStub) UpdateAccessor(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (coreApi.Response, error) {
+	return c.updateAccessor(ctx, objectID, accessorType, accessorID, adminAccess, body)
+}
+
+func (c *clientStub) DeleteAccessor(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (coreApi.Response, error) {
+	return c.deleteAccessor(ctx, objectID, accessorType, accessorID, adminAccess)
+}
+
+func (c *clientStub) UpdateAllUsersAccessor(ctx context.Context, objectID string, adminAccess bool, body []byte) (coreApi.Response, error) {
+	return c.updateAllUsersAccessor(ctx, objectID, adminAccess, body)
+}
+
+func (c *clientStub) DeleteAllUsersAccessor(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+	return c.deleteAllUsersAccessor(ctx, objectID, adminAccess)
+}
+
+func TestService(t *testing.T) {
+	t.Run("Get", func(t *testing.T) {
+		t.Run("It gets permissions", func(t *testing.T) {
+			client := &clientStub{
+				getAllAccessor: func(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+					response := permissions.PermissionObjects{
+						Accessors: []permissions.PermissionObject{
+							{
+								Accessor: permissions.Accessor{
+									Type: permissions.AllUsers,
+								},
+								Permissions: []permissions.TypePermissions{permissions.Read, permissions.Write},
+							},
+							{
+								Accessor: permissions.Accessor{
+									Type: permissions.User,
+									ID:   "userID",
+								},
+								Permissions: []permissions.TypePermissions{permissions.Read, permissions.Write},
+							},
+							{
+								Accessor: permissions.Accessor{
+									Type: permissions.Group,
+									ID:   "groupID",
+								},
+								Permissions: []permissions.TypePermissions{permissions.Read},
+							},
+						},
+					}
+					responseBytes, err := json.Marshal(response)
+					require.NoError(t, err)
+
+					return coreApi.Response{
+						StatusCode: 200,
+						Data:       responseBytes,
+					}, nil
+				},
+			}
+			service := permissionService.ServiceImpl{Client: client}
+			value := permissions.SettingPermissions{}
+			err := service.Get(t.Context(), "objectID", &value)
+
+			assert.NoError(t, err)
+			assert.Equal(t, permissions.SettingPermissions{
+				SettingsObjectID: "objectID",
+				AllUsers:         permissions.HCLAccessorWrite,
+				Users: permissions.Users{
+					{
+						UID:    "userID",
+						Access: permissions.HCLAccessorWrite,
+					},
+				},
+				Groups: permissions.Groups{
+					{
+						ID:     "groupID",
+						Access: permissions.HCLAccessorRead,
+					},
+				},
+			}, value)
+		})
+
+		t.Run("Errors during get", func(t *testing.T) {
+			client := &clientStub{
+				getAllAccessor: func(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+					return coreApi.Response{}, assert.AnError
+				},
+			}
+			service := permissionService.ServiceImpl{Client: client}
+			value := permissions.SettingPermissions{
+				SettingsObjectID: "objectID",
+			}
+			err := service.Get(t.Context(), "objectID", &value)
+			assert.Error(t, err)
+			assert.ErrorIs(t, assert.AnError, err)
+		})
+
+		t.Run("It errors during client creation", func(t *testing.T) {
+			service := permissionService.ServiceImpl{
+				Credentials: &rest.Credentials{},
+			}
+			err := service.Get(t.Context(), "objectID", &permissions.SettingPermissions{})
+			assert.ErrorIs(t, rest.NoPlatformCredentialsErr, err)
+		})
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		t.Run("It successfully upserts (no changes)", func(t *testing.T) {
+			client := &clientStub{
+				getAllAccessor: func(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+					response := permissions.PermissionObjects{
+						Accessors: []permissions.PermissionObject{},
+					}
+					responseBytes, err := json.Marshal(response)
+					require.NoError(t, err)
+
+					return coreApi.Response{
+						StatusCode: 200,
+						Data:       responseBytes,
+					}, nil
+				},
+			}
+			service := permissionService.ServiceImpl{Client: client}
+			value := permissions.SettingPermissions{
+				SettingsObjectID: "objectID",
+				AllUsers:         permissions.HCLAccessorNone,
+				Users:            permissions.Users{},
+				Groups:           permissions.Groups{},
+			}
+			_, err := service.Create(t.Context(), &value)
+			assert.NoError(t, err)
+		})
+
+		t.Run("It errors during upsert", func(t *testing.T) {
+			client := &clientStub{
+				updateAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (coreApi.Response, error) {
+					return coreApi.Response{}, assert.AnError
+				},
+				getAllAccessor: func(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+					response := permissions.PermissionObjects{
+						Accessors: []permissions.PermissionObject{
+							{
+								Accessor: permissions.Accessor{
+									Type: permissions.AllUsers,
+								},
+								Permissions: []permissions.TypePermissions{permissions.Read, permissions.Write},
+							},
+						},
+					}
+					responseBytes, err := json.Marshal(response)
+					require.NoError(t, err)
+
+					return coreApi.Response{
+						StatusCode: 200,
+						Data:       responseBytes,
+					}, nil
+				},
+			}
+			service := permissionService.ServiceImpl{Client: client}
+			value := permissions.SettingPermissions{
+				SettingsObjectID: "objectID",
+				AllUsers:         permissions.HCLAccessorRead,
+			}
+			_, err := service.Create(t.Context(), &value)
+			assert.ErrorContains(t, err, assert.AnError.Error())
+		})
+
+		t.Run("It errors during get", func(t *testing.T) {
+			client := &clientStub{
+				getAllAccessor: func(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+					return coreApi.Response{}, assert.AnError
+				},
+			}
+			service := permissionService.ServiceImpl{Client: client}
+			value := permissions.SettingPermissions{
+				SettingsObjectID: "objectID",
+			}
+			_, err := service.Create(t.Context(), &value)
+			assert.Error(t, err)
+			assert.ErrorIs(t, assert.AnError, err)
+		})
+
+		t.Run("It errors during client creation", func(t *testing.T) {
+			service := permissionService.ServiceImpl{
+				Credentials: &rest.Credentials{},
+			}
+			_, err := service.Create(t.Context(), &permissions.SettingPermissions{})
+			assert.ErrorIs(t, rest.NoPlatformCredentialsErr, err)
+		})
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		t.Run("It errors during client creation", func(t *testing.T) {
+			service := permissionService.ServiceImpl{
+				Credentials: &rest.Credentials{},
+			}
+			err := service.Update(t.Context(), "", &permissions.SettingPermissions{})
+			assert.ErrorIs(t, rest.NoPlatformCredentialsErr, err)
+		})
+	})
+
+	t.Run("Delete deletes every permission", func(t *testing.T) {
+		deleteAllUserCalled := 0
+		deleteAccessorCalled := 0
+		client := &clientStub{
+			getAllAccessor: func(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+				response := permissions.PermissionObjects{
+					Accessors: []permissions.PermissionObject{
+						{
+							Accessor: permissions.Accessor{
+								Type: permissions.AllUsers,
+							},
+							Permissions: []permissions.TypePermissions{permissions.Read, permissions.Write},
+						},
+						{
+							Accessor: permissions.Accessor{
+								Type: permissions.User,
+								ID:   "userID",
+							},
+							Permissions: []permissions.TypePermissions{permissions.Read, permissions.Write},
+						},
+						{
+							Accessor: permissions.Accessor{
+								Type: permissions.Group,
+								ID:   "groupID",
+							},
+							Permissions: []permissions.TypePermissions{permissions.Read},
+						},
+					},
+				}
+				responseBytes, err := json.Marshal(response)
+				require.NoError(t, err)
+
+				return coreApi.Response{
+					StatusCode: 200,
+					Data:       responseBytes,
+				}, nil
+			},
+			deleteAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error) {
+				deleteAllUserCalled++
+				return coreApi.Response{
+					StatusCode: 204,
+				}, nil
+			},
+			deleteAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (coreApi.Response, error) {
+				deleteAccessorCalled++
+				return coreApi.Response{
+					StatusCode: 204,
+				}, nil
+			},
+		}
+		service := permissionService.ServiceImpl{Client: client}
+		err := service.Delete(t.Context(), "objectID")
+		assert.NoError(t, err)
+		assert.Equal(t, 1, deleteAllUserCalled)
+		assert.Equal(t, 2, deleteAccessorCalled)
+	})
+
+	t.Run("Service returns a new instance", func(t *testing.T) {
+		service := permissionService.Service(nil)
+		assert.IsType(t, &permissionService.ServiceImpl{}, service)
+	})
+
+	t.Run("Returns the schema ID", func(t *testing.T) {
+		service := permissionService.ServiceImpl{}
+		assert.Equal(t, "settings:permissions", service.SchemaID())
+	})
+}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/dto.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/dto.go
@@ -1,5 +1,11 @@
 package settings
 
+import (
+	"context"
+
+	coreApi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+)
+
 type TypePermissions = string
 
 const (
@@ -41,4 +47,26 @@ type PermissionObjects struct {
 // PermissionObjectUpdate represents the updated permissions for a settings object to an accessor.
 type PermissionObjectUpdate struct {
 	Permissions []TypePermissions `json:"permissions"`
+}
+
+type AccessorClient interface {
+	Create(ctx context.Context, objectID string, adminAccess bool, body []byte) (coreApi.Response, error)
+	UpdateAccessor(ctx context.Context, objectID string, accessorType TypeAccessor, accessorID string, adminAccess bool, body []byte) (coreApi.Response, error)
+	DeleteAccessor(ctx context.Context, objectID string, accessorType TypeAccessor, accessorID string, adminAccess bool) (coreApi.Response, error)
+}
+
+type AllUsersClient interface {
+	Create(ctx context.Context, objectID string, adminAccess bool, body []byte) (coreApi.Response, error)
+	UpdateAllUsersAccessor(ctx context.Context, objectID string, adminAccess bool, body []byte) (coreApi.Response, error)
+	DeleteAllUsersAccessor(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error)
+}
+
+type PermissionUpdateClient interface {
+	AccessorClient
+	AllUsersClient
+}
+
+type PermissionClient interface {
+	PermissionUpdateClient
+	GetAllAccessors(ctx context.Context, objectID string, adminAccess bool) (coreApi.Response, error)
 }

--- a/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
@@ -39,7 +39,7 @@ func (_ *Groups) Schema() map[string]*schema.Schema {
 	}
 }
 
-func (g *Groups) MarshalHCL(properties hcl.Properties) error {
+func (g Groups) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeSlice("group", g)
 }
 
@@ -68,7 +68,7 @@ func (_ *GroupAccessor) Schema() map[string]*schema.Schema {
 	}
 }
 
-func (ga *GroupAccessor) MarshalHCL(properties hcl.Properties) error {
+func (ga GroupAccessor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
 		"id":     ga.ID,
 		"access": ga.Access,

--- a/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor.go
@@ -18,6 +18,8 @@
 package settings
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -59,9 +61,9 @@ func (_ *GroupAccessor) Schema() map[string]*schema.Schema {
 		},
 		"access": {
 			Type:         schema.TypeString,
-			Description:  "Valid values: read, write",
+			Description:  fmt.Sprintf("Valid values: `%s`, `%s`", HCLAccessorRead, HCLAccessorWrite),
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"read", "write"}, false),
+			ValidateFunc: validation.StringInSlice([]string{HCLAccessorRead, HCLAccessorWrite}, false),
 		},
 	}
 }

--- a/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
@@ -69,7 +69,7 @@ func (_ *SettingPermissions) Schema() map[string]*schema.Schema {
 	}
 }
 
-func (sp *SettingPermissions) MarshalHCL(properties hcl.Properties) error {
+func (sp SettingPermissions) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
 		"settings_object_id": sp.SettingsObjectID,
 		"all_users":          sp.AllUsers,

--- a/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
@@ -18,6 +18,8 @@
 package settings
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -30,6 +32,14 @@ type SettingPermissions struct {
 	Groups           Groups
 }
 
+type HCLAccessor = string
+
+const (
+	HCLAccessorRead  HCLAccessor = "read"
+	HCLAccessorWrite HCLAccessor = "write"
+	HCLAccessorNone  HCLAccessor = "none"
+)
+
 func (_ *SettingPermissions) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"settings_object_id": {
@@ -39,9 +49,10 @@ func (_ *SettingPermissions) Schema() map[string]*schema.Schema {
 		},
 		"all_users": {
 			Type:         schema.TypeString,
-			Description:  "Defines the default access level granted to all users in this environment. Allowed values are `read`, `write`, or `none`",
+			Description:  fmt.Sprintf("Defines the default access level granted to all users in this environment. Allowed values are `%s`, `%s`, or `%s`", HCLAccessorRead, HCLAccessorWrite, HCLAccessorNone),
 			Optional:     true,
-			ValidateFunc: validation.StringInSlice([]string{"read", "write", "none"}, false),
+			Default:      "none",
+			ValidateFunc: validation.StringInSlice([]string{HCLAccessorRead, HCLAccessorWrite, HCLAccessorNone}, false),
 		},
 		"users": {
 			Type:     schema.TypeList,

--- a/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
@@ -18,6 +18,8 @@
 package settings
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -59,9 +61,9 @@ func (_ *UserAccessor) Schema() map[string]*schema.Schema {
 		},
 		"access": {
 			Type:         schema.TypeString,
-			Description:  "Valid values: read, write",
+			Description:  fmt.Sprintf("Valid values: `%s`, `%s`", HCLAccessorRead, HCLAccessorWrite),
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"read", "write"}, false),
+			ValidateFunc: validation.StringInSlice([]string{HCLAccessorRead, HCLAccessorWrite}, false),
 		},
 	}
 }

--- a/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor.go
@@ -39,7 +39,7 @@ func (_ *Users) Schema() map[string]*schema.Schema {
 	}
 }
 
-func (u *Users) MarshalHCL(properties hcl.Properties) error {
+func (u Users) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeSlice("user", u)
 }
 

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -42,6 +42,7 @@ type platform_request request
 var platformClientCache = map[string]*rest.Client{}
 
 var platformClientCacheMutex sync.Mutex
+var NoPlatformCredentialsErr = errors.New("neither oauth credentials nor platform token present")
 
 func configureCommonRestClient(restClient *rest.Client) (*rest.Client, error) {
 	restClient.SetHeader("User-Agent", "Dynatrace Terraform Provider")
@@ -100,7 +101,7 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 	} else if credentials.ContainsOAuth() {
 		client, err = CreatePlatformOAuthClient(ctx, platformURL, credentials)
 	} else {
-		return nil, errors.New("neither oauth credentials nor platform token present")
+		return nil, NoPlatformCredentialsErr
 	}
 	if err != nil {
 		return nil, err

--- a/resources/generic.go
+++ b/resources/generic.go
@@ -393,7 +393,12 @@ func (me *Generic) ReadForSettings(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	for k, v := range marshalled {
-		d.Set(k, v)
+		err := d.Set(k, v)
+		// currently behind an env variable, because it could potentially break existing resources
+		// TODO: Remove this once we have proper integration tests
+		if err != nil && os.Getenv("DYNATRACE_DEBUG") == "true" {
+			return diag.FromErr(err)
+		}
 	}
 	return diag.Diagnostics{}
 }


### PR DESCRIPTION
This adds the service for the permission resource. This includes

- The diff check, if it needs to update, delete, or create permissions
- The actual CRUD calls


## Additional adjustments
- Missing unmarshals weren't visible as `d.Set(key, value)` errors weren't checked. In order to now break any existing resource, I added the error check iff the `DYNATRACE_DEBUG` flag is set.
- Moved accessors (read, write, none) into constants, so they can easily be re-used

**Issue:** CA-15664


As Sonar only complains about the test file, I would say we're safe to ignore it, as it makes sense not to overcomplicate the testing, and some duplication is fine.