### PR TITLE
ci: Add snyk for vulnerability scanning

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,21 @@
+name: Snyk Security Scan
+
+on:
+  pull_request:
+    branches: [ main ]
+  merge_group: # run if triggered as part of a merge queue
+  push:
+    branches: [ main ]
+
+jobs:
+  security:
+    name: Code security scanning alerts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Run Snyk to check for vulnerabilities
+      uses: snyk/actions/golang@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,25 @@
+version: v1.5.0
+
+ignore:
+  'snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0': &ignore-mpl-2-0-license
+    - '*':
+      reason: 'MPL-2.0 is an acceptable license for our use case.'
+  'snyk:lic:golang:github.com:hashicorp:go-checkpoint:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:go-cleanhttp:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:go-plugin:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:go-retryablehttp:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:go-uuid:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:go-version:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:hc-install:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:hcl:v2:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:logutils:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:terraform-exec:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:terraform-json:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:terraform-plugin-go:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:terraform-plugin-log:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:terraform-plugin-sdk:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:terraform-plugin-sdk:v2:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:terraform-registry-address:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:terraform-svchost:MPL-2.0': *ignore-mpl-2-0-license
+  'snyk:lic:golang:github.com:hashicorp:yamux:MPL-2.0': *ignore-mpl-2-0-license


### PR DESCRIPTION
#### **Why** this PR?
This PR introduces the [snyk](https://snyk.io/) security scan to ensure that we find vulnerabilities as early as possible.

#### **What** has changed?
Added the snyk workflow that is triggered for all merges to 1) `main`, and all PRs merging into `main`.

#### **How** does it do it?
See documentation [here](https://docs.snyk.io/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-golang-action) for details on golang scanning.

#### How is it **tested**?
N/A

#### How does it affect **users**?
Users can be assured that we perform code scanning to find vulnerabilities as early as possible.

**Issue:** CA-9133
