### PR TITLE
Updated `dynatrace_credentials` destroy behavior

### DIFF
--- a/resources/generic.go
+++ b/resources/generic.go
@@ -492,6 +492,9 @@ func (me *Generic) Delete(ctx context.Context, d *schema.ResourceData, m any) di
 	err = service.Delete(ctx, d.Id())
 
 	if err != nil {
+		if restWarning, ok := err.(rest.Warning); ok {
+			return diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: restWarning.Message}}
+		}
 		if restError, ok := err.(rest.Error); ok {
 			if restError.Code == 404 {
 				d.SetId("")

--- a/templates/resources/credentials.md.tmpl
+++ b/templates/resources/credentials.md.tmpl
@@ -8,10 +8,11 @@ description: |-
 
 # dynatrace_credentials (Resource)
 
--> This resource requires the API token scopes **Read credential vault entries** (`credentialVault.read`) and **Write credential vault entries** (`credentialVault.write`)
+~> **Destroy Warning** Credentials **cannot be deleted** if they are still associated with active synthetic monitors.
+Terraform will proceed with the destroy operation, but the credential will **not** be removed if any associations remain. **Action Required:** Before destroying this resource, ensure the credential is removed from all associated monitors.
+If any monitors remain associated after destroy, you must manually remove those associations and delete the credential manually.
 
-~> **Note:** A credential vault entry can't be deleted if a synthetic monitor uses it. Therefore, the synthetic monitors are also deleted when the credential vault entry is deleted.
-If you want to keep the synthetic monitors, remove the credential vault entry reference from them first.
+-> This resource requires the API token scopes **Read credential vault entries** (`credentialVault.read`) and **Write credential vault entries** (`credentialVault.write`)
 
 ## Dynatrace Documentation
 


### PR DESCRIPTION
Discussed internally on changing the default behavior for `dynatrace_credentials` destroy based off of findings from #733.

Previously, the destroy operation would remove synthetic monitors associated with a credential to allow successful deletion. However, this approach could lead to unpredictable or unintended consequences, especially if the credential was used by monitors in other workspaces or configured directly in the UI.

To avoid introducing a breaking change, we decided the best approach is to ignore the specific error:
```
It is not possible to delete credential with ID: CREDENTIALS_VAULT-XXXXX as long as there are monitors assigned to it.
```
This change allows the destroy operation to succeed, even if the credential itself remains in the environment.

Therefore, users must ensure the credential is removed from all associated monitors before destroying this resource.
Alternatively, if any monitors remain associated after destroy, users must manually remove those associations and manually delete the credential.