### PR TITLE
feat: Include version in `User-Agent` used for HTTP requests

### DIFF
--- a/dynatrace/api/iam/iam_client.go
+++ b/dynatrace/api/iam/iam_client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"github.com/google/uuid"
 )
 
@@ -191,6 +192,8 @@ func (me *iamClient) _request(ctx context.Context, url string, method string, ex
 		for k, v := range headers {
 			httpRequest.Header.Add(k, v)
 		}
+
+		httpRequest.Header.Set("User-Agent", version.UserAgent())
 
 		if httpResponse, err = http.DefaultClient.Do(httpRequest); err != nil {
 			return nil, err

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
@@ -121,7 +122,7 @@ func CreateClassicOAuthBasedClient(ctx context.Context, credentials *Credentials
 		crest.WithHTTPListener(logging.HTTPListener("classic ")),
 	)
 
-	oauthClient.SetHeader("User-Agent", "Dynatrace Terraform Provider")
+	oauthClient.SetHeader("User-Agent", version.UserAgent())
 	oauthClient.SetHeader("Authorization", "Api-Token "+credentials.Token)
 	return oauthClient, nil
 }
@@ -135,7 +136,7 @@ func CreateClassicClient(classicURL string, apiToken string) (*rest.Client, erro
 	}
 
 	factory := clients.Factory()
-	factory = factory.WithUserAgent("Dynatrace Terraform Provider")
+	factory = factory.WithUserAgent(version.UserAgent())
 	factory = factory.WithClassicURL(classicURL)
 	factory = factory.WithAccessToken(apiToken)
 	factory = factory.WithHTTPListener(logging.HTTPListener("classic "))

--- a/dynatrace/rest/cluster_request.go
+++ b/dynatrace/rest/cluster_request.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/google/uuid"
@@ -32,7 +33,7 @@ func clusterClient(baseURL string, apiToken string) (*rest.Client, error) {
 	}
 
 	factory := clients.Factory()
-	factory = factory.WithUserAgent("Dynatrace Terraform Provider")
+	factory = factory.WithUserAgent(version.UserAgent())
 	factory = factory.WithClassicURL(baseURL)
 	factory = factory.WithAccessToken(apiToken)
 	factory = factory.WithHTTPListener(HTTPListener("classic"))

--- a/dynatrace/rest/cluster_v1_client.go
+++ b/dynatrace/rest/cluster_v1_client.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	restlogging "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/google/uuid"
@@ -93,7 +94,7 @@ func clusterV1Client(baseURL string, apiToken string) (*rest.Client, error) {
 	}
 
 	factory := clients.Factory()
-	factory = factory.WithUserAgent("Dynatrace Terraform Provider")
+	factory = factory.WithUserAgent(version.UserAgent())
 	factory = factory.WithClassicURL(baseURL)
 	factory = factory.WithAccessToken(apiToken)
 	factory = factory.WithHTTPListener(restlogging.HTTPListener("clustv1 "))

--- a/dynatrace/rest/cluster_v2_client.go
+++ b/dynatrace/rest/cluster_v2_client.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 	"github.com/google/uuid"
@@ -93,7 +94,7 @@ func clusterV2Client(baseURL string, apiToken string) (*rest.Client, error) {
 	}
 
 	factory := clients.Factory()
-	factory = factory.WithUserAgent("Dynatrace Terraform Provider")
+	factory = factory.WithUserAgent(version.UserAgent())
 	factory = factory.WithClassicURL(baseURL)
 	factory = factory.WithAccessToken(apiToken)
 	factory = factory.WithHTTPListener(logging.HTTPListener("clustv2 "))

--- a/dynatrace/rest/legacy_request.go
+++ b/dynatrace/rest/legacy_request.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -61,7 +62,7 @@ type legacy_request request
 
 func (me *legacy_request) authenticate(req *http.Request) {
 	req.Header.Add("Authorization", "Api-Token "+me.client.Credentials().Token)
-	req.Header.Set("User-Agent", "Dynatrace Terraform Provider")
+	req.Header.Set("User-Agent", version.UserAgent())
 }
 
 func (me *legacy_request) Finish(vs ...any) error {

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/auth"
@@ -45,7 +46,7 @@ var platformClientCacheMutex sync.Mutex
 var NoPlatformCredentialsErr = errors.New("neither oauth credentials nor platform token present")
 
 func configureCommonRestClient(restClient *rest.Client) (*rest.Client, error) {
-	restClient.SetHeader("User-Agent", "Dynatrace Terraform Provider")
+	restClient.SetHeader("User-Agent", version.UserAgent())
 	return restClient, nil
 }
 

--- a/monaco/pkg/rest/request.go
+++ b/monaco/pkg/rest/request.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 )
 
 const MinWaitDuration = 1 * time.Second
@@ -152,7 +153,7 @@ func requestWithBody(ctx context.Context, method string, url string, body io.Rea
 
 func executeRequest(ctx context.Context, client *http.Client, request *http.Request) (Response, error) {
 
-	request.Header.Set("User-Agent", "Dynatrace Terraform Provider")
+	request.Header.Set("User-Agent", version.UserAgent())
 
 	response, err := executeWithRateLimiter(func() (Response, error) {
 		resp, err := client.Do(request)


### PR DESCRIPTION
#### **Why** this PR?
We would like all HTTP requests made by the Dynatrace Terraform provider to include a `User-Agent` header with the provider's version, operating system, and architecture. This header can be used to derive basic statistics to help improve the provider.

#### **What** has changed and **how** does it do it?
At all places an HTTP request is actually made, this PR sets / adjusts the `User-Agent` header. In most cases this was already set to a more basic value, "Dynatrace Terraform Provider"

#### How is it **tested**?
Currently, clients are created in many places, and the user agent is added in 9 separate instances. Fixing this is beyond the scope of this PR. Some verification can be achieved by observing requests made during acceptance tests.

The new user agent has been seen for at least requests made to the following:

**Classic:**
classic/v1/alertingProfiles
classic/v1/anomalyDetection/applications
classic/v1/anomalyDetection/databaseServices
classic/v1/anomalyDetection/diskEvents
classic/v1/anomalyDetection/hosts
classic/v1/anomalyDetection/metricEvents
classic/v1/anomalyDetection/processGroups
classic/v1/anomalyDetection/services
classic/v1/applications/web
classic/v1/autoTags
classic/v1/aws/credentials
classic/v1/azure/credentials
classic/v1/calculatedMetrics/mobile
classic/v1/calculatedMetrics/rum
classic/v1/calculatedMetrics/service
classic/v1/calculatedMetrics/synthetic
classic/v1/cloudFoundry/credentials
classic/v1/conditionalNaming/host
classic/v1/conditionalNaming/processGroup
classic/v1/conditionalNaming/service
classic/v1/dashboards
classic/v1/deployment/installer
classic/v1/kubernetes/credentials
classic/v1/maintenanceWindows
classic/v1/managementZones
classic/v1/notifications
classic/v1/reports
classic/v1/service/customServices
classic/v1/service/requestAttributes
classic/v1/synthetic/locations
classic/v1/synthetic/monitors
classic/v2/activeGateTokens
classic/v2/activeGateTokens/dt0g02
classic/v2/apiTokens
classic/v2/apiTokens/dt0c01
classic/v2/entities
classic/v2/settings/objects
classic/v2/slo
classic/v2/synthetic/locations
classic/v2/synthetic/monitors

**Platform:**
platform/automation/v1/business-calendars
platform/automation/v1/scheduling-rules
platform/automation/v1/workflows
platform/classic/environment-api/v1/deployment
platform/classic/environment-api/v1/synthetic
platform/classic/environment-api/v2/activeGateTokens
platform/classic/environment-api/v2/apiTokens
platform/classic/environment-api/v2/entities
platform/classic/environment-api/v2/settings
platform/classic/environment-api/v2/slo
platform/classic/environment-api/v2/synthetic
platform/document/v1/documents
platform/document/v1/trash/documents
platform/slo/v1/objective-templates
platform/slo/v1/slos
platform/storage/filter-segments/v1/filter-segments

#### How does it affect **users**?
No real effect.

**Issue:** CA-15726
