### PR TITLE
feat: GoReleaser sets build version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     - arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,10 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w'
+    - '-X github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version.Version={{ .Version }}'
+    - '-X github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version.OperatingSystem={{ .Os }}'
+    - '-X github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version.CPUArchitecture={{ .Arch }}'
   goos:
     - freebsd
     - windows

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -859,7 +859,7 @@ func (me *Environment) WriteMainProviderFile() error {
 		format(outputFile.Name(), true)
 	}()
 	providerSource := "dynatrace-oss/dynatrace"
-	providerVersion := version.Current
+	providerVersion := version.Version
 	if value := os.Getenv(DYNATRACE_PROVIDER_SOURCE); len(value) != 0 {
 		providerSource = value
 	}

--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -414,7 +414,7 @@ func (me *Module) writeProviderFile(specificPath string) error {
 		format(outputFile.Name(), true)
 	}()
 	providerSource := "dynatrace-oss/dynatrace"
-	providerVersion := version.Current
+	providerVersion := version.Version
 	if value := os.Getenv("DYNATRACE_PROVIDER_SOURCE"); len(value) != 0 {
 		providerSource = value
 	}

--- a/provider/version/version.go
+++ b/provider/version/version.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,4 +17,24 @@
 
 package version
 
-const Current = "1.83.0"
+import "fmt"
+
+// The following variables should be set during the build, for example by GoReleaser.
+// This can be accomplished using `ldflags`, for example `-X github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version.Version=1.2.3`.
+var (
+	// Version is a string representing the current version of the Dynatrace Terraform provider.
+	// This should be in `major.minor.patch` format, with prereleases having an optional suffix introduced by a dash, for example, `1.2.0-beta`.
+	Version = "(unknown-version)"
+
+	// OperatingSystem is a string representing the operating system the provider was built for.
+	OperatingSystem = "(unknown-os)"
+
+	// CPUArchitecture is a string representing the CPU archictecture the provider was built for.
+	CPUArchitecture = "(unknown-architecture)"
+)
+
+// UserAgent returns a string identifying the current version of the Dynatrace Terraform provider.
+// This is intended for use in HTTP requests.
+func UserAgent() string {
+	return fmt.Sprintf("Dynatrace Terraform Provider/%s %s %s", Version, OperatingSystem, CPUArchitecture)
+}


### PR DESCRIPTION
#### **Why** this PR?
The provider version information should be set automatically as part of the build process via GoReleaser.

#### **What** has changed and **how** does it do it?
- Variables are defined to hold version, operating system, and CPU architecture.
- The GoReleaser configuration `.goreleaser.yml` is updated to set the version, operating system, and CPU architecture.
- A function `version.GetUserAgent()` is added to build and return a user agent.

#### How is it **tested**?
- Manually tested by inserting a temporary log message in the export command, and building locally with GoReleaser.

#### How does it affect **users**?
- No effect.

**Issue:** CA-15726