### PR TITLE
chore: deprecate old openpipeline resource

### DIFF
--- a/dynatrace/api/openpipeline/settings/configuration.go
+++ b/dynatrace/api/openpipeline/settings/configuration.go
@@ -18,6 +18,10 @@ type Configuration struct {
 	Routing        *RoutingTable `json:"routing"`
 }
 
+func (me *Configuration) Deprecated() string {
+	return "This resource API endpoint has been deprecated, please migrate your openpipeline configurations and use `dynatrace_openpipeline_v2_*` instead."
+}
+
 func (d *Configuration) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"endpoints": {


### PR DESCRIPTION
#### **Why** this PR?
Because of the new dynatrace_openpipeline_v2_* resources, the old one is deprecated and should not be used anymore

#### **What** has changed?
The old resource now prints a warning, when used.
<img width="1187" height="417" alt="image" src="https://github.com/user-attachments/assets/87542ba8-7211-44c3-977c-6e593aabf8b6" />

#### **How** does it do it?
By adding a deprecation notice to the resource.

#### How is it **tested**?

#### How does it affect **users**?
They get a deprecation notice when using the old resource.

**Issue:** CA-15951
