### PR TITLE
feat(openpipeline): Improvements for ingest-source HCL handling

### DIFF
--- a/dynatrace/api/builtin/openpipeline/common.go
+++ b/dynatrace/api/builtin/openpipeline/common.go
@@ -1,0 +1,9 @@
+package openpipeline
+
+func RemoveNils(m map[string]interface{}) {
+	for a := range m {
+		if m[a] == nil {
+			delete(m, a)
+		}
+	}
+}

--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -107,31 +108,18 @@ func (is *IngestSource) Schema() map[string]*schema.Schema {
 }
 
 func (is *IngestSource) MarshalHCL(properties hcl.Properties) error {
-	if err := properties.EncodeAll(map[string]any{
-		"kind":         is.Kind,
-		"enabled":      is.Enabled,
-		"display_name": is.DisplayName,
-		"path_segment": is.PathSegment,
-	}); err != nil {
-		return err
-	}
-	if is.DefaultBucket != nil {
-		if err := properties.Encode("default_bucket", is.DefaultBucket); err != nil {
-			return err
-		}
-	}
-	if is.StaticRouting != nil {
-		if err := properties.Encode("static_routing", is.StaticRouting); err != nil {
-			return err
-		}
-	}
-	if is.Processing != nil && len(is.Processing.Processors) > 0 {
-		if err := properties.Encode("processing", is.Processing); err != nil {
-			return err
-		}
-	}
+	err := properties.EncodeAll(map[string]any{
+		"kind":           is.Kind,
+		"enabled":        is.Enabled,
+		"display_name":   is.DisplayName,
+		"path_segment":   is.PathSegment,
+		"default_bucket": is.DefaultBucket,
+		"static_routing": is.StaticRouting,
+		"processing":     is.Processing,
+	})
+	openpipeline.RemoveNils(properties)
 
-	return nil
+	return err
 }
 
 func (is *IngestSource) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source.go
@@ -151,7 +151,7 @@ func (p *Processing) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"processor": {
 			Type:        schema.TypeList,
-			Description: "One processor",
+			Description: "Groups all processors applicable for processing in the ingest-source.\nApplicable processors types are dql, fieldsAdd, fieldsRemove, fieldsRename, and drop",
 			Elem:        &schema.Resource{Schema: new(processors.Processor).Schema()},
 			Required:    true,
 		},

--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source_test.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/ingest_source_test.go
@@ -120,6 +120,24 @@ func TestIngestSource_MarshalHCL(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty-processors are not encoded",
+			input: settings.IngestSource{
+				Kind:        "events",
+				DisplayName: "displayName",
+				PathSegment: "my.path.segment",
+				Enabled:     true,
+				Processing: &settings.Processing{
+					Processors: []*processors.Processor{},
+				},
+			},
+			expected: hcl.Properties{
+				"kind":         "events",
+				"display_name": "displayName",
+				"enabled":      true,
+				"path_segment": "my.path.segment",
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/dynatrace/api/builtin/openpipeline/ingestsource/settings/pipeline_reference.go
+++ b/dynatrace/api/builtin/openpipeline/ingestsource/settings/pipeline_reference.go
@@ -18,6 +18,7 @@
 package settings
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -56,25 +57,14 @@ func (pr *PipelineReference) Schema(prefix string) map[string]*schema.Schema {
 }
 
 func (pr *PipelineReference) MarshalHCL(properties hcl.Properties) error {
-	err := properties.Encode("pipeline_type", pr.PipelineType)
-	if err != nil {
-		return err
-	}
+	err := properties.EncodeAll(map[string]any{
+		"pipeline_type":       pr.PipelineType,
+		"pipeline_id":         pr.PipelineID,
+		"builtin_pipeline_id": pr.BuiltinPipelineID,
+	})
+	openpipeline.RemoveNils(properties)
 
-	if pr.PipelineID != nil {
-		err = properties.Encode("pipeline_id", pr.PipelineID)
-		if err != nil {
-			return err
-		}
-	}
-
-	if pr.BuiltinPipelineID != nil {
-		err = properties.Encode("builtin_pipeline_id", pr.BuiltinPipelineID)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return err
 }
 
 func (pr *PipelineReference) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/processors/processor.go
+++ b/dynatrace/api/builtin/openpipeline/processors/processor.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -166,54 +167,20 @@ func (p *Processor) Schema() map[string]*schema.Schema {
 
 func (p *Processor) MarshalHCL(properties hcl.Properties) error {
 	err := properties.EncodeAll(map[string]any{
-		"enabled":     p.Enabled,
-		"id":          p.Id,
-		"type":        p.Type,
-		"description": p.Description,
+		"enabled":       p.Enabled,
+		"id":            p.Id,
+		"type":          p.Type,
+		"description":   p.Description,
+		"sample_data":   p.SampleData,
+		"matcher":       p.Matcher,
+		"dql":           p.Dql,
+		"fields_add":    p.FieldsAdd,
+		"fields_rename": p.FieldsRename,
+		"fields_remove": p.FieldsRemove,
 	})
+	openpipeline.RemoveNils(properties)
 
-	if err != nil {
-		return err
-	}
-
-	if p.SampleData != nil {
-		err = properties.Encode("sample_data", p.SampleData)
-		if err != nil {
-			return err
-		}
-	}
-	if p.Matcher != nil {
-		err = properties.Encode("matcher", p.Matcher)
-		if err != nil {
-			return err
-		}
-	}
-	if p.Dql != nil {
-		err = properties.Encode("dql", p.Dql)
-		if err != nil {
-			return err
-		}
-	}
-	if p.FieldsAdd != nil {
-		err = properties.Encode("fields_add", p.FieldsAdd)
-		if err != nil {
-			return err
-		}
-	}
-	if p.FieldsRename != nil {
-		err = properties.Encode("fields_rename", p.FieldsRename)
-		if err != nil {
-			return err
-		}
-	}
-	if p.FieldsRemove != nil {
-		err = properties.Encode("fields_remove", p.FieldsRemove)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return err
 }
 
 func (p *Processor) UnmarshalHCL(decoder hcl.Decoder) error {


### PR DESCRIPTION
#### **Why** this PR?
This is a follow-up to #751 introducing some improvements that were discussed on the original PR.

#### **What** has changed and **How**?

- Nil-values in MarshalHCL: Instead of checking for each field individually, all properties are encoded using `EncodeAll` and nil-values are removed afterwards.
- Descriptions: The description of the `processor` list is improved.

#### How is it **tested**?
Existing tests for marshalling HCL still work. 

#### How does it affect **users**?
It doesn't

**Issue:**
CA-15750