### PR TITLE
feat: wire up settings permissions

### DIFF
--- a/dynatrace/api/builtin/generic/service_test.go
+++ b/dynatrace/api/builtin/generic/service_test.go
@@ -26,3 +26,8 @@ import (
 func TestAccGenericSettings(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccGenericSettingsOAuth(t *testing.T) {
+	t.Setenv("DYNATRACE_API_TOKEN", "")
+	api.TestAcc(t)
+}

--- a/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
+++ b/dynatrace/api/v2/settings/objects/permissions/settings/setting_permissions.go
@@ -86,3 +86,7 @@ func (sp *SettingPermissions) UnmarshalHCL(decoder hcl.Decoder) error {
 		"groups":             &sp.Groups,
 	})
 }
+
+func (sp *SettingPermissions) Name() string {
+	return "permissions"
+}

--- a/dynatrace/export/enums.go
+++ b/dynatrace/export/enums.go
@@ -514,6 +514,7 @@ var ResourceTypes = struct {
 	WebAppIPAddressExclusion          ResourceType
 	RPCBasedSampling                  ResourceType
 	WebAppManualInsertion             ResourceType
+	SettingsPermissions               ResourceType
 }{
 	"dynatrace_autotag",
 	"dynatrace_autotag_v2",
@@ -875,6 +876,7 @@ var ResourceTypes = struct {
 	"dynatrace_web_app_ip_address_exclusion",
 	"dynatrace_rpc_based_sampling",
 	"dynatrace_web_app_manual_insertion",
+	"dynatrace_settings_permissions",
 }
 
 func (me ResourceType) GetFolderName(override string) string {

--- a/dynatrace/export/resource_descriptor.go
+++ b/dynatrace/export/resource_descriptor.go
@@ -23,7 +23,9 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/grail/segments"
-	openpipeline "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/openpipeline"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/permissions"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/openpipeline"
+	settingsPermissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 
 	msentraidconnection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/app/dynatrace/azure/connector/microsoftentraidentitydeveloperconnection"
@@ -158,7 +160,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/logagentconfiguration"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/logagentfeatureflags"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/logbucketsrules"
-	logcustomattributes "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/logcustomattributes"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/logcustomattributes"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/logdebugsettings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/logdpprules"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/logevents"
@@ -218,9 +220,9 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/process/builtinprocessmonitoringrule"
 	processmonitoring "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/process/monitoring"
 	customprocessmonitoring "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/process/monitoring/custom"
-	processavailability "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/processavailability"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/processavailability"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/processgroup/advanceddetectionrule"
-	workloaddetection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/processgroup/cloudapplication/workloaddetection"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/processgroup/cloudapplication/workloaddetection"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/processgroup/detectionflags"
 	processgroupmonitoring "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/processgroup/monitoring/state"
 	processgroupsimpledetection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/processgroup/simpledetectionrule"
@@ -302,12 +304,11 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/service/daviscopilot/dataminingblocklist"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/reports"
 
-	directshares "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/directshares"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/directshares"
 	documents "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/document"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/bindings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/boundaries"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/groups"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/permissions"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/policies"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/users"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/v2bindings"
@@ -1524,6 +1525,27 @@ var AllResources = map[ResourceType]ResourceDescriptor{
 		manualinsertion.Service,
 		Dependencies.ID(ResourceTypes.WebApplication),
 	),
+	ResourceTypes.SettingsPermissions: NewResourceDescriptor(
+		settingsPermissions.Service,
+
+		// OwnerBasedAccessControl enabled resources
+		Dependencies.ID(ResourceTypes.PagerDutyConnection),
+		Dependencies.ID(ResourceTypes.Microsoft365EmailConnection),
+		Dependencies.ID(ResourceTypes.MSEntraIDConnection),
+		Dependencies.ID(ResourceTypes.JiraForWorkflows),
+		Dependencies.ID(ResourceTypes.JenkinsConnection),
+		Dependencies.ID(ResourceTypes.ServiceNowConnection),
+		Dependencies.ID(ResourceTypes.AutomationControllerConnections),
+		Dependencies.ID(ResourceTypes.EventDrivenAnsibleConnections),
+		Dependencies.ID(ResourceTypes.K8sAutomationConnections),
+		Dependencies.ID(ResourceTypes.SlackForWorkflows),
+		Dependencies.ID(ResourceTypes.GitHubConnection),
+		Dependencies.ID(ResourceTypes.GitLabConnection),
+		Dependencies.ID(ResourceTypes.MSTeamsConnection),
+		Dependencies.ID(ResourceTypes.AWSAutomationConnections),
+
+		Dependencies.ID(ResourceTypes.GenericSetting),
+	),
 }
 
 type ResourceExclusion struct {
@@ -1629,6 +1651,7 @@ var excludeListedResourceGroups = []ResourceExclusionGroup{
 			{ResourceTypes.PlatformBucket, ""},
 			{ResourceTypes.Segments, ""},
 			{ResourceTypes.PlatformSLO, ""},
+			{ResourceTypes.SettingsPermissions, ""},
 		},
 	},
 	{

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -217,10 +217,6 @@ func TestAcc(t *testing.T, opts ...TestAccOptions) {
 		return
 	}
 
-	if v := os.Getenv("DYNATRACE_API_TOKEN"); v == "" {
-		t.Skip("DYNATRACE_API_TOKEN must be set for acceptance tests")
-		return
-	}
 	entries, _ := os.ReadDir("testdata")
 	for _, entry := range entries {
 		if entry.IsDir() {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -633,6 +633,7 @@ func Provider() *schema.Provider {
 			"dynatrace_web_app_ip_address_exclusion":       resources.NewGeneric(export.ResourceTypes.WebAppIPAddressExclusion).Resource(),
 			"dynatrace_rpc_based_sampling":                 resources.NewGeneric(export.ResourceTypes.RPCBasedSampling).Resource(),
 			"dynatrace_web_app_manual_insertion":           resources.NewGeneric(export.ResourceTypes.WebAppManualInsertion).Resource(),
+			"dynatrace_settings_permissions":               resources.NewGeneric(export.ResourceTypes.SettingsPermissions).Resource(),
 		},
 		ConfigureContextFunc: config.ProviderConfigure,
 	}


### PR DESCRIPTION
This adds the settings permission resource to the provider to be used as a resource and for export.
Limitation: Because other resources don't support `adminAccess=true`, only references to objects that the OAuth client and token are owner of are resolved and downloaded.

Because of the generic settings dependency, I also adjusted the generic settings service to support platform and classic credentials

Regarding the export name. Currently, I've set it to `permissions`, which will result in the following
<img width="358" height="226" alt="image" src="https://github.com/user-attachments/assets/55bad7be-9104-4256-9c9c-aa5157ad74e3" />

 => `permissions_{COUNTER}.settings_permissions.tf` and `resource "dynatrace_settings_permissions" "permissions_1"{...}`

This would be easier to read than the objectID and it's handled via incremental counter, else we can also return `sp.SettingsObjectID` if this one is preferred. 

Example with name `permissions`
```hcl
resource "dynatrace_settings_permissions" "permissions_1" {
  all_users          = "none"
  settings_object_id = "${var.dynatrace_automation_workflow_jira.asdf.id}" // or the plain objectID if the reference is not found
}
```

Example with name `sp.SettingsObjectID`
```hcl
resource "dynatrace_settings_permissions" "my-very-long-object-id-which-can-have-more-than-150-characters-and-basically-tells-nothing" {
  all_users          = "none"
  settings_object_id = "${var.dynatrace_automation_workflow_jira.asdf.id}" // or the plain objectID if the reference is not found
}
```

**Issue:** CA-15665