### PR TITLE
feat: add tests for settings permissions

### DIFF
--- a/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/group_accessor_test.go
@@ -1,0 +1,166 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupAccessor_MarshalHCL(t *testing.T) {
+	cases := []struct {
+		name     string
+		accessor *GroupAccessor
+		expected hcl.Properties
+	}{
+		{
+			name: "read-access",
+			accessor: &GroupAccessor{
+				"my-id",
+				HCLAccessorRead,
+			},
+			expected: map[string]any{"id": "my-id", "access": HCLAccessorRead},
+		},
+		{
+			name: "write-access",
+			accessor: &GroupAccessor{
+				"my-id",
+				HCLAccessorWrite,
+			},
+			expected: map[string]any{"id": "my-id", "access": HCLAccessorWrite},
+		},
+		{
+			name:     "empty",
+			accessor: &GroupAccessor{},
+			expected: map[string]any{"id": "", "access": ""},
+		},
+		{
+			name: "empty id",
+			accessor: &GroupAccessor{
+				"",
+				HCLAccessorRead,
+			},
+			expected: map[string]any{"id": "", "access": HCLAccessorRead},
+		},
+		{
+			name: "empty access",
+			accessor: &GroupAccessor{
+				"my-id",
+				"",
+			},
+			expected: map[string]any{"id": "my-id", "access": ""},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var actual = hcl.Properties{}
+			err := c.accessor.MarshalHCL(actual)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}
+
+func TestGroupAccessor_UnmarshalHCL(t *testing.T) {
+	s := new(GroupAccessor).Schema()
+
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *GroupAccessor
+	}{
+		{
+			name:  "read-access",
+			input: map[string]interface{}{"id": "my-id", "access": HCLAccessorRead},
+			expected: &GroupAccessor{
+				ID:     "my-id",
+				Access: HCLAccessorRead,
+			},
+		},
+		{
+			name:  "write-access",
+			input: map[string]interface{}{"id": "my-id", "access": HCLAccessorWrite},
+			expected: &GroupAccessor{
+				ID:     "my-id",
+				Access: HCLAccessorWrite,
+			},
+		},
+		{
+			name:     "empty",
+			input:    map[string]interface{}{"id": "", "access": ""},
+			expected: &GroupAccessor{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			assert.NotNil(t, d)
+
+			var actual GroupAccessor
+			decoder := hcl.DecoderFrom(d)
+			err := actual.UnmarshalHCL(decoder)
+			assert.Equal(t, c.expected, &actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestGroups_MarshalHCL(t *testing.T) {
+	groups := Groups{
+		{ID: "group-1", Access: HCLAccessorRead},
+		{ID: "group-2", Access: HCLAccessorWrite},
+	}
+
+	properties := hcl.Properties{}
+	err := groups.MarshalHCL(properties)
+	assert.NoError(t, err)
+
+	groupList, ok := properties["group"].([]interface{})
+	assert.True(t, ok)
+	assert.Len(t, groupList, 2)
+
+	group1 := groupList[0].(hcl.Properties)
+	assert.Equal(t, "group-1", group1["id"])
+	assert.Equal(t, HCLAccessorRead, group1["access"])
+
+	group2 := groupList[1].(hcl.Properties)
+	assert.Equal(t, "group-2", group2["id"])
+	assert.Equal(t, HCLAccessorWrite, group2["access"])
+}
+
+func TestGroups_UnmarshalHCL(t *testing.T) {
+	s := new(Groups).Schema()
+
+	input := map[string]interface{}{
+		"group": []interface{}{
+			map[string]interface{}{
+				"id":     "group-1",
+				"access": HCLAccessorRead,
+			},
+			map[string]interface{}{
+				"id":     "group-2",
+				"access": HCLAccessorWrite,
+			},
+		},
+	}
+
+	d := schema.TestResourceDataRaw(t, s, input)
+	assert.NotNil(t, d)
+
+	var groups Groups
+	decoder := hcl.DecoderFrom(d)
+	err := groups.UnmarshalHCL(decoder)
+	assert.NoError(t, err)
+	assert.Len(t, groups, 2)
+
+	// Define expected groups
+	expectedGroup1 := &GroupAccessor{ID: "group-1", Access: HCLAccessorRead}
+	expectedGroup2 := &GroupAccessor{ID: "group-2", Access: HCLAccessorWrite}
+
+	// Check that both expected groups are in the slice, regardless of order
+	assert.Contains(t, groups, expectedGroup1)
+	assert.Contains(t, groups, expectedGroup2)
+}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions_test.go
@@ -1,0 +1,173 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSettingPermissions_MarshalHCL(t *testing.T) {
+	cases := []struct {
+		name        string
+		permissions *SettingPermissions
+		expected    hcl.Properties
+	}{
+		{
+			name: "full-permissions",
+			permissions: &SettingPermissions{
+				SettingsObjectID: "obj-123",
+				AllUsers:         HCLAccessorNone,
+				Users: Users{
+					{UID: "user1", Access: HCLAccessorWrite},
+				},
+				Groups: Groups{
+					{ID: "group1", Access: HCLAccessorRead},
+					{ID: "group2", Access: HCLAccessorWrite},
+				},
+			},
+			expected: hcl.Properties{
+				"settings_object_id": "obj-123",
+				"all_users":          HCLAccessorNone,
+				"users": []interface{}{
+					hcl.Properties{
+						"user": []interface{}{
+							hcl.Properties{
+								"access": HCLAccessorWrite,
+								"uid":    "user1",
+							},
+						},
+					},
+				},
+				"groups": []interface{}{
+					hcl.Properties{
+						"group": []interface{}{
+							hcl.Properties{
+								"access": HCLAccessorRead,
+								"id":     "group1",
+							},
+							hcl.Properties{
+								"access": HCLAccessorWrite,
+								"id":     "group2",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "minimal-permissions",
+			permissions: &SettingPermissions{
+				SettingsObjectID: "obj-123",
+				AllUsers:         HCLAccessorNone,
+			},
+			expected: hcl.Properties{
+				"settings_object_id": "obj-123",
+				"all_users":          HCLAccessorNone,
+				"users":              nil,
+				"groups":             nil,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var actual = hcl.Properties{}
+			err := c.permissions.MarshalHCL(actual)
+
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}
+
+func TestSettingPermissions_UnmarshalHCL(t *testing.T) {
+	s := new(SettingPermissions).Schema()
+
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected SettingPermissions
+	}{
+		{
+			name: "full-permissions",
+			input: map[string]interface{}{
+				"settings_object_id": "obj-123",
+				"all_users":          HCLAccessorNone,
+				"users": []interface{}{
+					map[string]interface{}{
+						"user": []interface{}{
+							map[string]interface{}{
+								"uid":    "user1",
+								"access": HCLAccessorWrite,
+							},
+							map[string]interface{}{
+								"uid":    "user2",
+								"access": HCLAccessorWrite,
+							},
+						},
+					},
+				},
+				"groups": []interface{}{
+					map[string]interface{}{
+						"group": []interface{}{
+							map[string]interface{}{
+								"id":     "group1",
+								"access": HCLAccessorRead,
+							},
+							map[string]interface{}{
+								"id":     "group2",
+								"access": HCLAccessorWrite,
+							},
+						},
+					},
+				},
+			},
+			expected: SettingPermissions{
+				SettingsObjectID: "obj-123",
+				AllUsers:         HCLAccessorNone,
+				Users: Users{
+					{UID: "user1", Access: HCLAccessorWrite},
+					{UID: "user2", Access: HCLAccessorWrite},
+				},
+				Groups: Groups{
+					{ID: "group1", Access: HCLAccessorRead},
+					{ID: "group2", Access: HCLAccessorWrite},
+				},
+			},
+		},
+		{
+			name: "minimal-permissions",
+			input: map[string]interface{}{
+				"settings_object_id": "obj-123",
+				"all_users":          HCLAccessorNone,
+			},
+			expected: SettingPermissions{
+				SettingsObjectID: "obj-123",
+				AllUsers:         HCLAccessorNone,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			assert.NotNil(t, d)
+
+			var actual SettingPermissions
+			decoder := hcl.DecoderFrom(d)
+			err := actual.UnmarshalHCL(decoder)
+
+			assert.NoError(t, err)
+			assertSettingPermissionsAreEqual(t, c.expected, actual)
+		})
+	}
+}
+
+func assertSettingPermissionsAreEqual(t *testing.T, this SettingPermissions, that SettingPermissions) {
+	assert.Equal(t, this.SettingsObjectID, that.SettingsObjectID)
+	assert.Equal(t, this.AllUsers, that.AllUsers)
+	assert.ElementsMatch(t, this.Users, that.Users)
+	assert.ElementsMatch(t, this.Groups, that.Groups)
+}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/user_accessor_test.go
@@ -1,0 +1,166 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserAccessor_MarshalHCL(t *testing.T) {
+	cases := []struct {
+		name     string
+		accessor *UserAccessor
+		expected hcl.Properties
+	}{
+		{
+			name: "HCLAccessorRead-access",
+			accessor: &UserAccessor{
+				"my-id",
+				HCLAccessorRead,
+			},
+			expected: map[string]any{"uid": "my-id", "access": HCLAccessorRead},
+		},
+		{
+			name: "write-access",
+			accessor: &UserAccessor{
+				"my-id",
+				HCLAccessorWrite,
+			},
+			expected: map[string]any{"uid": "my-id", "access": HCLAccessorWrite},
+		},
+		{
+			name:     "empty",
+			accessor: &UserAccessor{},
+			expected: map[string]any{"uid": "", "access": ""},
+		},
+		{
+			name: "empty UID",
+			accessor: &UserAccessor{
+				"",
+				HCLAccessorRead,
+			},
+			expected: map[string]any{"uid": "", "access": HCLAccessorRead},
+		},
+		{
+			name: "empty access",
+			accessor: &UserAccessor{
+				"my-id",
+				"",
+			},
+			expected: map[string]any{"uid": "my-id", "access": ""},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+
+			var actual = hcl.Properties{}
+			_ = c.accessor.MarshalHCL(actual)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}
+
+func TestUserAccessor_UnmarshalHCL(t *testing.T) {
+	s := new(UserAccessor).Schema()
+
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *UserAccessor
+	}{
+		{
+			name:  "HCLAccessorRead-access",
+			input: map[string]interface{}{"uid": "my-id", "access": HCLAccessorRead},
+			expected: &UserAccessor{
+				UID:    "my-id",
+				Access: HCLAccessorRead,
+			},
+		},
+		{
+			name:  "write-access",
+			input: map[string]interface{}{"uid": "my-id", "access": HCLAccessorWrite},
+			expected: &UserAccessor{
+				UID:    "my-id",
+				Access: HCLAccessorWrite,
+			},
+		},
+		{
+			name:     "empty",
+			input:    map[string]interface{}{"uid": "", "access": ""},
+			expected: &UserAccessor{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			assert.NotNil(t, d)
+
+			var actual UserAccessor
+			decoder := hcl.DecoderFrom(d)
+			err := actual.UnmarshalHCL(decoder)
+			assert.Equal(t, c.expected, &actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestUsers_MarshalHCL(t *testing.T) {
+	users := Users{
+		{UID: "user1", Access: HCLAccessorRead},
+		{UID: "user2", Access: HCLAccessorWrite},
+	}
+
+	properties := hcl.Properties{}
+	err := users.MarshalHCL(properties)
+	assert.NoError(t, err)
+
+	userList, ok := properties["user"].([]interface{})
+	assert.True(t, ok)
+	assert.Len(t, userList, 2)
+
+	user1 := userList[0].(hcl.Properties)
+	assert.Equal(t, "user1", user1["uid"])
+	assert.Equal(t, HCLAccessorRead, user1["access"])
+
+	user2 := userList[1].(hcl.Properties)
+	assert.Equal(t, "user2", user2["uid"])
+	assert.Equal(t, HCLAccessorWrite, user2["access"])
+}
+
+func TestUsers_UnmarshalHCL(t *testing.T) {
+	s := new(Users).Schema()
+
+	input := map[string]interface{}{
+		"user": []interface{}{
+			map[string]interface{}{
+				"uid":    "user1",
+				"access": HCLAccessorRead,
+			},
+			map[string]interface{}{
+				"uid":    "user2",
+				"access": HCLAccessorWrite,
+			},
+		},
+	}
+
+	d := schema.TestResourceDataRaw(t, s, input)
+	assert.NotNil(t, d)
+
+	var users Users
+	decoder := hcl.DecoderFrom(d)
+	err := users.UnmarshalHCL(decoder)
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+
+	// Define expected users
+	expectedUser1 := &UserAccessor{UID: "user1", Access: HCLAccessorRead}
+	expectedUser2 := &UserAccessor{UID: "user2", Access: HCLAccessorWrite}
+
+	// Check that both expected users are in the slice, regardless of order
+	assert.Contains(t, users, expectedUser1)
+	assert.Contains(t, users, expectedUser2)
+}


### PR DESCRIPTION
This PR introduces some tests for the marshalling and unmarshalling between the settings permissions object and HCL.

