### PR TITLE
feat(openpipeline): HCL schema for ingest sources, including some processor types

### DIFF
--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source.go
@@ -58,6 +58,7 @@ func (is *IngestSource) Schema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Required:     true,
 			Description:  "Indicates OpenPipeline data source",
+			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice(AllowedKinds, true),
 		},
 		"enabled": {

--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source.go
@@ -1,0 +1,178 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var AllowedKinds = []string{
+	"logs", "events", "events.security", "security.events", "bizevents", "spans",
+	"events.sdlc", "metrics", "usersessions", "davis.problems", "davis.events",
+	"system.events", "azure.logs.forwarding", "user.events",
+}
+
+type IngestSource struct {
+	Kind          string             `json:"-"`
+	DefaultBucket *string            `json:"defaultBucket,omitempty"`
+	DisplayName   string             `json:"displayName"`
+	Enabled       bool               `json:"enabled"`
+	PathSegment   string             `json:"pathSegment"`
+	StaticRouting *PipelineReference `json:"staticRouting,omitempty"`
+	Processing    *Processing        `json:"processing,omitempty"`
+}
+
+const DisplayNameMaxLength = 512
+const PathSegmentMaxLength = 100
+const PathSegmentRegex = "^[a-zA-Z](\\.?[a-zA-Z0-9])*$"
+
+var PathSegmentErrorMessage = fmt.Sprintf("expected pattern: %s", PathSegmentRegex)
+
+const DefaultBucketMaxLength = 500
+
+func (is *IngestSource) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"kind": {
+			Type:         schema.TypeString,
+			Required:     true,
+			Description:  "Indicates OpenPipeline data source",
+			ValidateFunc: validation.StringInSlice(AllowedKinds, true),
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Description: "Indicates if the object is active",
+			Default:     true,
+			Optional:    true,
+		},
+		"default_bucket": {
+			Type:         schema.TypeString,
+			Description:  "The default bucket assigned to records for the ingest source",
+			ValidateFunc: validation.StringLenBetween(1, DefaultBucketMaxLength),
+			Optional:     true,
+		},
+		"display_name": {
+			Type:         schema.TypeString,
+			Description:  "Display name of the ingest source",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(1, DisplayNameMaxLength),
+		},
+		"path_segment": {
+			Type:        schema.TypeString,
+			Description: "The segment of the ingest source, which is applied to the base path",
+			Required:    true,
+			ValidateFunc: validation.All(
+				validation.StringLenBetween(1, PathSegmentMaxLength),
+				validation.StringMatch(regexp.MustCompile(PathSegmentRegex), PathSegmentErrorMessage)),
+		},
+		"static_routing": {
+			Type:        schema.TypeList,
+			Description: "References a pipeline, if present",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(PipelineReference).Schema("static_routing.0.")},
+			Optional:    true,
+		},
+		"processing": {
+			Type:        schema.TypeList,
+			Description: "The pre-processing done in the ingest source",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Processing).Schema()},
+			Optional:    true,
+		},
+	}
+}
+
+func (is *IngestSource) MarshalHCL(properties hcl.Properties) error {
+	if err := properties.EncodeAll(map[string]any{
+		"kind":         is.Kind,
+		"enabled":      is.Enabled,
+		"display_name": is.DisplayName,
+		"path_segment": is.PathSegment,
+	}); err != nil {
+		return err
+	}
+	if is.DefaultBucket != nil {
+		if err := properties.Encode("default_bucket", is.DefaultBucket); err != nil {
+			return err
+		}
+	}
+	if is.StaticRouting != nil {
+		if err := properties.Encode("static_routing", is.StaticRouting); err != nil {
+			return err
+		}
+	}
+	if is.Processing != nil && len(is.Processing.Processors) > 0 {
+		if err := properties.Encode("processing", is.Processing); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (is *IngestSource) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"kind":           &is.Kind,
+		"enabled":        &is.Enabled,
+		"default_bucket": &is.DefaultBucket,
+		"display_name":   &is.DisplayName,
+		"path_segment":   &is.PathSegment,
+		"static_routing": &is.StaticRouting,
+		"processing":     &is.Processing,
+	})
+}
+
+func (is *IngestSource) MarshalJSON() ([]byte, error) {
+	var temp = *is
+	if temp.Processing == nil {
+		// The API expected "processing" to be not null.
+		temp.Processing = &Processing{}
+	}
+	return json.Marshal(temp)
+}
+
+type Processing struct {
+	Processors []*processors.Processor `json:"processors,omitempty"`
+}
+
+func (p *Processing) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"processor": {
+			Type:        schema.TypeList,
+			Description: "One processor",
+			Elem:        &schema.Resource{Schema: new(processors.Processor).Schema()},
+			Required:    true,
+		},
+	}
+}
+
+func (p *Processing) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("processor", p.Processors)
+}
+
+func (p *Processing) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("processor", &p.Processors)
+}

--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source_test.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source_test.go
@@ -1,0 +1,475 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/ingestsource/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var minimalIngestSource = settings.IngestSource{
+	Kind:        "events",
+	DisplayName: "displayName",
+	PathSegment: "my.path.segment",
+	Enabled:     true,
+}
+
+var bucket = "bucket"
+var pipelineId = "pipelineId"
+var sampleData = "sampleData"
+var matcher = "not true"
+var allFieldsSetIngestSource = settings.IngestSource{
+	Kind:          "events",
+	DefaultBucket: &bucket,
+	DisplayName:   "displayName",
+	Enabled:       false,
+	PathSegment:   "some.path.segment",
+	StaticRouting: &settings.PipelineReference{
+		PipelineID:   &pipelineId,
+		PipelineType: "custom",
+	},
+	Processing: &settings.Processing{
+		Processors: []*processors.Processor{
+			{
+				Enabled:     true,
+				Id:          "proc-2",
+				Type:        processors.DqlProcessorType,
+				Description: "my-proc-2",
+				SampleData:  &sampleData,
+				Matcher:     &matcher,
+				Dql:         &processors.DqlAttributes{Script: "fieldsAdd true"},
+			},
+		},
+	},
+}
+
+func TestIngestSource_MarshalHCL(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    settings.IngestSource
+		expected hcl.Properties
+	}{
+		{
+			name:  "minimum-set",
+			input: minimalIngestSource,
+			expected: hcl.Properties{
+				"kind":         "events",
+				"display_name": "displayName",
+				"enabled":      true,
+				"path_segment": "my.path.segment",
+			},
+		},
+		{
+			name:  "all-set",
+			input: allFieldsSetIngestSource,
+			expected: hcl.Properties{
+				"kind":           "events",
+				"default_bucket": "bucket",
+				"display_name":   "displayName",
+				"enabled":        false,
+				"path_segment":   "some.path.segment",
+				"static_routing": []interface{}{
+					hcl.Properties{
+						"pipeline_id":   "pipelineId",
+						"pipeline_type": "custom",
+					},
+				},
+				"processing": []interface{}{
+					hcl.Properties{
+						"processor": []interface{}{
+							hcl.Properties{
+								"enabled":     true,
+								"id":          "proc-2",
+								"type":        processors.DqlProcessorType,
+								"description": "my-proc-2",
+								"sample_data": sampleData,
+								"matcher":     matcher,
+								"dql": []interface{}{
+									hcl.Properties{
+										"script": "fieldsAdd true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual = hcl.Properties{}
+			err := tc.input.MarshalHCL(actual)
+			assert.Equal(t, tc.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestIngestSource_UnmarshalHCL(t *testing.T) {
+	s := new(settings.IngestSource).Schema()
+
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected settings.IngestSource
+	}{
+		{
+			name: "minimal fields set",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"path_segment": "my.path.segment",
+			},
+			expected: minimalIngestSource,
+		},
+		{
+			name: "all fields set",
+			input: map[string]interface{}{
+				"kind":           "events",
+				"default_bucket": "bucket",
+				"display_name":   "displayName",
+				"path_segment":   "some.path.segment",
+				"enabled":        false,
+				"static_routing": []interface{}{
+					map[string]interface{}{
+						"pipeline_id":   "pipelineId",
+						"pipeline_type": "custom",
+					},
+				},
+				"processing": []interface{}{
+					map[string]interface{}{
+						"processor": []interface{}{
+							map[string]interface{}{
+								"id":          "proc-2",
+								"type":        "dql",
+								"matcher":     "not true",
+								"description": "my-proc-2",
+								"sample_data": "sampleData",
+								"enabled":     true,
+								"dql": []interface{}{
+									map[string]interface{}{
+										"script": "fieldsAdd true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: allFieldsSetIngestSource,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			assert.NotNil(t, d)
+
+			var actual settings.IngestSource
+			decoder := hcl.DecoderFrom(d)
+			err := actual.UnmarshalHCL(decoder)
+			assert.Equal(t, c.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestIngestSource_MarshalJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    settings.IngestSource
+		expected []byte
+	}{
+		{
+			name:  "minimal-fields-set",
+			input: minimalIngestSource,
+			expected: []byte( // The API demands that "processing" is present, even if it is null, so that seems correct.
+				`{
+					"displayName": "displayName",
+					"enabled": true,
+					"pathSegment": "my.path.segment",
+					"processing": {}
+				}`),
+		},
+		{
+			name:  "all-fields-set",
+			input: allFieldsSetIngestSource,
+			expected: []byte(
+				`{
+					"defaultBucket": "bucket",	
+					"displayName": "displayName",
+					"pathSegment": "some.path.segment",
+					"enabled": false,
+					"staticRouting": {
+					  "pipelineId": "pipelineId",
+					  "pipelineType": "custom"
+					},
+					"processing": {
+						"processors": [
+							{
+								"id": "proc-2",
+								"type": "dql",
+								"matcher": "not true",
+								"description": "my-proc-2",
+								"sampleData": "sampleData",
+								"enabled": true,
+								"dql": {
+									"script": "fieldsAdd true"
+								}
+							}
+						]
+					}	
+				}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.input.MarshalJSON()
+			require.NoError(t, err)
+
+			var actualJSON map[string]interface{}
+			err = json.Unmarshal(actual, &actualJSON)
+			require.NoError(t, err)
+
+			var expectedJSON map[string]interface{}
+			err = json.Unmarshal(tc.expected, &expectedJSON)
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedJSON, actualJSON)
+		})
+	}
+}
+
+func TestIngestSource_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"path_segment": "my.path.segment",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with all optional fields set",
+			input: map[string]interface{}{
+				"kind":           "events",
+				"default_bucket": "bucket",
+				"display_name":   "displayName",
+				"path_segment":   "some.path.segment",
+				"enabled":        false,
+				"static_routing": []interface{}{
+					map[string]interface{}{
+						"pipeline_id":   "pipelineId",
+						"pipeline_type": "custom",
+					},
+				},
+				"processing": []interface{}{
+					map[string]interface{}{
+						"processor": []interface{}{
+							map[string]interface{}{
+								"id":          "proc-2",
+								"type":        "dql",
+								"matcher":     "not true",
+								"description": "my-proc-2",
+								"sample_data": "sampleData",
+								"enabled":     true,
+								"dql": []interface{}{
+									map[string]interface{}{
+										"script": "fieldsAdd true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with digit",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"path_segment": "my.0.1",
+			},
+			wantErr: false,
+		},
+		{
+			name: "kind missing",
+			input: map[string]interface{}{
+				"display_name": "displayName",
+				"path_segment": "my.path.segment",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "kind invalid",
+			input: map[string]interface{}{
+				"kind":         "invalid",
+				"display_name": "displayName",
+				"path_segment": "my.path.segment",
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("expected kind to be one of %q, got invalid", settings.AllowedKinds),
+		},
+		{
+			name: "display_name missing",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"path_segment": "my.path.segment",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "display_name present but blank",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "",
+				"path_segment": "my.path.segment",
+			},
+			wantErr: true,
+			errMsg:  "expected length of display_name to be in the range (1 - 512), got ",
+		},
+		{
+			name: "display_name too long",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": strings.Repeat("a", settings.DisplayNameMaxLength+1),
+				"path_segment": "my.path.segment",
+			},
+			wantErr: true,
+			errMsg:  "expected length of display_name to be in the range (1 - 512), got " + strings.Repeat("a", settings.DisplayNameMaxLength+1),
+		},
+		{
+			name: "path_segment missing",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "path_segment present but blank",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"path_segment": "",
+			},
+			wantErr: true,
+			errMsg:  "expected length of path_segment to be in the range (1 - 100), got ",
+		},
+		{
+			name: "path_segment present too long",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"path_segment": strings.Repeat("a", settings.PathSegmentMaxLength+1),
+			},
+			wantErr: true,
+			errMsg:  "expected length of path_segment to be in the range (1 - 100), got " + strings.Repeat("a", settings.PathSegmentMaxLength+1),
+		},
+		{
+			name: "path_segment cannot start with number",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"path_segment": "0abc",
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("invalid value for path_segment (%s)", settings.PathSegmentErrorMessage),
+		},
+		{
+			name: "path_segment cannot start with dot",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"path_segment": ".abc",
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("invalid value for path_segment (%s)", settings.PathSegmentErrorMessage),
+		},
+		{
+			name: "path_segment cannot end with dot",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"path_segment": "abc.",
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("invalid value for path_segment (%s)", settings.PathSegmentErrorMessage),
+		},
+		{
+			name: "default_bucket is present but blank",
+			input: map[string]interface{}{
+				"kind":           "events",
+				"display_name":   "displayName",
+				"path_segment":   "my.path.segment",
+				"default_bucket": "",
+			},
+			wantErr: true,
+			errMsg:  "expected length of default_bucket to be in the range (1 - 500), got ",
+		},
+		{
+			name: "default_bucket too long",
+			input: map[string]interface{}{
+				"kind":           "events",
+				"display_name":   "displayName",
+				"path_segment":   "my.path.segment",
+				"default_bucket": strings.Repeat("a", settings.DefaultBucketMaxLength+1),
+			},
+			wantErr: true,
+			errMsg:  "expected length of default_bucket to be in the range (1 - 500), got " + strings.Repeat("a", settings.DefaultBucketMaxLength+1),
+		},
+	}
+
+	r := &schema.Resource{Schema: new(settings.IngestSource).Schema()}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}

--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/pipeline_reference.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/pipeline_reference.go
@@ -1,0 +1,86 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type PipelineReference struct {
+	PipelineID        *string `json:"pipelineId,omitempty"`
+	BuiltinPipelineID *string `json:"builtinPipelineId,omitempty"`
+	PipelineType      string  `json:"pipelineType"`
+}
+
+const BuiltinPipelineIDMaxLength = 500
+
+func (pr *PipelineReference) Schema(prefix string) map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"pipeline_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "ID of the pipeline. Only used if the pipeline type is \"custom\"",
+			ExactlyOneOf: []string{prefix + "pipeline_id", prefix + "builtin_pipeline_id"},
+		},
+		"builtin_pipeline_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "ID of the pipeline. Only used if the pipeline type is \"builtin\"",
+			ValidateFunc: validation.StringLenBetween(1, BuiltinPipelineIDMaxLength),
+			ExactlyOneOf: []string{prefix + "pipeline_id", prefix + "builtin_pipeline_id"},
+		},
+		"pipeline_type": {
+			Type:         schema.TypeString,
+			Required:     true,
+			Description:  "Type of the pipeline. Must be \"custom\" or \"builtin\"",
+			ValidateFunc: validation.StringInSlice([]string{"custom", "builtin"}, true),
+		},
+	}
+}
+
+func (pr *PipelineReference) MarshalHCL(properties hcl.Properties) error {
+	err := properties.Encode("pipeline_type", pr.PipelineType)
+	if err != nil {
+		return err
+	}
+
+	if pr.PipelineID != nil {
+		err = properties.Encode("pipeline_id", pr.PipelineID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if pr.BuiltinPipelineID != nil {
+		err = properties.Encode("builtin_pipeline_id", pr.BuiltinPipelineID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (pr *PipelineReference) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"pipeline_id":         &pr.PipelineID,
+		"builtin_pipeline_id": &pr.BuiltinPipelineID,
+		"pipeline_type":       &pr.PipelineType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/pipeline_reference_test.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/pipeline_reference_test.go
@@ -1,0 +1,202 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/ingestsource/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipelineReference_MarshalHCL(t *testing.T) {
+	var pId = "pipelineId"
+	cases := []struct {
+		name     string
+		input    settings.PipelineReference
+		expected hcl.Properties
+	}{
+		{
+			name: "builtin-pipeline-reference",
+			input: settings.PipelineReference{
+				BuiltinPipelineID: &pId,
+				PipelineType:      "builtin",
+			},
+			expected: hcl.Properties{
+				"builtin_pipeline_id": pId,
+				"pipeline_type":       "builtin",
+			},
+		},
+		{
+			name: "custom-pipeline-reference",
+			input: settings.PipelineReference{
+				PipelineID:   &pId,
+				PipelineType: "custom",
+			},
+			expected: hcl.Properties{
+				"pipeline_id":   pId,
+				"pipeline_type": "custom",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual = hcl.Properties{}
+			err := tc.input.MarshalHCL(actual)
+			assert.Equal(t, tc.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestPipelineReference_UnmarshalHCL(t *testing.T) {
+	s := new(settings.PipelineReference).Schema("")
+	var pId = "pipelineId"
+
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected settings.PipelineReference
+	}{
+		{
+			name: "builtin pipeline reference",
+			input: map[string]interface{}{
+				"builtin_pipeline_id": pId,
+				"pipeline_type":       "builtin",
+			},
+			expected: settings.PipelineReference{
+				BuiltinPipelineID: &pId,
+				PipelineType:      "builtin",
+			},
+		},
+		{
+			name: "custom pipeline reference",
+			input: map[string]interface{}{
+				"pipeline_id":   pId,
+				"pipeline_type": "custom",
+			},
+			expected: settings.PipelineReference{
+				PipelineID:   &pId,
+				PipelineType: "custom",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			assert.NotNil(t, d)
+
+			var actual settings.PipelineReference
+			decoder := hcl.DecoderFrom(d)
+			err := actual.UnmarshalHCL(decoder)
+			assert.Equal(t, c.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestPipelineReference_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			input: map[string]interface{}{
+				"builtin_pipeline_id": "pId",
+				"pipeline_type":       "builtin",
+			},
+			wantErr: false,
+		},
+		{
+			name: "type missing",
+			input: map[string]interface{}{
+				"builtin_pipeline_id": "pId",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "no id set",
+			input: map[string]interface{}{
+				"pipeline_type": "builtin",
+			},
+			wantErr: true,
+			errMsg:  "Invalid combination of arguments",
+		},
+		{
+			name: "both ids set",
+			input: map[string]interface{}{
+				"builtin_pipeline_id": "pId",
+				"pipeline_id":         "pId",
+				"pipeline_type":       "builtin",
+			},
+			wantErr: true,
+			errMsg:  "Invalid combination of arguments",
+		},
+		{
+			name: "type invalid",
+			input: map[string]interface{}{
+				"builtin_pipeline_id": "pId",
+				"pipeline_type":       "invalid",
+			},
+			wantErr: true,
+			errMsg:  "expected pipeline_type to be one of [\"custom\" \"builtin\"], got invalid",
+		},
+		{
+			name: "builtin_pipeline_id present but blank",
+			input: map[string]interface{}{
+				"builtin_pipeline_id": "",
+				"pipeline_type":       "builtin",
+			},
+			wantErr: true,
+			errMsg:  "expected length of builtin_pipeline_id to be in the range (1 - 500), got ",
+		},
+		{
+			name: "builtin_pipeline_id too long",
+			input: map[string]interface{}{
+				"builtin_pipeline_id": strings.Repeat("a", settings.BuiltinPipelineIDMaxLength+1),
+				"pipeline_type":       "builtin",
+			},
+			wantErr: true,
+			errMsg:  "expected length of builtin_pipeline_id to be in the range (1 - 500), got " + strings.Repeat("a", settings.BuiltinPipelineIDMaxLength+1),
+		},
+	}
+
+	r := &schema.Resource{Schema: new(settings.PipelineReference).Schema("")}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}

--- a/dynatrace/api/builtin/openpipeline/ingestsource/testdata/json/example.json
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/testdata/json/example.json
@@ -1,0 +1,87 @@
+{
+  "defaultBucket": "bucket",
+  "displayName": "displayName",
+  "pathSegment": "some.path.segment",
+  "enabled": false,
+  "staticRouting": {
+    "pipelineId": "pipelineId",
+    "pipelineType": "custom"
+  },
+  "processing": {
+    "processors": [
+      {
+        "id": "proc-1",
+        "type": "drop",
+        "matcher": "not true",
+        "description": "my-proc-1",
+        "sampleData": "sampleData",
+        "enabled": true
+      },
+      {
+        "id": "proc-2",
+        "type": "dql",
+        "matcher": "not true",
+        "description": "my-proc-2",
+        "sampleData": "sampleData",
+        "enabled": true,
+        "dql": {
+          "script": "fieldsAdd true"
+        }
+      },
+      {
+        "id": "proc-3",
+        "type": "fieldsAdd",
+        "matcher": "not true",
+        "description": "my-proc-3",
+        "sampleData": "sampleData",
+        "enabled": true,
+        "fieldsAdd": {
+          "fields": [
+            {
+              "name": "some-name",
+              "value": "some-value"
+            },
+            {
+              "name": "some-other-name",
+              "value": "some-other-value"
+            }
+          ]
+        }
+      },
+      {
+        "id": "proc-4",
+        "type": "fieldsRename",
+        "matcher": "not true",
+        "description": "my-proc-4",
+        "sampleData": "sampleData",
+        "enabled": true,
+        "fieldsRename": {
+          "fields": [
+            {
+              "fromName": "from-name",
+              "toName": "to-name"
+            },
+            {
+              "fromName": "from-other-name",
+              "toName": "to-other-name"
+            }
+          ]
+        }
+      },
+      {
+        "id": "proc-5",
+        "type": "fieldsRemove",
+        "matcher": "not true",
+        "description": "my-proc-5",
+        "sampleData": "sampleData",
+        "enabled": true,
+        "fieldsRemove": {
+          "fields": [
+            "to-remove-1",
+            "to-remove-2"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/dynatrace/api/builtin/openpipeline/ingestsource/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/testdata/terraform/example.tf
@@ -1,0 +1,80 @@
+resource "dynatrace_openpipeline_v2_ingest_source" "ingestsource" {
+  kind = "events"
+  default_bucket = "bucket"
+  display_name = "ingest-source-with-processor"
+  enabled = true
+  path_segment = "processor.ingestsource.path"
+  static_routing {
+    pipeline_id = "pipelineId"
+    pipeline_type = "custom"
+  }
+  processing {
+    processor {
+      type        = "drop"
+      enabled     = true
+      id          = "proc-1"
+      description = "my-proc-1"
+      sample_data = "my sample data"
+      matcher     = "not true"
+    }
+    processor {
+      type        = "dql"
+      enabled     = true
+      id          = "proc-2"
+      description = "my-proc-2"
+      sample_data = "my sample data"
+      matcher     = "not true"
+      dql {
+        script = "fieldsAdd true"
+      }
+    }
+    processor {
+      type        = "fieldsAdd"
+      enabled     = true
+      id          = "proc-3"
+      description = "my-proc-3"
+      sample_data = "my sample data"
+      matcher     = "not true"
+      fields_add {
+        field {
+          name = "some-name"
+          value = "some-value"
+        }
+        field {
+          name = "some-other-name"
+          value = "some-other-value"
+        }
+      }
+    }
+    processor {
+      type        = "fieldsRename"
+      enabled     = true
+      id          = "proc-4"
+      description = "my-proc-4"
+      sample_data = "my sample data"
+      matcher     = "not true"
+      fields_rename {
+        field {
+          from_name = "from-name"
+          to_name = "to-name"
+        }
+        field {
+          from_name = "from-other-name"
+          to_name = "to-other-name"
+        }
+      }
+    }
+
+    processor {
+      type        = "fieldsRemove"
+      enabled     = true
+      id          = "proc-5"
+      description = "my-proc-5"
+      sample_data = "my sample data"
+      matcher     = "not true"
+      fields_remove {
+        fields = ["to-remove-1", "to-remove-2"]
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/openpipeline/processors/dql.go
+++ b/dynatrace/api/builtin/openpipeline/processors/dql.go
@@ -1,0 +1,49 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type DqlAttributes struct {
+	Script string `json:"script"`
+}
+
+const DqlMaxScriptLength = 8192
+
+func (da *DqlAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"script": {
+			Type:         schema.TypeString,
+			Description:  "The DQL script to apply on the record",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(1, DqlMaxScriptLength),
+		},
+	}
+}
+
+func (da *DqlAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.Encode("script", da.Script)
+}
+
+func (da *DqlAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.Decode("script", &da.Script)
+}

--- a/dynatrace/api/builtin/openpipeline/processors/dql_test.go
+++ b/dynatrace/api/builtin/openpipeline/processors/dql_test.go
@@ -1,0 +1,116 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDqlAttributes_MarshalHCL(t *testing.T) {
+	var input = processors.DqlAttributes{Script: "fieldsAdd true"}
+	var actual = hcl.Properties{}
+
+	err := input.MarshalHCL(actual)
+
+	assert.Equal(t, hcl.Properties{"script": "fieldsAdd true"}, actual)
+	assert.NoError(t, err)
+}
+
+func TestDqlAttributes_UnmarshalHCL(t *testing.T) {
+	d := schema.TestResourceDataRaw(t,
+		new(processors.DqlAttributes).Schema(),
+		map[string]interface{}{"script": "fieldsAdd true"})
+	assert.NotNil(t, d)
+	var actual processors.DqlAttributes
+	decoder := hcl.DecoderFrom(d)
+
+	err := actual.UnmarshalHCL(decoder)
+
+	assert.Equal(t, processors.DqlAttributes{Script: "fieldsAdd true"}, actual)
+	assert.NoError(t, err)
+}
+
+func TestDqlAttributes_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			input: map[string]interface{}{
+				"script": "fieldsAdd true",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid",
+			input: map[string]interface{}{
+				"script":        "fieldsAdd true",
+				"unknown-field": true,
+			},
+			wantErr: true,
+			errMsg:  "Invalid or unknown key",
+		},
+		{
+			name:    "empty",
+			input:   map[string]interface{}{},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "script empty",
+			input: map[string]interface{}{
+				"script": "",
+			},
+			wantErr: true,
+			errMsg:  "expected length of script to be in the range (1 - 8192), got ",
+		},
+		{
+			name: "script exceeds limit",
+			input: map[string]interface{}{
+				"script": strings.Repeat("a", processors.DqlMaxScriptLength+1),
+			},
+			wantErr: true,
+			errMsg:  "expected length of script to be in the range (1 - 8192), got " + strings.Repeat("a", processors.DqlMaxScriptLength+1),
+		},
+	}
+
+	r := &schema.Resource{Schema: new(processors.DqlAttributes).Schema()}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}

--- a/dynatrace/api/builtin/openpipeline/processors/fields_add.go
+++ b/dynatrace/api/builtin/openpipeline/processors/fields_add.go
@@ -1,0 +1,88 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type FieldsAddAttributes struct {
+	Fields []*FieldsAddItem `json:"fields"`
+}
+
+func (faa *FieldsAddAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Resource{Schema: new(FieldsAddItem).Schema()},
+			Description: "Field to add to the record",
+			Required:    true,
+			MinItems:    1,
+			MaxItems:    50,
+		},
+	}
+}
+
+func (faa *FieldsAddAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("field", faa.Fields)
+}
+
+func (faa *FieldsAddAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("field", &faa.Fields)
+}
+
+type FieldsAddItem struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+const FieldsAddMaxNameLength = 256
+const FieldsAddMaxValueLength = 512
+
+func (f *FieldsAddItem) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         schema.TypeString,
+			Description:  "Name of the field",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(0, FieldsAddMaxNameLength),
+		},
+		"value": {
+			Type:         schema.TypeString,
+			Description:  "Value to assign to the field",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(0, FieldsAddMaxValueLength),
+		},
+	}
+}
+
+func (f *FieldsAddItem) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"name":  f.Name,
+		"value": f.Value,
+	})
+}
+
+func (f *FieldsAddItem) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"name":  &f.Name,
+		"value": &f.Value,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/processors/fields_add_test.go
+++ b/dynatrace/api/builtin/openpipeline/processors/fields_add_test.go
@@ -1,0 +1,264 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldsAddAttributes_MarshalHCL(t *testing.T) {
+	var input = processors.FieldsAddAttributes{
+		Fields: []*processors.FieldsAddItem{
+			{
+				Name:  "some-name",
+				Value: "some-value",
+			},
+			{
+				Name:  "some-other-name",
+				Value: "some-other-value",
+			},
+		},
+	}
+	var expected = hcl.Properties{
+		"field": []interface{}{
+			hcl.Properties{
+				"name":  "some-name",
+				"value": "some-value",
+			},
+			hcl.Properties{
+				"name":  "some-other-name",
+				"value": "some-other-value",
+			},
+		},
+	}
+
+	var actual = hcl.Properties{}
+
+	err := input.MarshalHCL(actual)
+
+	assert.Equal(t, expected, actual)
+	assert.NoError(t, err)
+}
+
+func TestFieldsAddAttributes_UnmarshalHCL(t *testing.T) {
+	var input = map[string]interface{}{
+		"field": []interface{}{
+			map[string]interface{}{
+				"name":  "some-name",
+				"value": "some-value",
+			},
+			map[string]interface{}{
+				"name":  "some-other-name",
+				"value": "some-other-value",
+			},
+		},
+	}
+	var expected = processors.FieldsAddAttributes{
+		Fields: []*processors.FieldsAddItem{
+			{
+				Name:  "some-name",
+				Value: "some-value",
+			},
+			{
+				Name:  "some-other-name",
+				Value: "some-other-value",
+			},
+		},
+	}
+
+	d := schema.TestResourceDataRaw(t, new(processors.FieldsAddAttributes).Schema(), input)
+	assert.NotNil(t, d)
+
+	var actual processors.FieldsAddAttributes
+	decoder := hcl.DecoderFrom(d)
+
+	err := actual.UnmarshalHCL(decoder)
+
+	assert.Equal(t, expected, actual)
+	assert.NoError(t, err)
+}
+
+func TestFieldsAddAttributes_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"name":  "some-name",
+						"value": "some-value",
+					},
+					map[string]interface{}{
+						"name":  "some-other-name",
+						"value": "some-other-value",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			input:   map[string]interface{}{},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "empty-fields",
+			input: map[string]interface{}{
+				"field": []interface{}{},
+			},
+			wantErr: true,
+			errMsg:  "Not enough list items",
+		},
+		{
+			name: "empty-field",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "field-missing-name",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"value": "some-value",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "field-missing-value",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"name": "some-name",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "field-with-unrecognized-property",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"name":             "some-name",
+						"value":            "some-value",
+						"strange-property": true,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Invalid or unknown key",
+		},
+		{
+			name: "name and value empty is valid",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"name":  "",
+						"value": "",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "field name too long",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"name":  strings.Repeat("a", processors.FieldsAddMaxNameLength+1),
+						"value": "some-value",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected length of field.0.name to be in the range (0 - 256), got " + strings.Repeat("a", processors.FieldsAddMaxNameLength+1),
+		},
+		{
+			name: "field value too long",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"name":  "some-name",
+						"value": strings.Repeat("a", processors.FieldsAddMaxValueLength+1),
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected length of field.0.value to be in the range (0 - 512), got " + strings.Repeat("a", processors.FieldsAddMaxValueLength+1),
+		},
+		{
+			name: "too-many-fields",
+			input: map[string]interface{}{
+				"field": createNFieldAddFields(51),
+			},
+			wantErr: true,
+			errMsg:  "Too many list items",
+		},
+	}
+
+	r := &schema.Resource{Schema: new(processors.FieldsAddAttributes).Schema()}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}
+
+func createNFieldAddFields(n int) []interface{} {
+	var fields []interface{}
+	var field = map[string]interface{}{
+		"name":  "some-name",
+		"value": "some-value",
+	}
+
+	for i := 0; i < n; i++ {
+		fields = append(fields, field)
+	}
+
+	return fields
+}

--- a/dynatrace/api/builtin/openpipeline/processors/fields_remove.go
+++ b/dynatrace/api/builtin/openpipeline/processors/fields_remove.go
@@ -1,0 +1,48 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type FieldsRemoveAttributes struct {
+	Fields []string `json:"fields"`
+}
+
+func (fra *FieldsRemoveAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"fields": {
+			Type:        schema.TypeSet,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Fields to be removed from the record",
+			Required:    true,
+			MinItems:    1,
+			MaxItems:    50,
+		},
+	}
+}
+
+func (fra *FieldsRemoveAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.Encode("fields", fra.Fields)
+}
+
+func (fra *FieldsRemoveAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.Decode("fields", &fra.Fields)
+}

--- a/dynatrace/api/builtin/openpipeline/processors/fields_remove_test.go
+++ b/dynatrace/api/builtin/openpipeline/processors/fields_remove_test.go
@@ -1,0 +1,134 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldsRemoveAttributes_MarshalHCL(t *testing.T) {
+	var input = processors.FieldsRemoveAttributes{
+		Fields: []string{"field1", "field2"},
+	}
+	var expected = hcl.Properties{
+		"fields": []string{"field1", "field2"},
+	}
+
+	var actual = hcl.Properties{}
+
+	err := input.MarshalHCL(actual)
+
+	assert.Equal(t, expected, actual)
+	assert.NoError(t, err)
+}
+
+func TestFieldsRemoveAttributes_UnmarshalHCL(t *testing.T) {
+	var input = map[string]interface{}{
+		"fields": []interface{}{"field1", "field2"},
+	}
+	var expected = processors.FieldsRemoveAttributes{Fields: []string{"field1", "field2"}}
+
+	d := schema.TestResourceDataRaw(t, new(processors.FieldsRemoveAttributes).Schema(), input)
+	assert.NotNil(t, d)
+
+	var actual processors.FieldsRemoveAttributes
+	decoder := hcl.DecoderFrom(d)
+
+	err := actual.UnmarshalHCL(decoder)
+
+	assert.Equal(t, expected, actual)
+	assert.NoError(t, err)
+}
+
+func TestFieldsRemoveAttributes_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid",
+			input:   map[string]interface{}{"fields": []interface{}{"field1", "field2"}},
+			wantErr: false,
+		},
+		{
+			name:    "duplicate fields, still valid",
+			input:   map[string]interface{}{"fields": []interface{}{"field1", "field1"}},
+			wantErr: false,
+		},
+		{
+			name:    "empty fields are also valid",
+			input:   map[string]interface{}{"fields": []interface{}{"", ""}},
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			input:   map[string]interface{}{},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name:    "empty-fields",
+			input:   map[string]interface{}{"fields": []interface{}{}},
+			wantErr: true,
+			errMsg:  "Not enough list items",
+		},
+		{
+			name:    "unrecognized-property",
+			input:   map[string]interface{}{"fields": []interface{}{"field1"}, "strange-property": true},
+			wantErr: true,
+			errMsg:  "Invalid or unknown key",
+		},
+		{
+			name:    "too many fields",
+			input:   map[string]interface{}{"fields": createNFieldsRemoveFields(51)},
+			wantErr: true,
+			errMsg:  "Too many list items",
+		},
+	}
+
+	r := &schema.Resource{Schema: new(processors.FieldsRemoveAttributes).Schema()}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}
+
+func createNFieldsRemoveFields(n int) []interface{} {
+	var fields []interface{}
+	for i := 0; i < n; i++ {
+		fields = append(fields, "field"+strconv.Itoa(i))
+	}
+	return fields
+}

--- a/dynatrace/api/builtin/openpipeline/processors/fields_rename.go
+++ b/dynatrace/api/builtin/openpipeline/processors/fields_rename.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type FieldsRenameAttributes struct {
+	Fields []*FieldsRenameItem `json:"fields"`
+}
+
+func (fra *FieldsRenameAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Resource{Schema: new(FieldsRenameItem).Schema()},
+			Description: "Field to rename on the record",
+			Required:    true,
+			MinItems:    1,
+			MaxItems:    50,
+		},
+	}
+}
+
+func (fra *FieldsRenameAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("field", fra.Fields)
+}
+
+func (fra *FieldsRenameAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("field", &fra.Fields)
+}
+
+type FieldsRenameItem struct {
+	FromName string `json:"fromName"`
+	ToName   string `json:"toName"`
+}
+
+const FieldsRenameMaxNameLength = 256
+
+func (f *FieldsRenameItem) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"from_name": {
+			Type:         schema.TypeString,
+			Description:  "The field to rename",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(0, FieldsRenameMaxNameLength),
+		},
+		"to_name": {
+			Type:         schema.TypeString,
+			Description:  "The new field name",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(0, FieldsRenameMaxNameLength),
+		},
+	}
+}
+
+func (f *FieldsRenameItem) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"from_name": f.FromName,
+		"to_name":   f.ToName,
+	})
+}
+
+func (f *FieldsRenameItem) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"from_name": &f.FromName,
+		"to_name":   &f.ToName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/processors/fields_rename_test.go
+++ b/dynatrace/api/builtin/openpipeline/processors/fields_rename_test.go
@@ -1,0 +1,263 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldsRenameAttributes_MarshalHCL(t *testing.T) {
+	var input = processors.FieldsRenameAttributes{
+		Fields: []*processors.FieldsRenameItem{
+			{
+				FromName: "some-name",
+				ToName:   "new-name",
+			},
+			{
+				FromName: "some-other-name",
+				ToName:   "other-new-name",
+			},
+		},
+	}
+	var expected = hcl.Properties{
+		"field": []interface{}{
+			hcl.Properties{
+				"from_name": "some-name",
+				"to_name":   "new-name",
+			},
+			hcl.Properties{
+				"from_name": "some-other-name",
+				"to_name":   "other-new-name",
+			},
+		},
+	}
+
+	var actual = hcl.Properties{}
+
+	err := input.MarshalHCL(actual)
+
+	assert.Equal(t, expected, actual)
+	assert.NoError(t, err)
+}
+
+func TestFieldsRenameAttributes_UnmarshalHCL(t *testing.T) {
+	var input = map[string]interface{}{
+		"field": []interface{}{
+			map[string]interface{}{
+				"from_name": "some-name",
+				"to_name":   "new-name",
+			},
+			map[string]interface{}{
+				"from_name": "some-other-name",
+				"to_name":   "other-new-name",
+			},
+		},
+	}
+	var expected = processors.FieldsRenameAttributes{
+		Fields: []*processors.FieldsRenameItem{
+			{
+				FromName: "some-name",
+				ToName:   "new-name",
+			},
+			{
+				FromName: "some-other-name",
+				ToName:   "other-new-name",
+			},
+		},
+	}
+
+	d := schema.TestResourceDataRaw(t, new(processors.FieldsRenameAttributes).Schema(), input)
+	assert.NotNil(t, d)
+
+	var actual processors.FieldsRenameAttributes
+	decoder := hcl.DecoderFrom(d)
+
+	err := actual.UnmarshalHCL(decoder)
+
+	assert.Equal(t, expected, actual)
+	assert.NoError(t, err)
+}
+
+func TestFieldsRenameAttributes_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"from_name": "some-name",
+						"to_name":   "new-name",
+					},
+					map[string]interface{}{
+						"from_name": "some-other-name",
+						"to_name":   "other-new-name",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty from_name and to_name is valid",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"from_name": "",
+						"to_name":   "",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			input:   map[string]interface{}{},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "empty-fields",
+			input: map[string]interface{}{
+				"field": []interface{}{},
+			},
+			wantErr: true,
+			errMsg:  "Not enough list items",
+		},
+		{
+			name: "empty-field",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "field-missing-from-name",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"to_name": "new-name",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "field-missing-to-name",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"from_name": "some-name",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "field-with-unrecognized-property",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"from_name":        "some-name",
+						"to_name":          "new-name",
+						"strange-property": true,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Invalid or unknown key",
+		},
+		{
+			name: "from-name too long",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"from_name": strings.Repeat("a", processors.FieldsRenameMaxNameLength+1),
+						"to_name":   "new-name",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected length of field.0.from_name to be in the range (0 - 256), got " + strings.Repeat("a", processors.FieldsRenameMaxNameLength+1),
+		},
+		{
+			name: "to-name too long",
+			input: map[string]interface{}{
+				"field": []interface{}{
+					map[string]interface{}{
+						"from_name": "old-name",
+						"to_name":   strings.Repeat("a", processors.FieldsRenameMaxNameLength+1),
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected length of field.0.to_name to be in the range (0 - 256), got " + strings.Repeat("a", processors.FieldsRenameMaxNameLength+1),
+		},
+		{
+			name: "too many fields",
+			input: map[string]interface{}{
+				"field": createNFieldsRenameFields(51),
+			},
+			wantErr: true,
+			errMsg:  "Too many list items",
+		},
+	}
+
+	r := &schema.Resource{Schema: new(processors.FieldsRenameAttributes).Schema()}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}
+
+func createNFieldsRenameFields(n int) []interface{} {
+	var fields []interface{}
+	var field = map[string]interface{}{
+		"from_name": "old-name",
+		"to_name":   "new-name",
+	}
+
+	for i := 0; i < n; i++ {
+		fields = append(fields, field)
+	}
+
+	return fields
+}

--- a/dynatrace/api/builtin/openpipeline/processors/processor.go
+++ b/dynatrace/api/builtin/openpipeline/processors/processor.go
@@ -1,0 +1,232 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	DqlProcessorType          = "dql"
+	FieldsAddProcessorType    = "fieldsAdd"
+	FieldsRemoveProcessorType = "fieldsRemove"
+	FieldsRenameProcessorType = "fieldsRename"
+	DropProcessorType         = "drop"
+
+	CounterMetricProcessorType = "counterMetric"
+	ValueMetricProcessorType   = "valueMetric"
+
+	DavisEventExtractionProcessorType = "davis"
+	BizEventExtractionProcessorType   = "bizevent"
+
+	SecurityContextProcessorType = "securityContext"
+
+	NoStorageStageProcessorType        = "noStorage"
+	BucketAssignmentStageProcessorType = "bucketAssignment"
+
+	TechnologyProcessorType = "technology"
+
+	AzureLogForwardingProcessorType = "azureLogForwarding"
+	SecurityEventProcessorType      = "securityEvent"
+	CostAllocationProcessorType     = "costAllocation"
+	ProductAllocationProcessorType  = "productAllocation"
+)
+
+var AvailableProcessorTypes = []string{DqlProcessorType, FieldsAddProcessorType, FieldsRemoveProcessorType,
+	FieldsRenameProcessorType, TechnologyProcessorType, DropProcessorType, BucketAssignmentStageProcessorType,
+	NoStorageStageProcessorType, SecurityContextProcessorType, CounterMetricProcessorType, ValueMetricProcessorType,
+	DavisEventExtractionProcessorType, BizEventExtractionProcessorType, AzureLogForwardingProcessorType,
+	SecurityEventProcessorType, CostAllocationProcessorType, ProductAllocationProcessorType}
+
+type Processor struct {
+	Enabled      bool                    `json:"enabled"`
+	Id           string                  `json:"id"`
+	Type         string                  `json:"type"`
+	Description  string                  `json:"description"`
+	SampleData   *string                 `json:"sampleData,omitempty"`
+	Matcher      *string                 `json:"matcher,omitempty"`
+	Dql          *DqlAttributes          `json:"dql,omitempty"`
+	FieldsAdd    *FieldsAddAttributes    `json:"fieldsAdd,omitempty"`
+	FieldsRename *FieldsRenameAttributes `json:"fieldsRename,omitempty"`
+	FieldsRemove *FieldsRemoveAttributes `json:"fieldsRemove,omitempty"`
+}
+
+const IDMinLength = 4
+const IDMaxLength = 100
+const DescriptionMaxLength = 512
+const SampleDataMaxLength = 8192
+const MatcherMaxLength = 1500
+
+func (p *Processor) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"enabled": {
+			Type:        schema.TypeBool,
+			Description: "Indicates if the object is active",
+			Default:     true,
+			Optional:    true,
+		},
+		"id": {
+			Type:        schema.TypeString,
+			Description: "Identifier of the processor. Must be unique within a stage. Must not start with 'dt.' or 'dynatrace.'",
+			Required:    true,
+			ValidateFunc: validation.All(
+				validation.StringLenBetween(IDMinLength, IDMaxLength),
+				func(input interface{}, schema string) (warnings []string, errors []error) {
+					id, ok := input.(string)
+					if !ok {
+						errors = append(errors, fmt.Errorf("expected type of %s to be string", schema))
+						return warnings, errors
+					}
+
+					if strings.HasPrefix(id, "dt.") || strings.HasPrefix(id, "dynatrace.") {
+						errors = append(errors,
+							fmt.Errorf("%s must not start with 'dt.' or 'dynatrace.'", schema))
+					}
+					return warnings, errors
+				}),
+		},
+		"type": {
+			Type:         schema.TypeString,
+			Description:  fmt.Sprintf("Type of the processor. Available values: %q", AvailableProcessorTypes),
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(AvailableProcessorTypes, true),
+		},
+		"description": {
+			Type:         schema.TypeString,
+			Description:  "Name or description of the processor",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(1, DescriptionMaxLength),
+		},
+		"sample_data": {
+			Type:         schema.TypeString,
+			Description:  "Sample data related to the processor for documentation or testing",
+			Optional:     true,
+			ValidateFunc: validation.StringLenBetween(1, SampleDataMaxLength),
+		},
+		"matcher": {
+			Type:         schema.TypeString,
+			Description:  "Matching condition to apply on incoming records. Does not work with processors of type \"technology\"",
+			Optional:     true,
+			ValidateFunc: validation.StringLenBetween(1, MatcherMaxLength),
+		},
+		"dql": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			MinItems:    0,
+			Description: "Properties of the DQL processor",
+			Elem:        &schema.Resource{Schema: new(DqlAttributes).Schema()},
+			Optional:    true,
+		},
+		"fields_add": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			MinItems:    0,
+			Description: "Properties of the fieldsAdd processor",
+			Elem:        &schema.Resource{Schema: new(FieldsAddAttributes).Schema()},
+			Optional:    true,
+		},
+		"fields_rename": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			MinItems:    0,
+			Description: "Properties of the fieldsRename processor",
+			Elem:        &schema.Resource{Schema: new(FieldsRenameAttributes).Schema()},
+			Optional:    true,
+		},
+		"fields_remove": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			MinItems:    0,
+			Description: "Properties of the fieldsRemove processor",
+			Elem:        &schema.Resource{Schema: new(FieldsRemoveAttributes).Schema()},
+			Optional:    true,
+		},
+	}
+}
+
+func (p *Processor) MarshalHCL(properties hcl.Properties) error {
+	err := properties.EncodeAll(map[string]any{
+		"enabled":     p.Enabled,
+		"id":          p.Id,
+		"type":        p.Type,
+		"description": p.Description,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if p.SampleData != nil {
+		err = properties.Encode("sample_data", p.SampleData)
+		if err != nil {
+			return err
+		}
+	}
+	if p.Matcher != nil {
+		err = properties.Encode("matcher", p.Matcher)
+		if err != nil {
+			return err
+		}
+	}
+	if p.Dql != nil {
+		err = properties.Encode("dql", p.Dql)
+		if err != nil {
+			return err
+		}
+	}
+	if p.FieldsAdd != nil {
+		err = properties.Encode("fields_add", p.FieldsAdd)
+		if err != nil {
+			return err
+		}
+	}
+	if p.FieldsRename != nil {
+		err = properties.Encode("fields_rename", p.FieldsRename)
+		if err != nil {
+			return err
+		}
+	}
+	if p.FieldsRemove != nil {
+		err = properties.Encode("fields_remove", p.FieldsRemove)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"enabled":       &p.Enabled,
+		"id":            &p.Id,
+		"type":          &p.Type,
+		"description":   &p.Description,
+		"sample_data":   &p.SampleData,
+		"matcher":       &p.Matcher,
+		"dql":           &p.Dql,
+		"fields_add":    &p.FieldsAdd,
+		"fields_rename": &p.FieldsRename,
+		"fields_remove": &p.FieldsRemove,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/processors/processor_test.go
+++ b/dynatrace/api/builtin/openpipeline/processors/processor_test.go
@@ -1,0 +1,691 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package processors_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sampleData = "my-sample-data"
+var matcher = "not true"
+var allFieldsSetDropProcessor = processors.Processor{
+	Enabled:     true,
+	Id:          "proc-1",
+	Type:        processors.DropProcessorType,
+	Description: "my-drop-processor",
+	SampleData:  &sampleData,
+	Matcher:     &matcher,
+}
+
+var minimalFieldsDropSetProcessor = processors.Processor{
+	Enabled:     false,
+	Id:          "proc-2",
+	Type:        processors.DropProcessorType,
+	Description: "my-other-drop-processor",
+	Matcher:     &matcher,
+}
+
+var dqlProcessor = processors.Processor{
+	Enabled:     true,
+	Id:          "proc-2",
+	Type:        processors.DqlProcessorType,
+	Description: "my-proc-2",
+	SampleData:  &sampleData,
+	Matcher:     &matcher,
+	Dql:         &processors.DqlAttributes{Script: "fieldsAdd true"},
+}
+
+var fieldsAddProcessor = processors.Processor{
+	Enabled:     true,
+	Id:          "proc-3",
+	Type:        processors.FieldsAddProcessorType,
+	Description: "my-proc-3",
+	SampleData:  &sampleData,
+	Matcher:     &matcher,
+	FieldsAdd: &processors.FieldsAddAttributes{
+		Fields: []*processors.FieldsAddItem{
+			{
+				Name:  "some-name",
+				Value: "some-value",
+			},
+			{
+				Name:  "some-other-name",
+				Value: "some-other-value",
+			},
+		},
+	},
+}
+
+var fieldsRenameProcessor = processors.Processor{
+	Enabled:     true,
+	Id:          "proc-4",
+	Type:        processors.FieldsRenameProcessorType,
+	Description: "my-proc-4",
+	SampleData:  &sampleData,
+	Matcher:     &matcher,
+	FieldsRename: &processors.FieldsRenameAttributes{
+		Fields: []*processors.FieldsRenameItem{
+			{
+				FromName: "from-name",
+				ToName:   "to-name",
+			},
+			{
+				FromName: "from-other-name",
+				ToName:   "to-other-name",
+			},
+		},
+	},
+}
+
+var fieldsRemoveProcessor = processors.Processor{
+	Enabled:     true,
+	Id:          "proc-5",
+	Type:        processors.FieldsRemoveProcessorType,
+	Description: "my-proc-5",
+	SampleData:  &sampleData,
+	Matcher:     &matcher,
+	FieldsRemove: &processors.FieldsRemoveAttributes{
+		Fields: []string{"to-remove-1", "to-remove-2"},
+	},
+}
+
+func TestProcessor_MarshalJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    processors.Processor
+		expected []byte
+	}{
+		{
+			name:  "drop-processor all fields set",
+			input: allFieldsSetDropProcessor,
+			expected: []byte(
+				`{
+				"id": "proc-1",
+				"type": "drop",
+				"matcher": "not true",
+				"description": "my-drop-processor",
+				"sampleData": "my-sample-data",
+				"enabled": true
+			}`),
+		},
+		{
+			name:  "drop-processor minimal fields set",
+			input: minimalFieldsDropSetProcessor,
+			expected: []byte(
+				`{
+				"id": "proc-2",
+				"type": "drop",
+				"matcher": "not true",
+				"description": "my-other-drop-processor",
+				"enabled": false
+			}`),
+		},
+		{
+			name:  "dql-processor",
+			input: dqlProcessor,
+			expected: []byte(
+				`{
+				"id": "proc-2",
+				"type": "dql",
+				"matcher": "not true",
+				"description": "my-proc-2",
+				"sampleData": "my-sample-data",
+				"enabled": true,
+				"dql": {
+					"script": "fieldsAdd true"
+				}
+			}`),
+		},
+		{
+			name:  "fieldsAdd-processor",
+			input: fieldsAddProcessor,
+			expected: []byte(
+				`{
+				"id": "proc-3",
+				"type": "fieldsAdd",
+				"matcher": "not true",
+				"description": "my-proc-3",
+				"sampleData": "my-sample-data",
+				"enabled": true,
+				"fieldsAdd": {
+					"fields": [
+						{
+							"name": "some-name",
+							"value": "some-value"
+						},
+						{
+							"name": "some-other-name",
+							"value": "some-other-value"
+						}
+					]
+				}
+			}`),
+		},
+		{
+			name:  "fieldsRename-processor",
+			input: fieldsRenameProcessor,
+			expected: []byte(
+				`{
+				"id": "proc-4",
+				"type": "fieldsRename",
+				"matcher": "not true",
+				"description": "my-proc-4",
+				"sampleData": "my-sample-data",
+				"enabled": true,
+				"fieldsRename": {
+					"fields": [
+						{
+							"fromName": "from-name",
+							"toName": "to-name"
+						},
+						{
+							"fromName": "from-other-name",
+							"toName": "to-other-name"
+						}
+					]
+				}
+			}`),
+		},
+		{
+			name:  "fieldsRemove-processor",
+			input: fieldsRemoveProcessor,
+			expected: []byte(
+				`{
+				"id": "proc-5",
+				"type": "fieldsRemove",
+				"matcher": "not true",
+				"description": "my-proc-5",
+				"sampleData": "my-sample-data",
+				"enabled": true,
+				"fieldsRemove": {
+					"fields": [
+						"to-remove-1",
+						"to-remove-2"
+					]
+				}
+			}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+
+			var actualJSON map[string]interface{}
+			err = json.Unmarshal(actual, &actualJSON)
+			require.NoError(t, err)
+
+			var expectedJSON map[string]interface{}
+			err = json.Unmarshal(tc.expected, &expectedJSON)
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedJSON, actualJSON)
+		})
+	}
+}
+
+func TestProcessor_MarshalHCL(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    processors.Processor
+		expected hcl.Properties
+	}{
+		{
+			name:  "drop-processor all fields set",
+			input: allFieldsSetDropProcessor,
+			expected: hcl.Properties{
+				"enabled":     true,
+				"type":        "drop",
+				"id":          "proc-1",
+				"sample_data": sampleData,
+				"description": "my-drop-processor",
+				"matcher":     "not true",
+			},
+		},
+		{
+			name:  "drop-processor minimal fields set",
+			input: minimalFieldsDropSetProcessor,
+			expected: hcl.Properties{
+				"enabled":     false,
+				"type":        "drop",
+				"id":          "proc-2",
+				"description": "my-other-drop-processor",
+				"matcher":     "not true",
+			},
+		},
+		{
+			name:  "dql-processor",
+			input: dqlProcessor,
+			expected: hcl.Properties{
+				"enabled":     true,
+				"type":        "dql",
+				"id":          "proc-2",
+				"description": "my-proc-2",
+				"sample_data": sampleData,
+				"matcher":     "not true",
+				"dql": []interface{}{
+					hcl.Properties{
+						"script": "fieldsAdd true",
+					},
+				},
+			},
+		},
+		{
+			name:  "fieldsAdd-processor",
+			input: fieldsAddProcessor,
+			expected: hcl.Properties{
+				"enabled":     true,
+				"type":        "fieldsAdd",
+				"id":          "proc-3",
+				"description": "my-proc-3",
+				"sample_data": sampleData,
+				"matcher":     "not true",
+				"fields_add": []interface{}{
+					hcl.Properties{
+						"field": []interface{}{
+							hcl.Properties{
+								"name":  "some-name",
+								"value": "some-value",
+							},
+							hcl.Properties{
+								"name":  "some-other-name",
+								"value": "some-other-value",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "fieldsRename-processor",
+			input: fieldsRenameProcessor,
+			expected: hcl.Properties{
+				"enabled":     true,
+				"type":        "fieldsRename",
+				"id":          "proc-4",
+				"description": "my-proc-4",
+				"sample_data": sampleData,
+				"matcher":     "not true",
+				"fields_rename": []interface{}{
+					hcl.Properties{
+						"field": []interface{}{
+							hcl.Properties{
+								"from_name": "from-name",
+								"to_name":   "to-name",
+							},
+							hcl.Properties{
+								"from_name": "from-other-name",
+								"to_name":   "to-other-name",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "fieldsRemove-processor",
+			input: fieldsRemoveProcessor,
+			expected: hcl.Properties{
+				"enabled":     true,
+				"type":        "fieldsRemove",
+				"id":          "proc-5",
+				"description": "my-proc-5",
+				"sample_data": sampleData,
+				"matcher":     "not true",
+				"fields_remove": []interface{}{
+					hcl.Properties{
+						"fields": []string{
+							"to-remove-1",
+							"to-remove-2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual = hcl.Properties{}
+			err := tc.input.MarshalHCL(actual)
+			assert.Equal(t, tc.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestProcessor_UnmarshalHCL(t *testing.T) {
+	s := new(processors.Processor).Schema()
+
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected processors.Processor
+	}{
+		{
+			name: "all fields set",
+			input: map[string]interface{}{
+				"enabled":     true,
+				"type":        "drop",
+				"id":          "proc-1",
+				"sample_data": sampleData,
+				"description": "my-drop-processor",
+				"matcher":     "not true",
+			},
+			expected: allFieldsSetDropProcessor,
+		},
+		{
+			name: "minimal fields set",
+			input: map[string]interface{}{
+				"enabled":     false,
+				"type":        "drop",
+				"id":          "proc-2",
+				"description": "my-other-drop-processor",
+				"matcher":     "not true",
+			},
+			expected: minimalFieldsDropSetProcessor,
+		},
+		{
+			name: "dql-processor",
+			input: map[string]interface{}{
+				"enabled":     true,
+				"type":        "dql",
+				"id":          "proc-2",
+				"description": "my-proc-2",
+				"matcher":     "not true",
+				"sample_data": sampleData,
+				"dql": []interface{}{
+					map[string]interface{}{
+						"script": "fieldsAdd true",
+					},
+				},
+			},
+			expected: dqlProcessor,
+		},
+		{
+			name: "fieldsAdd-processor",
+			input: map[string]interface{}{
+				"enabled":     true,
+				"type":        "fieldsAdd",
+				"id":          "proc-3",
+				"description": "my-proc-3",
+				"matcher":     "not true",
+				"sample_data": sampleData,
+				"fields_add": []interface{}{
+					map[string]interface{}{
+						"field": []interface{}{
+							map[string]interface{}{
+								"name":  "some-name",
+								"value": "some-value",
+							},
+							map[string]interface{}{
+								"name":  "some-other-name",
+								"value": "some-other-value",
+							},
+						},
+					},
+				},
+			},
+			expected: fieldsAddProcessor,
+		},
+		{
+			name: "fieldsRename-processor",
+			input: map[string]interface{}{
+				"enabled":     true,
+				"type":        "fieldsRename",
+				"id":          "proc-4",
+				"description": "my-proc-4",
+				"matcher":     "not true",
+				"sample_data": sampleData,
+				"fields_rename": []interface{}{
+					map[string]interface{}{
+						"field": []interface{}{
+							map[string]interface{}{
+								"from_name": "from-name",
+								"to_name":   "to-name",
+							},
+							map[string]interface{}{
+								"from_name": "from-other-name",
+								"to_name":   "to-other-name",
+							},
+						},
+					},
+				},
+			},
+			expected: fieldsRenameProcessor,
+		},
+		{
+			name: "fieldsRemove-processor",
+			input: map[string]interface{}{
+				"enabled":     true,
+				"type":        "fieldsRemove",
+				"id":          "proc-5",
+				"description": "my-proc-5",
+				"matcher":     "not true",
+				"sample_data": sampleData,
+				"fields_remove": []interface{}{
+					map[string]interface{}{
+						"fields": []interface{}{
+							"to-remove-1",
+							"to-remove-2",
+						},
+					},
+				},
+			},
+			expected: fieldsRemoveProcessor,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			assert.NotNil(t, d)
+
+			var actual processors.Processor
+			decoder := hcl.DecoderFrom(d)
+			err := actual.UnmarshalHCL(decoder)
+			assert.Equal(t, c.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestProcessor_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "proc-1",
+				"description": "my-drop-processor",
+			},
+			wantErr: false,
+		},
+		{
+			name: "type missing",
+			input: map[string]interface{}{
+				"id":          "proc-1",
+				"description": "my-drop-processor",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "invalid processor type",
+			input: map[string]interface{}{
+				"type":        "invalid",
+				"id":          "proc-1",
+				"description": "my-drop-processor",
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("expected type to be one of %q, got invalid", processors.AvailableProcessorTypes),
+		},
+		{
+			name: "id missing",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"description": "my-drop-processor",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "id too short",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          strings.Repeat("a", processors.IDMinLength-1),
+				"description": "my-drop-processor",
+			},
+			wantErr: true,
+			errMsg:  "expected length of id to be in the range (4 - 100), got aaa",
+		},
+		{
+			name: "id too long",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          strings.Repeat("a", processors.IDMaxLength+1),
+				"description": "my-drop-processor",
+			},
+			wantErr: true,
+			errMsg:  "expected length of id to be in the range (4 - 100), got " + strings.Repeat("a", processors.IDMaxLength+1),
+		},
+		{
+			name: "id starts with dt.",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "dt.2",
+				"description": "my-drop-processor",
+			},
+			wantErr: true,
+			errMsg:  "id must not start with 'dt.' or 'dynatrace.'",
+		},
+		{
+			name: "id starts with dynatrace.",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "dynatrace.2",
+				"description": "my-drop-processor",
+			},
+			wantErr: true,
+			errMsg:  "id must not start with 'dt.' or 'dynatrace.'",
+		},
+		{
+			name: "description missing",
+			input: map[string]interface{}{
+				"type": "drop",
+				"id":   "proc-1",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "description present but blank",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "processor1",
+				"description": "",
+			},
+			wantErr: true,
+			errMsg:  "expected length of description to be in the range (1 - 512), got ",
+		},
+		{
+			name: "description too long",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "processor1",
+				"description": strings.Repeat("a", processors.DescriptionMaxLength+1),
+			},
+			wantErr: true,
+			errMsg:  "expected length of description to be in the range (1 - 512), got " + strings.Repeat("a", processors.DescriptionMaxLength+1),
+		},
+		{
+			name: "matcher present but blank",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "processor1",
+				"description": "my-drop-processor",
+				"matcher":     "",
+			},
+			wantErr: true,
+			errMsg:  "expected length of matcher to be in the range (1 - 1500), got ",
+		},
+		{
+			name: "matcher too long",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "processor1",
+				"description": "my-drop-processor",
+				"matcher":     strings.Repeat("a", processors.MatcherMaxLength+1),
+			},
+			wantErr: true,
+			errMsg:  "expected length of matcher to be in the range (1 - 1500), got " + strings.Repeat("a", processors.MatcherMaxLength+1),
+		},
+		{
+			name: "sample_data present but blank",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "processor1",
+				"description": "my-drop-processor",
+				"sample_data": "",
+			},
+			wantErr: true,
+			errMsg:  "expected length of sample_data to be in the range (1 - 8192), got ",
+		},
+		{
+			name: "sample_data too long",
+			input: map[string]interface{}{
+				"type":        "drop",
+				"id":          "processor1",
+				"description": "my-drop-processor",
+				"sample_data": strings.Repeat("a", processors.SampleDataMaxLength+1),
+			},
+			wantErr: true,
+			errMsg:  "expected length of sample_data to be in the range (1 - 8192), got " + strings.Repeat("a", processors.SampleDataMaxLength+1),
+		},
+	}
+
+	r := &schema.Resource{Schema: new(processors.Processor).Schema()}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Why this PR?
This PR is the first in supporting the OpenPipeline settings schemas in the Terraform provider.

### What has changed?

This PR adds the HCL representation of the ingest-sources schema(s).

### How does it do it?

The first commit introduces some example files: A JSON file which represents the payload expected by the settings API and a TF file which shows how the HCL representation of ingest-source resources would look like.

The second commit introduces support for several processors: `drop`, `fieldAdd`, `fieldRename`, `fieldRemove`, and `dql`.
`Schema()`, `MarshalHCL()`, and `UnmarshalHCL()` are implemented.

The third commit introduces support for the ingest-source itself, again with `Schema()`, `MarshalHCL()`, and `UnmarshalHCL()` implemented.

### How is it tested?

There are tests for `MarshalHCL()` and `UnmarshalHCL()` for the ingest source and for each processor type. Also, there is a JSON marshalling test for the ingest source.

### How does it affect users?

It doesn't yet. The feature is under development.

**Issue**: CA-15750

Notes: Unmarshalling of the ingest source is not figured out yet. We would need the `kind` information, which is not part of the JSON payload. We would need to parse that from the settings schema name.