### PR TITLE
feat(openpipeline): adds pipeline HCL schema and examples

### DIFF
--- a/dynatrace/api/builtin/openpipeline/pipeline/settings/pipeline.go
+++ b/dynatrace/api/builtin/openpipeline/pipeline/settings/pipeline.go
@@ -1,0 +1,230 @@
+package settings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var AllowedKinds = []string{
+	"logs", "events", "events.security", "security.events", "bizevents", "spans",
+	"events.sdlc", "metrics", "usersessions", "davis.problems", "davis.events",
+	"system.events", "azure.logs.forwarding", "user.events",
+}
+
+type Pipeline struct {
+	Kind              string `json:"-"`
+	CustomID          string `json:"customId"`
+	DisplayName       string `json:"displayName"`
+	Processing        *Stage `json:"processing,omitempty"`
+	SecurityContext   *Stage `json:"securityContext,omitempty"`
+	CostAllocation    *Stage `json:"costAllocation,omitempty"`
+	ProductAllocation *Stage `json:"productAllocation,omitempty"`
+	Storage           *Stage `json:"storage,omitempty"`
+	MetricExtraction  *Stage `json:"metricExtraction,omitempty"`
+	Davis             *Stage `json:"davis,omitempty"`
+	DataExtraction    *Stage `json:"dataExtraction,omitempty"`
+}
+
+const DisplayNameMaxLength = 500
+const CustomIDMinLength = 4
+const CustomIDMaxLength = 100
+
+func (p *Pipeline) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"kind": {
+			Type:         schema.TypeString,
+			Required:     true,
+			Description:  "Indicates OpenPipeline data source",
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(AllowedKinds, true),
+		},
+		"custom_id": {
+			Type:        schema.TypeString,
+			Description: "The ID of the pipeline. Must not start with 'dt.' or 'dynatrace.'",
+			Required:    true,
+			ValidateFunc: validation.All(
+				validation.StringLenBetween(CustomIDMinLength, CustomIDMaxLength),
+				func(input interface{}, schema string) (warnings []string, errors []error) {
+					id, ok := input.(string)
+
+					// Schema has "NO_WHITESPACE" validation which is missing here.
+					if !ok {
+						errors = append(errors, fmt.Errorf("expected type of %s to be string", schema))
+						return warnings, errors
+					}
+
+					if strings.HasPrefix(id, "dt.") || strings.HasPrefix(id, "dynatrace.") {
+						errors = append(errors,
+							fmt.Errorf("%s must not start with 'dt.' or 'dynatrace.'", schema))
+					}
+					return warnings, errors
+				}),
+		},
+		"display_name": {
+			Type:         schema.TypeString,
+			Description:  "Display name of the pipeline",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(1, DisplayNameMaxLength),
+		},
+		"processing": {
+			Type:        schema.TypeList,
+			Description: "Processing stage",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			Optional:    true,
+		},
+		"security_context": {
+			Type:        schema.TypeList,
+			Description: "Security context stage",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			Optional:    true,
+		},
+		"cost_allocation": {
+			Type:        schema.TypeList,
+			Description: "Cost allocation stage",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			Optional:    true,
+		},
+		"product_allocation": {
+			Type:        schema.TypeList,
+			Description: "Product allocation stage",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			Optional:    true,
+		},
+		"storage": {
+			Type:        schema.TypeList,
+			Description: "Storage stage",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			Optional:    true,
+		},
+		"metric_extraction": {
+			Type:        schema.TypeList,
+			Description: "Metrics extraction stage",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			Optional:    true,
+		},
+		"davis": {
+			Type:        schema.TypeList,
+			Description: "Davis event extraction stage",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			Optional:    true,
+		},
+		"data_extraction": {
+			Type:        schema.TypeList,
+			Description: "Data extraction stage",
+			MinItems:    1,
+			MaxItems:    1,
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			Optional:    true,
+		},
+	}
+}
+
+func (p *Pipeline) MarshalHCL(properties hcl.Properties) error {
+	err := properties.EncodeAll(map[string]any{
+		"kind":               p.Kind,
+		"custom_id":          p.CustomID,
+		"display_name":       p.DisplayName,
+		"processing":         p.Processing,
+		"security_context":   p.SecurityContext,
+		"cost_allocation":    p.CostAllocation,
+		"product_allocation": p.ProductAllocation,
+		"storage":            p.Storage,
+		"metric_extraction":  p.MetricExtraction,
+		"davis":              p.Davis,
+		"data_extraction":    p.DataExtraction,
+	})
+	openpipeline.RemoveNils(properties)
+
+	return err
+}
+
+func (p *Pipeline) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"kind":               &p.Kind,
+		"custom_id":          &p.CustomID,
+		"display_name":       &p.DisplayName,
+		"processing":         &p.Processing,
+		"security_context":   &p.SecurityContext,
+		"cost_allocation":    &p.CostAllocation,
+		"product_allocation": &p.ProductAllocation,
+		"storage":            &p.Storage,
+		"metric_extraction":  &p.MetricExtraction,
+		"davis":              &p.Davis,
+		"data_extraction":    &p.DataExtraction,
+	})
+}
+
+func (p *Pipeline) MarshalJSON() ([]byte, error) {
+	var temp = *p
+	// The API expects the following fields to be non-nil
+	if temp.Processing == nil {
+		temp.Processing = &Stage{}
+	}
+	if temp.SecurityContext == nil {
+		temp.SecurityContext = &Stage{}
+	}
+	if temp.CostAllocation == nil {
+		temp.CostAllocation = &Stage{}
+	}
+	if temp.ProductAllocation == nil {
+		temp.ProductAllocation = &Stage{}
+	}
+	if temp.Storage == nil {
+		temp.Storage = &Stage{}
+	}
+	if temp.MetricExtraction == nil {
+		temp.MetricExtraction = &Stage{}
+	}
+	if temp.Davis == nil {
+		temp.Davis = &Stage{}
+	}
+	if temp.DataExtraction == nil {
+		temp.DataExtraction = &Stage{}
+	}
+
+	return json.Marshal(temp)
+}
+
+type Stage struct {
+	Processors []*processors.Processor `json:"processors,omitempty"`
+}
+
+func (s *Stage) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"processor": {
+			Type:        schema.TypeList,
+			Description: "Groups all processors of the stage",
+			Elem:        &schema.Resource{Schema: new(processors.Processor).Schema()},
+			Required:    true,
+		},
+	}
+}
+
+func (s *Stage) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("processor", s.Processors)
+}
+
+func (s *Stage) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("processor", &s.Processors)
+}

--- a/dynatrace/api/builtin/openpipeline/pipeline/settings/pipeline_test.go
+++ b/dynatrace/api/builtin/openpipeline/pipeline/settings/pipeline_test.go
@@ -1,0 +1,400 @@
+package settings_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/pipeline/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/processors"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var minimalPipeline = settings.Pipeline{
+	Kind:        "events",
+	CustomID:    "customId",
+	DisplayName: "displayName",
+}
+
+var sampleData = "sampleData"
+var matcher = "not true"
+var pipelineWithProcessor = settings.Pipeline{
+	Kind:        "events",
+	CustomID:    "customId",
+	DisplayName: "displayName",
+	Processing: &settings.Stage{
+		Processors: []*processors.Processor{
+			{
+				Enabled:     true,
+				Id:          "proc-2",
+				Type:        processors.DqlProcessorType,
+				Description: "my-proc-2",
+				SampleData:  &sampleData,
+				Matcher:     &matcher,
+				Dql:         &processors.DqlAttributes{Script: "fieldsAdd true"},
+			},
+		},
+	},
+}
+
+func TestPipeline_MarshalHCL(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    settings.Pipeline
+		expected hcl.Properties
+	}{
+		{
+			name:  "minimum-set",
+			input: minimalPipeline,
+			expected: hcl.Properties{
+				"kind":         "events",
+				"custom_id":    "customId",
+				"display_name": "displayName",
+			},
+		},
+		{
+			name:  "all-set",
+			input: pipelineWithProcessor,
+			expected: hcl.Properties{
+				"kind":         "events",
+				"custom_id":    "customId",
+				"display_name": "displayName",
+				"processing": []interface{}{
+					hcl.Properties{
+						"processor": []interface{}{
+							hcl.Properties{
+								"enabled":     true,
+								"id":          "proc-2",
+								"type":        processors.DqlProcessorType,
+								"description": "my-proc-2",
+								"sample_data": sampleData,
+								"matcher":     matcher,
+								"dql": []interface{}{
+									hcl.Properties{
+										"script": "fieldsAdd true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual = hcl.Properties{}
+			err := tc.input.MarshalHCL(actual)
+			assert.Equal(t, tc.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestPipeline_UnmarshalHCL(t *testing.T) {
+	s := new(settings.Pipeline).Schema()
+
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected settings.Pipeline
+	}{
+		{
+			name: "minimal fields set",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"custom_id":    "customId",
+				"display_name": "displayName",
+			},
+			expected: minimalPipeline,
+		},
+		{
+			name: "all fields set",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"custom_id":    "customId",
+				"display_name": "displayName",
+				"processing": []interface{}{
+					map[string]interface{}{
+						"processor": []interface{}{
+							map[string]interface{}{
+								"enabled":     true,
+								"id":          "proc-2",
+								"type":        processors.DqlProcessorType,
+								"description": "my-proc-2",
+								"sample_data": sampleData,
+								"matcher":     matcher,
+								"dql": []interface{}{
+									map[string]interface{}{
+										"script": "fieldsAdd true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: pipelineWithProcessor,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			assert.NotNil(t, d)
+
+			var actual settings.Pipeline
+			decoder := hcl.DecoderFrom(d)
+			err := actual.UnmarshalHCL(decoder)
+			assert.Equal(t, c.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestIngestSource_MarshalJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    settings.Pipeline
+		expected []byte
+	}{
+		{
+			name:  "minimal-fields-set",
+			input: minimalPipeline,
+			expected: []byte( // The API demands that "processing" is present, even if it is null, so that seems correct.
+				`{
+					"customId": "customId",
+					"displayName": "displayName",
+					"processing": {},
+					"securityContext": {},
+					"costAllocation": {},
+					"productAllocation": {},
+					"storage": {},
+					"metricExtraction": {},
+					"davis": {},
+					"dataExtraction": {}
+				}`),
+		},
+		{
+			name:  "pipeline-with-processor",
+			input: pipelineWithProcessor,
+			expected: []byte(
+				`{
+					"customId": "customId",
+					"displayName": "displayName",
+					"processing": {
+						"processors": [
+							{
+								"id": "proc-2",
+								"type": "dql",
+								"matcher": "not true",
+								"description": "my-proc-2",
+								"sampleData": "sampleData",
+								"enabled": true,
+								"dql": {
+									"script": "fieldsAdd true"
+								}
+							}
+						]
+					},
+					"securityContext": {},
+					"costAllocation": {},
+					"productAllocation": {},
+					"storage": {},
+					"metricExtraction": {},
+					"davis": {},
+					"dataExtraction": {}
+				}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.input.MarshalJSON()
+			require.NoError(t, err)
+
+			var actualJSON map[string]interface{}
+			err = json.Unmarshal(actual, &actualJSON)
+			require.NoError(t, err)
+
+			var expectedJSON map[string]interface{}
+			err = json.Unmarshal(tc.expected, &expectedJSON)
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedJSON, actualJSON)
+		})
+	}
+}
+
+func TestIngestSource_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"custom_id":    "customId",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with 1 processor set",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"custom_id":    "customId",
+				"display_name": "displayName",
+				"processing": []interface{}{
+					map[string]interface{}{
+						"processor": []interface{}{
+							map[string]interface{}{
+								"enabled":     true,
+								"id":          "proc-2",
+								"type":        processors.DqlProcessorType,
+								"description": "my-proc-2",
+								"sample_data": sampleData,
+								"matcher":     matcher,
+								"dql": []interface{}{
+									map[string]interface{}{
+										"script": "fieldsAdd true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "kind missing",
+			input: map[string]interface{}{
+				"display_name": "displayName",
+				"custom_id":    "customId",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "kind invalid",
+			input: map[string]interface{}{
+				"kind":         "invalid",
+				"display_name": "displayName",
+				"custom_id":    "customId",
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("expected kind to be one of %q, got invalid", settings.AllowedKinds),
+		},
+		{
+			name: "display_name missing",
+			input: map[string]interface{}{
+				"kind":      "events",
+				"custom_id": "customId",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "display_name present but blank",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "",
+				"custom_id":    "customId",
+			},
+			wantErr: true,
+			errMsg:  "expected length of display_name to be in the range (1 - 500), got ",
+		},
+		{
+			name: "display_name too long",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": strings.Repeat("a", settings.DisplayNameMaxLength+1),
+				"custom_id":    "customId",
+			},
+			wantErr: true,
+			errMsg:  "expected length of display_name to be in the range (1 - 500), got " + strings.Repeat("a", settings.DisplayNameMaxLength+1),
+		},
+		{
+			name: "custom_id missing",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "custom_id present but blank",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"custom_id":    "",
+			},
+			wantErr: true,
+			errMsg:  "expected length of custom_id to be in the range (4 - 100), got ",
+		},
+		{
+			name: "custom_id too short",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"custom_id":    strings.Repeat("a", settings.CustomIDMinLength-1),
+			},
+			wantErr: true,
+			errMsg:  "expected length of custom_id to be in the range (4 - 100), got " + strings.Repeat("a", settings.CustomIDMinLength-1),
+		},
+		{
+			name: "custom_id too long",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"custom_id":    strings.Repeat("a", settings.CustomIDMaxLength+1),
+			},
+			wantErr: true,
+			errMsg:  "expected length of custom_id to be in the range (4 - 100), got " + strings.Repeat("a", settings.CustomIDMaxLength+1),
+		},
+		{
+			name: "custom_id starts with dt. ",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"custom_id":    "dt.customId",
+			},
+			wantErr: true,
+			errMsg:  "custom_id must not start with 'dt.' or 'dynatrace.'",
+		},
+		{
+			name: "custom_id starts with dynatrace. ",
+			input: map[string]interface{}{
+				"kind":         "events",
+				"display_name": "displayName",
+				"custom_id":    "dynatrace.customId",
+			},
+			wantErr: true,
+			errMsg:  "custom_id must not start with 'dt.' or 'dynatrace.'",
+		},
+	}
+
+	r := &schema.Resource{Schema: new(settings.Pipeline).Schema()}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}

--- a/dynatrace/api/builtin/openpipeline/pipeline/testdata/json/example.json
+++ b/dynatrace/api/builtin/openpipeline/pipeline/testdata/json/example.json
@@ -1,0 +1,102 @@
+{
+  "customId": "pipeline_id",
+  "displayName": "pipeline-with-processor",
+  "processing": {
+    "processors": [
+      {
+        "id": "proc-1",
+        "type": "drop",
+        "matcher": "not true",
+        "description": "my-proc-1",
+        "sampleData": "sampleData",
+        "enabled": true
+      },
+      {
+        "id": "proc-2",
+        "type": "dql",
+        "matcher": "not true",
+        "description": "my-proc-2",
+        "sampleData": "sampleData",
+        "enabled": true,
+        "dql": {
+          "script": "fieldsAdd true"
+        }
+      },
+      {
+        "id": "proc-3",
+        "type": "fieldsAdd",
+        "matcher": "not true",
+        "description": "my-proc-3",
+        "sampleData": "sampleData",
+        "enabled": true,
+        "fieldsAdd": {
+          "fields": [
+            {
+              "name": "some-name",
+              "value": "some-value"
+            },
+            {
+              "name": "some-other-name",
+              "value": "some-other-value"
+            }
+          ]
+        }
+      },
+      {
+        "id": "proc-4",
+        "type": "fieldsRename",
+        "matcher": "not true",
+        "description": "my-proc-4",
+        "sampleData": "sampleData",
+        "enabled": true,
+        "fieldsRename": {
+          "fields": [
+            {
+              "fromName": "from-name",
+              "toName": "to-name"
+            },
+            {
+              "fromName": "from-other-name",
+              "toName": "to-other-name"
+            }
+          ]
+        }
+      },
+      {
+        "id": "proc-5",
+        "type": "fieldsRemove",
+        "matcher": "not true",
+        "description": "my-proc-5",
+        "sampleData": "sampleData",
+        "enabled": true,
+        "fieldsRemove": {
+          "fields": [
+            "to-remove-1",
+            "to-remove-2"
+          ]
+        }
+      }
+    ]
+  },
+  "securityContext": {
+    "processors": []
+  },
+  "costAllocation": {
+    "processors": []
+  },
+  "productAllocation": {
+    "processors": []
+  },
+  "storage": {
+    "processors": []
+  },
+  "metricExtraction": {
+    "processors": []
+  },
+  "davis": {
+    "processors": []
+  },
+  "dataExtraction": {
+    "processors": []
+  }
+}

--- a/dynatrace/api/builtin/openpipeline/pipeline/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/pipeline/testdata/terraform/example.tf
@@ -1,0 +1,73 @@
+resource "dynatrace_openpipeline_v2_pipeline" "pipeline" {
+  kind = "events"
+  display_name = "pipeline-with-processor"
+  custom_id = "pipeline_id"
+  processing {
+    processor {
+      type        = "drop"
+      enabled     = true
+      id          = "proc-1"
+      description = "my-proc-1"
+      sample_data = "my sample data"
+      matcher     = "not true"
+    }
+    processor {
+      type        = "dql"
+      enabled     = true
+      id          = "proc-2"
+      description = "my-proc-2"
+      sample_data = "my sample data"
+      matcher     = "not true"
+      dql {
+        script = "fieldsAdd true"
+      }
+    }
+    processor {
+      type        = "fieldsAdd"
+      enabled     = true
+      id          = "proc-3"
+      description = "my-proc-3"
+      sample_data = "my sample data"
+      matcher     = "not true"
+      fields_add {
+        field {
+          name = "some-name"
+          value = "some-value"
+        }
+        field {
+          name = "some-other-name"
+          value = "some-other-value"
+        }
+      }
+    }
+    processor {
+      type        = "fieldsRename"
+      enabled     = true
+      id          = "proc-4"
+      description = "my-proc-4"
+      sample_data = "my sample data"
+      matcher     = "not true"
+      fields_rename {
+        field {
+          from_name = "from-name"
+          to_name = "to-name"
+        }
+        field {
+          from_name = "from-other-name"
+          to_name = "to-other-name"
+        }
+      }
+    }
+    processor {
+      type        = "fieldsRemove"
+      enabled     = true
+      id          = "proc-5"
+      description = "my-proc-5"
+      sample_data = "my sample data"
+      matcher     = "not true"
+      fields_remove {
+        fields = ["to-remove-1", "to-remove-2"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
This PR adds HCL handling for the OpenPipeline pipeline settings schemas.

#### **What** has changed?

A `Pipeline` schema and HCL marshalling logic, including some validation and tests, have been added. Examples are added as well.

#### **How** does it do it?
The example and the tests could be further improved in follow-ups. Currently, only the `processing` stage is used in tests and examples. The reason for this is that the processors required by the other stages are not yet implemented in the `processors` package.

#### How is it **tested**?
Tests are included.

#### How does it affect **users**?
Currently, it doesn't.

**Issue:**
CA-15946
