### PR TITLE
fix(export): add validation to exporter to check if credentials are set

### DIFF
--- a/dynatrace/export/initialize.go
+++ b/dynatrace/export/initialize.go
@@ -177,7 +177,16 @@ func Initialize(cfgGetter config.Getter) (environment *Environment, err error) {
 
 	var credentials *rest.Credentials
 	configResult, _ := config.ProviderConfigureGeneric(context.Background(), cfgGetter)
-	if credentials, err = config.Credentials(configResult, config.CredValExport); err != nil {
+
+	dwValidationStrategy := config.CredValExport
+	for key, _ := range resArgs {
+		if strings.Contains(key, "iam") {
+			dwValidationStrategy = config.CredValExportIAM
+			break
+		}
+	}
+
+	if credentials, err = config.Credentials(configResult, dwValidationStrategy); err != nil {
 		return nil, err
 	}
 

--- a/dynatrace/export/initialize.go
+++ b/dynatrace/export/initialize.go
@@ -176,9 +176,8 @@ func Initialize(cfgGetter config.Getter) (environment *Environment, err error) {
 	}
 
 	var credentials *rest.Credentials
-
 	configResult, _ := config.ProviderConfigureGeneric(context.Background(), cfgGetter)
-	if credentials, err = config.Credentials(configResult, config.CredValNone); err != nil {
+	if credentials, err = config.Credentials(configResult, config.CredValExport); err != nil {
 		return nil, err
 	}
 

--- a/dynatrace/export/initialize.go
+++ b/dynatrace/export/initialize.go
@@ -180,7 +180,7 @@ func Initialize(cfgGetter config.Getter) (environment *Environment, err error) {
 
 	dwValidationStrategy := config.CredValExport
 	for key, _ := range resArgs {
-		if strings.Contains(key, "iam") {
+		if strings.Contains(key, "_iam_") {
 			dwValidationStrategy = config.CredValExportIAM
 			break
 		}

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -46,6 +46,7 @@ const (
 	CredValCluster
 	CredValAutomation
 	CredValNone
+	CredValExport
 )
 
 func validateCredentials(conf *ProviderConfiguration, CredentialValidation int) error {
@@ -95,6 +96,15 @@ func validateCredentials(conf *ProviderConfiguration, CredentialValidation int) 
 		if len(conf.Automation.EnvironmentURL) == 0 {
 			return fmt.Errorf(" No Environment URL for the Automation API has been specified. Use either the environment variable `DT_AUTOMATION_ENVIRONMENT_URL` or the configuration attribute `automation_env_url` of the provider for that")
 		}
+	case CredValExport:
+		if len(conf.EnvironmentURL) == 0 {
+			return fmt.Errorf(" No Environment URL has been specified. Use either the environment variable `DYNATRACE_ENV_URL` or the configuration attribute `dt_env_url` of the provider for that")
+		}
+
+		if len(conf.APIToken) == 0 && len(conf.Automation.PlatformToken) == 0 && validateCredentials(conf, CredValAutomation) != nil {
+			return fmt.Errorf(" No API Token, Platform Token, or OAuth client has been specified. More detailed information can be found in the documentation at https://registry.terraform.io/providers/dynatrace-oss/dynatrace/latest/docs#configure-the-dynatrace-provider")
+		}
+
 	}
 	return nil
 }

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -47,6 +47,7 @@ const (
 	CredValAutomation
 	CredValNone
 	CredValExport
+	CredValExportIAM
 )
 
 func validateCredentials(conf *ProviderConfiguration, CredentialValidation int) error {
@@ -100,11 +101,15 @@ func validateCredentials(conf *ProviderConfiguration, CredentialValidation int) 
 		if len(conf.EnvironmentURL) == 0 {
 			return fmt.Errorf(" No Environment URL has been specified. Use either the environment variable `DYNATRACE_ENV_URL` or the configuration attribute `dt_env_url` of the provider for that")
 		}
-
 		if len(conf.APIToken) == 0 && len(conf.Automation.PlatformToken) == 0 && validateCredentials(conf, CredValAutomation) != nil {
-			return fmt.Errorf(" No API Token, Platform Token, or OAuth client has been specified. More detailed information can be found in the documentation at https://registry.terraform.io/providers/dynatrace-oss/dynatrace/latest/docs#configure-the-dynatrace-provider")
+			return fmt.Errorf(" No API Token, Platform Token, or OAuth has been specified for export. More detailed information can be found in the documentation at https://registry.terraform.io/providers/dynatrace-oss/dynatrace/latest/docs#configure-the-dynatrace-provider")
+		}
+	case CredValExportIAM:
+		if conf.IAM.AccountID == "" {
+			return fmt.Errorf(" No Account ID has been specified for export IAM validation")
 		}
 
+		return validateCredentials(conf, CredValExport)
 	}
 	return nil
 }


### PR DESCRIPTION
#### **Why** this PR?
Exporting with not set credentials(missconfigured) ended in an unclear log.
```
The environment variable DYNATRACE_TARGET_FOLDER has not been set - using folder 'configuration' as default
Downloading "dynatrace_custom_service_order" Count:  1  
Downloading "dynatrace_direct_share" Count:  0  
Downloading "dynatrace_host_naming_order" Count:  1  
Downloading "dynatrace_oneagent_default_version" Count:  0  
Downloading "dynatrace_openpipeline_business_events" Count:  1  
Downloading "dynatrace_openpipeline_davis_problems" Count:  1  
Downloading "dynatrace_openpipeline_davis_events" Count:  1  
Downloading "dynatrace_openpipeline_metrics" Count:  1  
Downloading "dynatrace_openpipeline_system_events" Count:  1  
Downloading "dynatrace_openpipeline_events" Count:  1  
Downloading "dynatrace_openpipeline_logs" Count:  1  
Downloading "dynatrace_openpipeline_sdlc_events" Count:  1  
Downloading "dynatrace_openpipeline_user_sessions" Count:  1  
Downloading "dynatrace_openpipeline_security_events" Count:  1  
Downloading "dynatrace_openpipeline_spans" Count:  1  
Downloading "dynatrace_openpipeline_user_events" Count:  1  
Downloading "dynatrace_processgroup_naming_order" Count:  1  
Downloading "dynatrace_request_namings" Count:  1  
Downloading "dynatrace_service_naming_order" Count:  1  
Post-Processing Resources ...
Post-Processing Resources - Group child configs with parent configs ...
Finishing touches ...
Writing ___resources___.tf
Writing ___datasources___.tf
Writing main.tf
Writing ___variables___.tf
Writing main ___providers___.tf
Writing modules ___providers___.tf
Remove Non-Referenced Modules ...
Finish Export ...
Terraform executable path:  /opt/homebrew/bin/terraform
Executing 'terraform init'
... finished after 0 seconds
```
From this log, it's unclear whether anything was able to be exported.

#### **What** has changed?
A new credentials type validation, `CredValExport,` is added specifically for export to keep compatibility with other code.

#### **How** does it do it?
Check if the values are set. No specific validation of the validity of strings.

#### How is it **tested**?
No tests where added, manual tested.

#### How does it affect **users**?
Yes, in the future, if the export command is not finding credentials, the user will be presented with a message that points to the problem.
```
The environment variable DYNATRACE_TARGET_FOLDER has not been set - using folder 'configuration' as default
... finished after 0 seconds
 No API Token, Platform Token, or OAuth client has been specified. More detailed information can be found in the documentation at https://registry.terraform.io/providers/dynatrace-oss/dynatrace/latest/docs#configure-the-dynatrace-provider
```

**Issue:**
