### PR TITLE
feat: add admin access retry for permissions

### DIFF
--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile.go
@@ -7,9 +7,10 @@ import (
 	"sync"
 
 	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 )
 
-func CompareAndUpdate(ctx context.Context, cl permissions.PermissionUpdateClient, current *permissions.SettingPermissions, desired *permissions.SettingPermissions) error {
+func CompareAndUpdate(ctx context.Context, cl permissions.PermissionUpdateClient, current *permissions.SettingPermissions, desired *permissions.SettingPermissions, adminAccess bool) error {
 	groupUpserts, groupErr := getGroupUpserts(ctx, cl, current.SettingsObjectID, current.Groups, desired.Groups)
 	userUpserts, userErr := getUserUpserts(ctx, cl, current.SettingsObjectID, current.Users, desired.Users)
 	allUserUpsert, allUserErr := getAllUserUpsert(ctx, cl, current.SettingsObjectID, current.AllUsers, desired.AllUsers)
@@ -24,10 +25,10 @@ func CompareAndUpdate(ctx context.Context, cl permissions.PermissionUpdateClient
 	if allUserUpsert != nil {
 		upserts = append(upserts, allUserUpsert)
 	}
-	return executeUpserts(upserts)
+	return executeUpserts(upserts, adminAccess)
 }
 
-func executeUpserts(upserts []func(adminAccess bool) error) error {
+func executeUpserts(upserts []rest.AdminAccessRequestFn, adminAccess bool) error {
 	errChan := make(chan error, len(upserts))
 
 	var wg sync.WaitGroup
@@ -35,7 +36,8 @@ func executeUpserts(upserts []func(adminAccess bool) error) error {
 	for _, upsert := range upserts {
 		go func() {
 			defer wg.Done()
-			errChan <- upsert(false)
+			_, err := upsert(adminAccess)
+			errChan <- err
 		}()
 	}
 	wg.Wait()

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/reconcile"
 	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 )
@@ -59,7 +60,7 @@ func TestCompareAndUpdate(t *testing.T) {
 					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
 				},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, createCalls, "Expected one user to be created")
 		})
@@ -84,7 +85,7 @@ func TestCompareAndUpdate(t *testing.T) {
 					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorRead},
 				},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, updateCalls, "Expected one user to be updated")
 		})
@@ -105,7 +106,7 @@ func TestCompareAndUpdate(t *testing.T) {
 			desired := &permissions.SettingPermissions{
 				Users: permissions.Users{},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, deleteCalls, "Expected one user to be deleted")
 		})
@@ -127,7 +128,7 @@ func TestCompareAndUpdate(t *testing.T) {
 					&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
 				},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 		})
 	})
@@ -149,7 +150,7 @@ func TestCompareAndUpdate(t *testing.T) {
 					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
 				},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, createCalls, "Expected one group to be created")
 		})
@@ -172,7 +173,7 @@ func TestCompareAndUpdate(t *testing.T) {
 					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorRead},
 				},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, updateCalls, "Expected one group to be updated")
 		})
@@ -193,7 +194,7 @@ func TestCompareAndUpdate(t *testing.T) {
 			desired := &permissions.SettingPermissions{
 				Groups: permissions.Groups{},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, deleteCalls, "Expected one group to be deleted")
 		})
@@ -215,7 +216,7 @@ func TestCompareAndUpdate(t *testing.T) {
 					&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
 				},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 		})
 	})
@@ -235,7 +236,7 @@ func TestCompareAndUpdate(t *testing.T) {
 			desired := &permissions.SettingPermissions{
 				AllUsers: permissions.HCLAccessorWrite,
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, createCalls, "Expected allUser to be created")
 		})
@@ -254,7 +255,7 @@ func TestCompareAndUpdate(t *testing.T) {
 			desired := &permissions.SettingPermissions{
 				AllUsers: permissions.HCLAccessorWrite,
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, updateCalls, "Expected allUser to be updated")
 		})
@@ -273,7 +274,7 @@ func TestCompareAndUpdate(t *testing.T) {
 			desired := &permissions.SettingPermissions{
 				AllUsers: permissions.HCLAccessorNone,
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, deleteCalls, "Expected allUser to be deleted")
 		})
@@ -291,7 +292,7 @@ func TestCompareAndUpdate(t *testing.T) {
 			desired := &permissions.SettingPermissions{
 				AllUsers: permissions.HCLAccessorWrite,
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.NoError(t, err)
 		})
 	})
@@ -317,7 +318,7 @@ func TestCompareAndUpdate(t *testing.T) {
 					&permissions.UserAccessor{UID: "user2", Access: permissions.HCLAccessorWrite},
 				},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.Error(t, err)
 			assert.Equal(t, 2, createCalls, "Should attempt both users")
 		})
@@ -342,7 +343,7 @@ func TestCompareAndUpdate(t *testing.T) {
 					&permissions.GroupAccessor{ID: "group2", Access: permissions.HCLAccessorWrite},
 				},
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.Error(t, err)
 			assert.Equal(t, 2, createCalls, "Should attempt both groups")
 		})
@@ -361,7 +362,7 @@ func TestCompareAndUpdate(t *testing.T) {
 			desired := &permissions.SettingPermissions{
 				AllUsers: permissions.HCLAccessorWrite,
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.Error(t, err)
 			assert.Equal(t, 1, calls, "Should attempt allUser")
 		})
@@ -402,8 +403,118 @@ func TestCompareAndUpdate(t *testing.T) {
 				},
 				AllUsers: permissions.HCLAccessorWrite,
 			}
-			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired)
+			err := reconcile.CompareAndUpdate(t.Context(), client, current, desired, false)
 			assert.Error(t, err)
+		})
+	})
+
+	t.Run("Handles admin access correctly for accessors", func(t *testing.T) {
+		client := clientStub{
+			create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+				require.True(t, adminAccess, "Expected admin access to be true")
+				return api.Response{StatusCode: 201, Data: []byte("{}")}, nil
+			},
+			updateAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool, body []byte) (api.Response, error) {
+				require.True(t, adminAccess, "Expected admin access to be true")
+				return api.Response{StatusCode: 200, Data: []byte("{}")}, nil
+			},
+			deleteAccessor: func(ctx context.Context, objectID string, accessorType string, accessorID string, adminAccess bool) (api.Response, error) {
+				require.True(t, adminAccess, "Expected admin access to be true")
+				return api.Response{StatusCode: 204, Data: []byte("{}")}, nil
+			},
+		}
+
+		current := &permissions.SettingPermissions{
+			Users: permissions.Users{
+				&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorRead},
+				&permissions.UserAccessor{UID: "user2", Access: permissions.HCLAccessorRead},
+			},
+			Groups: permissions.Groups{
+				&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorRead},
+				&permissions.GroupAccessor{ID: "group2", Access: permissions.HCLAccessorRead},
+			},
+		}
+		desired := &permissions.SettingPermissions{
+			Users: permissions.Users{
+				// update
+				&permissions.UserAccessor{UID: "user1", Access: permissions.HCLAccessorWrite},
+				// delete user2
+				// create
+				&permissions.UserAccessor{UID: "user3", Access: permissions.HCLAccessorWrite},
+			},
+			Groups: permissions.Groups{
+				// update
+				&permissions.GroupAccessor{ID: "group1", Access: permissions.HCLAccessorWrite},
+				// delete group2
+				// create
+				&permissions.GroupAccessor{ID: "group3", Access: permissions.HCLAccessorWrite},
+			},
+		}
+		err := reconcile.CompareAndUpdate(context.Background(), client, current, desired, true)
+		assert.NoError(t, err, "Expected no error during admin access operations")
+	})
+
+	t.Run("Handle adminAccess correctly for allUsers", func(t *testing.T) {
+		t.Run("Updates allUsers with admin access", func(t *testing.T) {
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					require.True(t, adminAccess, "Expected admin access to be true")
+					return api.Response{StatusCode: 201, Data: []byte("{}")}, nil
+				},
+				updateAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					require.True(t, adminAccess, "Expected admin access to be true")
+					return api.Response{StatusCode: 200, Data: []byte("{}")}, nil
+				},
+				deleteAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool) (api.Response, error) {
+					require.True(t, adminAccess, "Expected admin access to be true")
+					return api.Response{StatusCode: 204, Data: []byte("{}")}, nil
+				},
+			}
+
+			current := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorNone,
+			}
+			desired := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			err := reconcile.CompareAndUpdate(context.Background(), client, current, desired, true)
+			assert.NoError(t, err, "Expected no error during admin access operations")
+		})
+
+		t.Run("Deletes allUsers with admin access", func(t *testing.T) {
+			client := clientStub{
+				deleteAllUsersAccessor: func(ctx context.Context, objectID string, adminAccess bool) (api.Response, error) {
+					require.True(t, adminAccess, "Expected admin access to be true")
+					return api.Response{StatusCode: 204, Data: []byte("{}")}, nil
+				},
+			}
+
+			current := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			desired := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorNone,
+			}
+			err := reconcile.CompareAndUpdate(context.Background(), client, current, desired, true)
+			assert.NoError(t, err, "Expected no error during admin access operations")
+		})
+
+		t.Run("Creates allUsers with admin access", func(t *testing.T) {
+			client := clientStub{
+				create: func(ctx context.Context, objectID string, adminAccess bool, body []byte) (api.Response, error) {
+					require.True(t, adminAccess, "Expected admin access to be true")
+					return api.Response{StatusCode: 201, Data: []byte("{}")}, nil
+				},
+			}
+
+			current := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorNone,
+			}
+			desired := &permissions.SettingPermissions{
+				AllUsers: permissions.HCLAccessorWrite,
+			}
+			err := reconcile.CompareAndUpdate(context.Background(), client, current, desired, true)
+			assert.NoError(t, err, "Expected no error during admin access operations")
 		})
 	})
 }

--- a/dynatrace/rest/admin_retry.go
+++ b/dynatrace/rest/admin_retry.go
@@ -1,0 +1,30 @@
+package rest
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+)
+
+type AdminAccessRequestFn = func(adminAccess bool) (api.Response, error)
+
+// DoWithAdminAccessRetry calls a given function with adminAccess and retries it without adminAccess in case there is a 403.
+//
+// returns:
+//   - response: The response of the API call with adminAccess enabled if the permission is given
+//     or the response of the API call without adminAccess if the permission is not given.
+//   - err: Any occurring error, not related to the permission error of the adminAccess enabled call.
+//   - adminAccess: The used adminAccess for the returned response.
+func DoWithAdminAccessRetry(requestFn AdminAccessRequestFn) (response api.Response, err error, adminAccess bool) {
+	var apiErr api.APIError
+	resp, err := requestFn(true)
+	if err != nil {
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusForbidden {
+			resp, err = requestFn(false)
+			return resp, err, false
+		}
+		return api.Response{}, err, false
+	}
+	return resp, nil, true
+}

--- a/dynatrace/rest/admin_retry_test.go
+++ b/dynatrace/rest/admin_retry_test.go
@@ -1,0 +1,88 @@
+package rest_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+)
+
+func TestDoWithAdminAccessRetry(t *testing.T) {
+	type apiReturnValues struct {
+		response api.Response
+		error    error
+	}
+
+	t.Run("returns on first try with adminAccess", func(t *testing.T) {
+		response := api.Response{StatusCode: http.StatusOK}
+		call := func(_ bool) (api.Response, error) {
+			return response, nil
+		}
+		resp, err, adminAccess := rest.DoWithAdminAccessRetry(call)
+		assert.NoError(t, err)
+		assert.True(t, adminAccess)
+		assert.Equal(t, response, resp)
+	})
+
+	t.Run("returns on second try without adminAccess", func(t *testing.T) {
+		responsesRetrySuccess := []apiReturnValues{
+			{
+				api.Response{},
+				api.APIError{StatusCode: http.StatusForbidden},
+			},
+			{
+				api.Response{StatusCode: 200},
+				nil,
+			},
+		}
+		calls := 0
+		call := func(_ bool) (api.Response, error) {
+			resp := responsesRetrySuccess[calls]
+			calls++
+			return resp.response, resp.error
+		}
+		resp, err, adminAccess := rest.DoWithAdminAccessRetry(call)
+		assert.Equal(t, calls, 2)
+		assert.NoError(t, err)
+		assert.False(t, adminAccess)
+		assert.Equal(t, responsesRetrySuccess[1].response, resp)
+	})
+
+	t.Run("errors if first response is not 403", func(t *testing.T) {
+		respErr := api.APIError{StatusCode: http.StatusNotFound}
+		call := func(_ bool) (api.Response, error) {
+			return api.Response{}, respErr
+		}
+		_, err, adminAccess := rest.DoWithAdminAccessRetry(call)
+		assert.Equal(t, err, respErr)
+		assert.False(t, adminAccess)
+	})
+
+	t.Run("errors if second try without adminAccess errors", func(t *testing.T) {
+		calls := 0
+		responses := []apiReturnValues{
+			{
+				api.Response{},
+				api.APIError{StatusCode: http.StatusForbidden},
+			},
+			{
+				api.Response{},
+				// body here just to differentiate between the other error and still have a 403 check,
+				// just to be sure that sequential 403 will not lead to a loop
+				api.APIError{StatusCode: http.StatusForbidden, Body: []byte("{}")},
+			},
+		}
+		call := func(_ bool) (api.Response, error) {
+			resp := responses[calls]
+			calls++
+			return resp.response, resp.error
+		}
+		_, err, adminAccess := rest.DoWithAdminAccessRetry(call)
+		assert.Equal(t, calls, 2)
+		assert.Equal(t, err, responses[1].error)
+		assert.False(t, adminAccess)
+	})
+}


### PR DESCRIPTION
This adds the retry mechanism for adminAccess calls. If the call CRUD call with adminAccess=true fails, it will retry it again with adminAccess=false

**Issue:**: CA-15739