### PR TITLE
fix: update dynatrace_attack_settings and dynatrace_vulnerability_settings schemas

### DIFF
--- a/dynatrace/api/builtin/appsec/attackprotectionsettings/schema.json
+++ b/dynatrace/api/builtin/appsec/attackprotectionsettings/schema.json
@@ -1,125 +1,120 @@
 {
-	"allowedScopes": [
-		"environment"
-	],
-	"description": "[Runtime Application Protection](https://dt-url.net/0w6327u) allows you to control how Dynatrace handles incoming attacks to your applications on a global scale. To set up specific rules or exceptions, go to the [Monitoring rules](/ui/settings/builtin:appsec.attack-protection-advanced-config) settings page.",
-	"displayName": "Application Protection: General settings",
-	"documentation": "",
-	"dynatrace": "1",
-	"enums": {
-		"BlockingStrategy": {
-			"description": "",
-			"displayName": "Off | Monitor | Block",
-			"documentation": "",
-			"items": [
-				{
-					"description": "Attacks will be ignored.",
-					"displayName": "Off; incoming attacks NOT detected or blocked.",
-					"value": "OFF"
-				},
-				{
-					"description": "Attacks will be recorded.",
-					"displayName": "Monitor; incoming attacks detected only.",
-					"value": "MONITOR"
-				},
-				{
-					"description": "Attacks will be blocked.",
-					"displayName": "Block; incoming attacks detected and blocked.",
-					"value": "BLOCK"
-				}
-			],
-			"type": "enum"
-		}
-	},
-	"maxObjects": 1,
-	"multiObject": false,
-	"properties": {
-		"defaultAttackHandling": {
-			"description": "",
-			"displayName": "Define global incoming attack control",
-			"documentation": "",
-			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": {
-				"$ref": "#/types/AttackHandling"
-			}
-		},
-		"enabled": {
-			"default": false,
-			"description": "Note: This functionality consumes Application Security units. For details, see the [Application Security Monitoring documentation](https://dt-url.net/wq031ql).",
-			"displayName": "Enable Runtime Application Protection ",
-			"documentation": "",
-			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": "boolean"
-		}
-	},
-	"schemaGroups": [
-		"group:appsec",
-		"group:appsec.attack-protection"
-	],
-	"schemaId": "builtin:appsec.attack-protection-settings",
-	"types": {
-		"AttackHandling": {
-			"description": "Default settings for handling attacks.",
-			"displayName": "Default attack handling",
-			"documentation": "",
-			"properties": {
-				"blockingStrategyDotNet": {
-					"default": "OFF",
-					"description": "",
-					"displayName": "Attack control .NET",
-					"documentation": "",
-					"maxObjects": 1,
-					"metadata": {
-						"maturity": "EARLY_ADOPTER",
-						"sortItems": "disabled"
-					},
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": {
-						"$ref": "#/enums/BlockingStrategy"
-					}
-				},
-				"blockingStrategyGo": {
-					"description": "",
-					"displayName": "Attack control Go",
-					"documentation": "",
-					"maxObjects": 1,
-					"metadata": {
-						"featureFlag": "com.compuware.EnableCaspClvReportingGo.feature",
-						"maturity": "EARLY_ADOPTER",
-						"sortItems": "disabled"
-					},
-					"modificationPolicy": "DEFAULT",
-					"nullable": true,
-					"type": {
-						"$ref": "#/enums/BlockingStrategy"
-					}
-				},
-				"blockingStrategyJava": {
-					"default": "MONITOR",
-					"description": "",
-					"displayName": "Attack control Java",
-					"documentation": "",
-					"maxObjects": 1,
-					"metadata": {
-						"sortItems": "disabled"
-					},
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": {
-						"$ref": "#/enums/BlockingStrategy"
-					}
-				}
-			},
-			"summaryPattern": "",
-			"type": "object",
-			"version": "0",
-			"versionInfo": ""
-		}
-	},
-	"version": "2.4"
+  "dynatrace": "1",
+  "schemaId": "builtin:appsec.attack-protection-settings",
+  "displayName": "Application Protection: General settings",
+  "description": "[Runtime Application Protection](https://dt-url.net/0w6327u) allows you to control how Dynatrace handles incoming attacks to your applications on a global scale. To set up specific rules or exceptions, go to the [Monitoring rules](/ui/settings/builtin:appsec.attack-protection-advanced-config) settings page.",
+  "documentation": "",
+  "schemaGroups": [
+    "group:appsec",
+    "group:appsec.attack-protection"
+  ],
+  "version": "2.6",
+  "multiObject": false,
+  "maxObjects": 1,
+  "allowedScopes": [
+    "environment"
+  ],
+  "enums": {
+    "BlockingStrategy": {
+      "displayName": "Off | Monitor | Block",
+      "description": "",
+      "documentation": "",
+      "items": [
+        {
+          "value": "OFF",
+          "displayName": "Off; incoming attacks NOT detected or blocked.",
+          "description": "Attacks will be ignored."
+        },
+        {
+          "value": "MONITOR",
+          "displayName": "Monitor; incoming attacks detected only.",
+          "description": "Attacks will be recorded."
+        },
+        {
+          "value": "BLOCK",
+          "displayName": "Block; incoming attacks detected and blocked.",
+          "description": "Attacks will be blocked."
+        }
+      ],
+      "type": "enum"
+    }
+  },
+  "types": {
+    "AttackHandling": {
+      "version": "0",
+      "versionInfo": "",
+      "displayName": "Default attack handling",
+      "summaryPattern": "",
+      "description": "Default settings for handling attacks.",
+      "documentation": "",
+      "properties": {
+        "blockingStrategyJava": {
+          "displayName": "Attack control Java",
+          "description": "",
+          "documentation": "",
+          "type": {
+            "$ref": "#/enums/BlockingStrategy"
+          },
+          "nullable": false,
+          "metadata": {
+            "sortItems": "disabled"
+          },
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": "MONITOR"
+        },
+        "blockingStrategyDotNet": {
+          "displayName": "Attack control .NET",
+          "description": "",
+          "documentation": "",
+          "type": {
+            "$ref": "#/enums/BlockingStrategy"
+          },
+          "nullable": false,
+          "metadata": {
+            "sortItems": "disabled"
+          },
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": "OFF"
+        },
+        "blockingStrategyGo": {
+          "displayName": "Attack control Go",
+          "description": "",
+          "documentation": "",
+          "type": {
+            "$ref": "#/enums/BlockingStrategy"
+          },
+          "nullable": false,
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": "OFF"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "enabled": {
+      "displayName": "Enable Runtime Application Protection ",
+      "description": "Note: This functionality consumes Application Security units. For details, see the [Application Security Monitoring documentation](https://dt-url.net/wq031ql).",
+      "documentation": "",
+      "type": "boolean",
+      "nullable": false,
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT",
+      "default": false
+    },
+    "defaultAttackHandling": {
+      "displayName": "Define global incoming attack control",
+      "description": "",
+      "documentation": "",
+      "type": {
+        "$ref": "#/types/AttackHandling"
+      },
+      "nullable": false,
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT"
+    }
+  }
 }

--- a/dynatrace/api/builtin/appsec/attackprotectionsettings/service.go
+++ b/dynatrace/api/builtin/appsec/attackprotectionsettings/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "2.4"
+const SchemaVersion = "2.6"
 const SchemaID = "builtin:appsec.attack-protection-settings"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*attackprotectionsettings.Settings] {

--- a/dynatrace/api/builtin/appsec/attackprotectionsettings/settings/attack_handling.go
+++ b/dynatrace/api/builtin/appsec/attackprotectionsettings/settings/attack_handling.go
@@ -41,6 +41,7 @@ func (me *AttackHandling) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Possible Values: `BLOCK`, `MONITOR`, `OFF`",
 			Optional:    true, // nullable
+			Default:     "OFF",
 		},
 		"blocking_strategy_java": {
 			Type:        schema.TypeString,

--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/schema.json
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/schema.json
@@ -1,331 +1,329 @@
 {
-	"allowedScopes": [
-		"environment"
-	],
-	"description": "Automated [Runtime Vulnerability Analytics](https://dt-url.net/c010iio) helps you quickly and completely understand each detected vulnerability in your environment and how to remediate it, allowing you to prioritize which vulnerabilities to fix first. Note: Enabling Third-party or Code-level Vulnerability Analytics consumes Application Security units. For details, see the [Application Security Monitoring documentation](https://dt-url.net/wq031ql).",
-	"displayName": "Vulnerability Analytics: General settings",
-	"documentation": "",
-	"dynatrace": "1",
-	"enums": {
-		"MonitoringMode": {
-			"description": "",
-			"displayName": "MonitoringMode",
-			"documentation": "",
-			"items": [
-				{
-					"description": "Code-level vulnerabilities will be ignored ",
-					"displayName": "Do not monitor",
-					"value": "MONITORING_OFF"
-				},
-				{
-					"description": "Code-level vulnerabilities will be recorded",
-					"displayName": "Monitor",
-					"value": "MONITORING_ON"
-				}
-			],
-			"type": "enum"
-		},
-		"MonitoringModeTPV": {
-			"description": "",
-			"displayName": "MonitoringModeTPV",
-			"documentation": "",
-			"items": [
-				{
-					"description": "Third-party vulnerabilities will not be monitored",
-					"displayName": "Do not monitor",
-					"value": "MONITORING_OFF"
-				},
-				{
-					"description": "Third-party vulnerabilities will be monitored",
-					"displayName": "Monitor",
-					"value": "MONITORING_ON"
-				}
-			],
-			"type": "enum"
-		}
-	},
-	"maxObjects": 1,
-	"multiObject": false,
-	"properties": {
-		"enableCodeLevelVulnerabilityDetection": {
-			"default": false,
-			"description": "",
-			"displayName": "Enable Code-level Vulnerability Analytics",
-			"documentation": "",
-			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": "boolean"
-		},
-		"enableResourceAttributeRules": {
-			"description": "When new monitoring rules are enabled, classic rules are disabled. To re-enable classic rules, disable the new monitoring rules.",
-			"displayName": "Enable new monitoring rules",
-			"documentation": "",
-			"maxObjects": 1,
-			"metadata": {
-				"featureFlag": "com.compuware.EnableCaspResourceAttributesSettingsToggle.feature",
-				"maturity": "GENERAL_AVAILABILITY"
-			},
-			"modificationPolicy": "DEFAULT",
-			"nullable": true,
-			"type": "boolean"
-		},
-		"enableRuntimeVulnerabilityDetection": {
-			"default": false,
-			"description": "",
-			"displayName": "Enable Third-party Vulnerability Analytics",
-			"documentation": "",
-			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": "boolean"
-		},
-		"globalMonitoringModeDotNet": {
-			"default": "MONITORING_OFF",
-			"description": "Global .NET code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
-			"displayName": "Global .NET code-level vulnerability detection control",
-			"documentation": "Code-level vulnerability detection for .NET has been recently released as a preview version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \".NET code-level vulnerability evaluation\" to get started.",
-			"maxObjects": 1,
-			"metadata": {
-				"maturity": "EARLY_ADOPTER",
-				"sortItems": "disabled"
-			},
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": {
-				"$ref": "#/enums/MonitoringMode"
-			}
-		},
-		"globalMonitoringModeGo": {
-			"description": "Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
-			"displayName": "Global Go code-level vulnerability detection control",
-			"documentation": "Code-level vulnerability detection for Go has been recently released as a preview version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \"Go code-level vulnerability evaluation\" to get started.",
-			"maxObjects": 1,
-			"metadata": {
-				"featureFlag": "com.compuware.EnableCaspClvReportingGo.feature",
-				"maturity": "EARLY_ADOPTER",
-				"sortItems": "disabled"
-			},
-			"modificationPolicy": "DEFAULT",
-			"nullable": true,
-			"type": {
-				"$ref": "#/enums/MonitoringMode"
-			}
-		},
-		"globalMonitoringModeJava": {
-			"default": "MONITORING_ON",
-			"description": "Global Java code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
-			"displayName": "Global Java code-level vulnerability detection control",
-			"documentation": "Code-level vulnerability detection for Java has been recently released as early access version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \"Java code-level vulnerability evaluation\" to get started.",
-			"maxObjects": 1,
-			"metadata": {
-				"sortItems": "disabled"
-			},
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": {
-				"$ref": "#/enums/MonitoringMode"
-			}
-		},
-		"globalMonitoringModeTPV": {
-			"default": "MONITORING_ON",
-			"description": "Global third-party vulnerability detection control defines the default for all processes.",
-			"displayName": "Global third-party vulnerability detection control",
-			"documentation": "",
-			"maxObjects": 1,
-			"metadata": {
-				"sortItems": "disabled"
-			},
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": {
-				"$ref": "#/enums/MonitoringModeTPV"
-			}
-		},
-		"technologies": {
-			"description": "Vulnerability Analytics can be enabled/disabled per supported technology.",
-			"displayName": "Technologies",
-			"documentation": "",
-			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": {
-				"$ref": "#/types/Technology"
-			}
-		}
-	},
-	"schemaGroups": [
-		"group:appsec.vulnerability-analytics",
-		"group:appsec"
-	],
-	"schemaId": "builtin:appsec.runtime-vulnerability-detection",
-	"types": {
-		"Technology": {
-			"description": "",
-			"displayName": "Technology",
-			"documentation": "",
-			"properties": {
-				"enableDotNet": {
-					"default": true,
-					"description": "",
-					"displayName": ".NET",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": "boolean"
-				},
-				"enableDotNetRuntime": {
-					"default": true,
-					"description": "",
-					"displayName": ".NET runtimes",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"precondition": {
-						"expectedValue": true,
-						"property": "enableDotNet",
-						"type": "EQUALS"
-					},
-					"type": "boolean"
-				},
-				"enableGo": {
-					"default": true,
-					"description": "",
-					"displayName": "Go",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": "boolean"
-				},
-				"enableJava": {
-					"default": true,
-					"description": "",
-					"displayName": "Java",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": "boolean"
-				},
-				"enableJavaRuntime": {
-					"default": true,
-					"description": "",
-					"displayName": "Java runtimes",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"precondition": {
-						"expectedValue": true,
-						"property": "enableJava",
-						"type": "EQUALS"
-					},
-					"type": "boolean"
-				},
-				"enableKubernetes": {
-					"default": true,
-					"description": "",
-					"displayName": "Kubernetes",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": "boolean"
-				},
-				"enableNodeJs": {
-					"default": true,
-					"description": "",
-					"displayName": "Node.js",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": "boolean"
-				},
-				"enableNodeJsRuntime": {
-					"default": true,
-					"description": "",
-					"displayName": "Node.js runtimes",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"precondition": {
-						"expectedValue": true,
-						"property": "enableNodeJs",
-						"type": "EQUALS"
-					},
-					"type": "boolean"
-				},
-				"enablePhp": {
-					"default": true,
-					"description": "",
-					"displayName": "PHP",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": "boolean"
-				},
-				"enablePython": {
-					"default": true,
-					"description": "",
-					"displayName": "Python",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"type": "boolean"
-				},
-				"enablePythonRuntime": {
-					"default": true,
-					"description": "",
-					"displayName": "Python runtimes",
-					"documentation": "",
-					"maxObjects": 1,
-					"modificationPolicy": "DEFAULT",
-					"nullable": false,
-					"precondition": {
-						"expectedValue": true,
-						"property": "enablePython",
-						"type": "EQUALS"
-					},
-					"type": "boolean"
-				}
-			},
-			"summaryPattern": "",
-			"type": "object",
-			"version": "0",
-			"versionInfo": ""
-		}
-	},
-	"uiCustomization": {
-		"tabs": {
-			"groups": [
-				{
-					"displayName": "Third-party Vulnerability Analytics",
-					"properties": [
-						"enableRuntimeVulnerabilityDetection",
-						"enableResourceAttributeRules",
-						"globalMonitoringModeTPV",
-						"technologies"
-					]
-				},
-				{
-					"displayName": "Code-level Vulnerability Analytics",
-					"properties": [
-						"enableCodeLevelVulnerabilityDetection",
-						"globalMonitoringModeJava",
-						"globalMonitoringModeDotNet",
-						"globalMonitoringModeGo",
-						"globalMonitoringModeNodeJs"
-					]
-				}
-			]
-		}
-	},
-	"version": "3.10"
+  "dynatrace": "1",
+  "schemaId": "builtin:appsec.runtime-vulnerability-detection",
+  "displayName": "Vulnerability Analytics: General settings",
+  "description": "Automated [Runtime Vulnerability Analytics](https://dt-url.net/c010iio) helps you quickly and completely understand each detected vulnerability in your environment and how to remediate it, allowing you to prioritize which vulnerabilities to fix first. Note: Enabling Third-party or Code-level Vulnerability Analytics consumes Application Security units. For details, see the [Application Security Monitoring documentation](https://dt-url.net/wq031ql).",
+  "documentation": "",
+  "schemaGroups": [
+    "group:appsec.vulnerability-analytics",
+    "group:appsec"
+  ],
+  "version": "3.12",
+  "multiObject": false,
+  "maxObjects": 1,
+  "allowedScopes": [
+    "environment"
+  ],
+  "enums": {
+    "MonitoringModeTPV": {
+      "displayName": "MonitoringModeTPV",
+      "description": "",
+      "documentation": "",
+      "items": [
+        {
+          "value": "MONITORING_OFF",
+          "displayName": "Do not monitor",
+          "description": "Third-party vulnerabilities will not be monitored"
+        },
+        {
+          "value": "MONITORING_ON",
+          "displayName": "Monitor",
+          "description": "Third-party vulnerabilities will be monitored"
+        }
+      ],
+      "type": "enum"
+    },
+    "MonitoringMode": {
+      "displayName": "MonitoringMode",
+      "description": "",
+      "documentation": "",
+      "items": [
+        {
+          "value": "MONITORING_OFF",
+          "displayName": "Do not monitor",
+          "description": "Code-level vulnerabilities will be ignored "
+        },
+        {
+          "value": "MONITORING_ON",
+          "displayName": "Monitor",
+          "description": "Code-level vulnerabilities will be recorded"
+        }
+      ],
+      "type": "enum"
+    }
+  },
+  "types": {
+    "Technology": {
+      "version": "0",
+      "versionInfo": "",
+      "displayName": "Technology",
+      "summaryPattern": "",
+      "description": "",
+      "documentation": "",
+      "properties": {
+        "enableDotNet": {
+          "displayName": ".NET",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enableDotNetRuntime": {
+          "displayName": ".NET runtimes",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "precondition": {
+            "type": "EQUALS",
+            "property": "enableDotNet",
+            "expectedValue": true
+          },
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enableGo": {
+          "displayName": "Go",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enableJava": {
+          "displayName": "Java",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enableJavaRuntime": {
+          "displayName": "Java runtimes",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "precondition": {
+            "type": "EQUALS",
+            "property": "enableJava",
+            "expectedValue": true
+          },
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enableKubernetes": {
+          "displayName": "Kubernetes",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enableNodeJs": {
+          "displayName": "Node.js",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enableNodeJsRuntime": {
+          "displayName": "Node.js runtimes",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "precondition": {
+            "type": "EQUALS",
+            "property": "enableNodeJs",
+            "expectedValue": true
+          },
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enablePython": {
+          "displayName": "Python",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enablePythonRuntime": {
+          "displayName": "Python runtimes",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "precondition": {
+            "type": "EQUALS",
+            "property": "enablePython",
+            "expectedValue": true
+          },
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        },
+        "enablePhp": {
+          "displayName": "PHP",
+          "description": "",
+          "documentation": "",
+          "type": "boolean",
+          "nullable": false,
+          "maxObjects": 1,
+          "modificationPolicy": "DEFAULT",
+          "default": true
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "enableRuntimeVulnerabilityDetection": {
+      "displayName": "Enable Third-party Vulnerability Analytics",
+      "description": "",
+      "documentation": "",
+      "type": "boolean",
+      "nullable": false,
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT",
+      "default": false
+    },
+    "enableResourceAttributeRules": {
+      "displayName": "Enable new monitoring rules",
+      "description": "When new monitoring rules are enabled, classic rules are disabled. To re-enable classic rules, disable the new monitoring rules.",
+      "documentation": "",
+      "type": "boolean",
+      "nullable": true,
+      "metadata": {
+        "featureFlag": "com.compuware.EnableCaspResourceAttributesSettingsToggle.feature",
+        "maturity": "GENERAL_AVAILABILITY"
+      },
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT"
+    },
+    "globalMonitoringModeTPV": {
+      "displayName": "Global third-party vulnerability detection control",
+      "description": "Global third-party vulnerability detection control defines the default for all processes.",
+      "documentation": "",
+      "type": {
+        "$ref": "#/enums/MonitoringModeTPV"
+      },
+      "nullable": false,
+      "metadata": {
+        "sortItems": "disabled"
+      },
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT",
+      "default": "MONITORING_ON"
+    },
+    "technologies": {
+      "displayName": "Technologies",
+      "description": "Vulnerability Analytics can be enabled/disabled per supported technology.",
+      "documentation": "",
+      "type": {
+        "$ref": "#/types/Technology"
+      },
+      "nullable": false,
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT"
+    },
+    "enableCodeLevelVulnerabilityDetection": {
+      "displayName": "Enable Code-level Vulnerability Analytics",
+      "description": "",
+      "documentation": "",
+      "type": "boolean",
+      "nullable": false,
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT",
+      "default": false
+    },
+    "globalMonitoringModeJava": {
+      "displayName": "Global Java code-level vulnerability detection control",
+      "description": "Global Java code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
+      "documentation": "Code-level vulnerability detection for Java has been recently released as early access version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \"Java code-level vulnerability evaluation\" to get started.",
+      "type": {
+        "$ref": "#/enums/MonitoringMode"
+      },
+      "nullable": false,
+      "metadata": {
+        "sortItems": "disabled"
+      },
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT",
+      "default": "MONITORING_ON"
+    },
+    "globalMonitoringModeDotNet": {
+      "displayName": "Global .NET code-level vulnerability detection control",
+      "description": "Global .NET code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
+      "documentation": "Code-level vulnerability detection for .NET has been recently released as a preview version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \".NET code-level vulnerability evaluation\" to get started.",
+      "type": {
+        "$ref": "#/enums/MonitoringMode"
+      },
+      "nullable": false,
+      "metadata": {
+        "sortItems": "disabled"
+      },
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT",
+      "default": "MONITORING_OFF"
+    },
+    "globalMonitoringModeGo": {
+      "displayName": "Global Go code-level vulnerability detection control",
+      "description": "Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
+      "documentation": "Code-level vulnerability detection for Go has been recently released as a preview version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \"Go code-level vulnerability evaluation\" to get started.",
+      "type": {
+        "$ref": "#/enums/MonitoringMode"
+      },
+      "nullable": false,
+      "metadata": {
+        "sortItems": "disabled"
+      },
+      "maxObjects": 1,
+      "modificationPolicy": "DEFAULT",
+      "default": "MONITORING_OFF"
+    }
+  },
+  "uiCustomization": {
+    "tabs": {
+      "groups": [
+        {
+          "displayName": "Third-party Vulnerability Analytics",
+          "properties": [
+            "enableRuntimeVulnerabilityDetection",
+            "enableResourceAttributeRules",
+            "globalMonitoringModeTPV",
+            "technologies"
+          ]
+        },
+        {
+          "displayName": "Code-level Vulnerability Analytics",
+          "properties": [
+            "enableCodeLevelVulnerabilityDetection",
+            "globalMonitoringModeJava",
+            "globalMonitoringModeDotNet",
+            "globalMonitoringModeGo",
+            "globalMonitoringModeNodeJs"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/service.go
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "3.10"
+const SchemaVersion = "3.12"
 const SchemaID = "builtin:appsec.runtime-vulnerability-detection"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*runtimevulnerabilitydetection.Settings] {

--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings/settings.go
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings/settings.go
@@ -64,6 +64,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
 			Optional:    true, // nullable
+			Default:     "MONITORING_OFF",
 		},
 		"global_monitoring_mode_java": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
#### **Why** this PR?
Tests were failing and `terraform plan` showed changes after apply for the schemas  "dynatrace_attack_settings" and "dynatrace_vulnerability_settings". [Reference pipeline run that failed](https://github.com/dynatrace-oss/terraform-provider-dynatrace/actions/runs/17070026597/job/48396281970)

#### **What** has changed?
Adjusted a property for both of the schemas to have a default value. The property can't be `null` anymore.

#### **How** does it do it?
By adding a default value in the schema, and updating the `schema.json` and schema version

#### How is it **tested**?
Is tested. This PR fixes the test.

#### How does it affect **users**?
`terraform plan` won't show updates (e.g., `"OFF" => null`) after apply


#### Note for reviewers
The changes for the schemas look but because of different formatting (spaces and order) it's bigger. The current order/formatting is simply a copy&paste of the schema response.