### PR TITLE
feat(openpipeline): Routing resource

### DIFF
--- a/dynatrace/api/builtin/openpipeline/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/routing/service.go
@@ -1,0 +1,165 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package routing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	routing "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/routing/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+)
+
+const SchemaFormat = "builtin:openpipeline.%s.routing"
+
+var SchemaRegex = regexp.MustCompile("^builtin:openpipeline.(.*?).routing$")
+
+func Service(credentials *rest.Credentials) settings.CRUDService[*routing.Routing] {
+	return &ServiceImpl{Credentials: credentials}
+}
+
+type SettingsObject struct {
+	SchemaID string          `json:"schemaId"`
+	Value    json.RawMessage `json:"value"`
+}
+
+type GenericSettingsClient interface {
+	Get(ctx context.Context, id string) (settings20.Response, error)
+	Delete(ctx context.Context, id string) (settings20.Response, error)
+}
+
+type SettingsClientForKind interface {
+	List(ctx context.Context) (api.Stubs, error)
+	Create(ctx context.Context, v *routing.Routing) (*api.Stub, error)
+	Update(ctx context.Context, id string, v *routing.Routing) error
+}
+
+type ServiceImpl struct {
+	Credentials            *rest.Credentials
+	GenericSettingsClient  GenericSettingsClient
+	SettingsClientsPerKind map[string]SettingsClientForKind
+}
+
+func (si *ServiceImpl) getClient(ctx context.Context) GenericSettingsClient {
+	if si.GenericSettingsClient == nil {
+		tokenClient, _ := rest.CreateClassicClient(si.Credentials.URL, si.Credentials.Token)
+		oauthClient, _ := rest.CreateClassicOAuthBasedClient(ctx, si.Credentials)
+		si.GenericSettingsClient = settings20.NewClient(tokenClient, oauthClient, "")
+	}
+
+	return si.GenericSettingsClient
+}
+
+func (si *ServiceImpl) getClientForKind(kind string) SettingsClientForKind {
+	if si.SettingsClientsPerKind == nil {
+		si.SettingsClientsPerKind = make(map[string]SettingsClientForKind)
+	}
+
+	client, ok := si.SettingsClientsPerKind[kind]
+	if ok && client != nil {
+		return client
+	}
+
+	client = settings20.Service[*routing.Routing](si.Credentials, fmt.Sprintf(SchemaFormat, kind), "")
+	si.SettingsClientsPerKind[kind] = client
+	return client
+}
+
+func (si *ServiceImpl) parseKindFromSchemaID(schemaID string) (kind string, found bool) {
+	res := SchemaRegex.FindStringSubmatch(schemaID)
+	if res == nil {
+		return "", false
+	}
+
+	return res[1], true
+}
+
+func (si *ServiceImpl) Get(ctx context.Context, objectID string, v *routing.Routing) error {
+	var response settings20.Response
+	var settingsObject SettingsObject
+
+	response, err := si.getClient(ctx).Get(ctx, objectID)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != 200 {
+		if err = rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
+			return err
+		}
+		return fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
+	}
+	if err = json.Unmarshal(response.Data, &settingsObject); err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(settingsObject.Value, v); err != nil {
+		return err
+	}
+
+	kind, ok := si.parseKindFromSchemaID(settingsObject.SchemaID)
+	if !ok {
+		return fmt.Errorf("could not parse kind from schema id '%s'", settingsObject.SchemaID)
+	}
+
+	v.Kind = kind
+	return nil
+}
+
+func (si *ServiceImpl) List(ctx context.Context) (api.Stubs, error) {
+	var stubs api.Stubs
+	stubs = make(api.Stubs, 0)
+	var errs []error
+	for _, kind := range routing.AllowedKinds {
+		client := si.getClientForKind(kind)
+		res, err := client.List(ctx)
+
+		errs = append(errs, err)
+		stubs = append(stubs, res...)
+	}
+
+	if len(errs) > 0 {
+		return stubs, errors.Join(errs...)
+	}
+	return stubs, nil
+}
+
+func (si *ServiceImpl) Create(ctx context.Context, v *routing.Routing) (*api.Stub, error) {
+	return si.getClientForKind(v.Kind).Create(ctx, v)
+}
+
+// Update will not be called if "kind" changes, because of ForceNew: true
+// Therefore we do not need to care about changes in "kind" here, which would otherwise
+// entail a settings deletion and re-creation
+func (si *ServiceImpl) Update(ctx context.Context, id string, v *routing.Routing) error {
+	return si.getClientForKind(v.Kind).Update(ctx, id, v)
+}
+
+func (si *ServiceImpl) Delete(ctx context.Context, id string) error {
+	_, err := si.getClient(ctx).Delete(ctx, id)
+	return err
+}
+
+func (si *ServiceImpl) SchemaID() string {
+	return "openpipelinev2:routing"
+}

--- a/dynatrace/api/builtin/openpipeline/routing/settings/routing.go
+++ b/dynatrace/api/builtin/openpipeline/routing/settings/routing.go
@@ -1,0 +1,172 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var AllowedKinds = []string{
+	"logs", "events", "events.security", "security.events", "bizevents", "spans",
+	"events.sdlc", "metrics", "usersessions", "davis.problems", "davis.events",
+	"system.events", "azure.logs.forwarding", "user.events",
+}
+
+type Routing struct {
+	Kind           string          `json:"-"`
+	RoutingEntries []*RoutingEntry `json:"routingEntries,omitempty"`
+}
+
+func (r *Routing) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"kind": {
+			Type:         schema.TypeString,
+			Required:     true,
+			Description:  "Indicates OpenPipeline data source",
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(AllowedKinds, true),
+		},
+		"routing_entry": {
+			Type:        schema.TypeList,
+			Description: "Groups all entries of the routing table together, mapping ingest sources to pipelines",
+			Elem:        &schema.Resource{Schema: new(RoutingEntry).Schema()},
+			Optional:    true,
+			MaxItems:    3000,
+		},
+	}
+}
+
+func (r *Routing) MarshalHCL(properties hcl.Properties) error {
+	err := properties.Encode("kind", r.Kind)
+	if err != nil {
+		return err
+	}
+
+	return properties.EncodeSlice("routing_entry", r.RoutingEntries)
+}
+
+func (r *Routing) UnmarshalHCL(decoder hcl.Decoder) error {
+	err := decoder.Decode("kind", &r.Kind)
+	if err != nil {
+		return err
+	}
+
+	return decoder.DecodeSlice("routing_entry", &r.RoutingEntries)
+}
+
+func (r *Routing) Name() string {
+	return "Routing for pipelines"
+}
+
+type RoutingEntry struct {
+	Enabled           bool    `json:"enabled"`
+	PipelineType      string  `json:"pipelineType"`
+	BuiltinPipelineID *string `json:"builtinPipelineId,omitempty"`
+	PipelineID        *string `json:"pipelineId,omitempty"`
+	Matcher           string  `json:"matcher"`
+	Description       string  `json:"description"`
+}
+
+const BuiltinPipelineIDMaxLength = 500
+const DescriptionMaxLength = 512
+const MatcherMaxLength = 1500
+
+func (re *RoutingEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"enabled": {
+			Type:        schema.TypeBool,
+			Description: "Indicates if the routing entry is active",
+			Default:     true,
+			Optional:    true,
+		},
+		"pipeline_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "ID of the pipeline. Only used if the pipeline type is \"custom\"",
+		},
+		"builtin_pipeline_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "ID of the pipeline. Only used if the pipeline type is \"builtin\"",
+			ValidateFunc: validation.StringLenBetween(1, BuiltinPipelineIDMaxLength),
+		},
+		"pipeline_type": {
+			Type:         schema.TypeString,
+			Required:     true,
+			Description:  "Type of the pipeline. Must be \"custom\" or \"builtin\"",
+			ValidateFunc: validation.StringInSlice([]string{"custom", "builtin"}, true),
+		},
+		"matcher": {
+			Type:         schema.TypeString,
+			Description:  "Query which determines whether the record should be routed to the target pipeline of this rule",
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(1, MatcherMaxLength),
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Description: "Description of the routing table entry. Must not start with 'dt.' or 'dynatrace.'",
+			Required:    true,
+			ValidateFunc: validation.All(
+				validation.StringLenBetween(1, DescriptionMaxLength),
+				func(input interface{}, schema string) (warnings []string, errors []error) {
+					id, ok := input.(string)
+					if !ok {
+						errors = append(errors, fmt.Errorf("expected type of %s to be string", schema))
+						return warnings, errors
+					}
+
+					if strings.HasPrefix(id, "dt.") || strings.HasPrefix(id, "dynatrace.") {
+						errors = append(errors,
+							fmt.Errorf("%s must not start with 'dt.' or 'dynatrace.'", schema))
+					}
+					return warnings, errors
+				}),
+		},
+	}
+}
+
+func (re *RoutingEntry) MarshalHCL(properties hcl.Properties) error {
+	err := properties.EncodeAll(map[string]any{
+		"enabled":             re.Enabled,
+		"pipeline_id":         re.PipelineID,
+		"builtin_pipeline_id": re.BuiltinPipelineID,
+		"pipeline_type":       re.PipelineType,
+		"matcher":             re.Matcher,
+		"description":         re.Description,
+	})
+	openpipeline.RemoveNils(properties)
+
+	return err
+}
+
+func (re *RoutingEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"enabled":             &re.Enabled,
+		"pipeline_id":         &re.PipelineID,
+		"builtin_pipeline_id": &re.BuiltinPipelineID,
+		"pipeline_type":       &re.PipelineType,
+		"matcher":             &re.Matcher,
+		"description":         &re.Description,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/routing/settings/routing_test.go
+++ b/dynatrace/api/builtin/openpipeline/routing/settings/routing_test.go
@@ -1,0 +1,489 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/routing/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var minimalRouting = settings.Routing{
+	Kind: "events",
+}
+
+var pipelineId = "pipelineId"
+var builtinPipelineId = "builtinPipelineId"
+var routingWithEntries = settings.Routing{
+	Kind: "events",
+	RoutingEntries: []*settings.RoutingEntry{
+		{
+			Enabled:           true,
+			PipelineType:      "custom",
+			BuiltinPipelineID: nil,
+			PipelineID:        &pipelineId,
+			Matcher:           "some matcher",
+			Description:       "somedescription",
+		},
+		{
+			Enabled:           false,
+			PipelineType:      "builtin",
+			BuiltinPipelineID: &builtinPipelineId,
+			PipelineID:        nil,
+			Matcher:           "some matcher",
+			Description:       "somedescription2",
+		},
+		{
+			Enabled:           true,
+			PipelineType:      "builtin",
+			BuiltinPipelineID: &builtinPipelineId,
+			PipelineID:        nil,
+			Matcher:           "some other matcher",
+			Description:       "somedescription3",
+		},
+	},
+}
+
+func TestRouting_MarshalHCL(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    settings.Routing
+		expected hcl.Properties
+	}{
+		{
+			name:  "minimum-set",
+			input: minimalRouting,
+			expected: hcl.Properties{
+				"kind": "events",
+			},
+		},
+		{
+			name:  "with entries",
+			input: routingWithEntries,
+			expected: hcl.Properties{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					hcl.Properties{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       "some matcher",
+						"description":   "somedescription",
+					},
+					hcl.Properties{
+						"enabled":             false,
+						"builtin_pipeline_id": builtinPipelineId,
+						"pipeline_type":       "builtin",
+						"matcher":             "some matcher",
+						"description":         "somedescription2",
+					},
+					hcl.Properties{
+						"enabled":             true,
+						"builtin_pipeline_id": builtinPipelineId,
+						"pipeline_type":       "builtin",
+						"matcher":             "some other matcher",
+						"description":         "somedescription3",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual = hcl.Properties{}
+			err := tc.input.MarshalHCL(actual)
+			assert.Equal(t, tc.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestRouting_UnmarshalHCL(t *testing.T) {
+	s := new(settings.Routing).Schema()
+
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected settings.Routing
+	}{
+		{
+			name: "minimal fields set",
+			input: map[string]interface{}{
+				"kind": "events",
+			},
+			expected: minimalRouting,
+		},
+		{
+			name: "with entries",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       "some matcher",
+						"description":   "somedescription",
+					},
+					map[string]interface{}{
+						"enabled":             false,
+						"builtin_pipeline_id": builtinPipelineId,
+						"pipeline_type":       "builtin",
+						"matcher":             "some matcher",
+						"description":         "somedescription2",
+					},
+					map[string]interface{}{
+						"enabled":             true,
+						"builtin_pipeline_id": builtinPipelineId,
+						"pipeline_type":       "builtin",
+						"matcher":             "some other matcher",
+						"description":         "somedescription3",
+					},
+				},
+			},
+			expected: routingWithEntries,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			assert.NotNil(t, d)
+
+			var actual settings.Routing
+			decoder := hcl.DecoderFrom(d)
+			err := actual.UnmarshalHCL(decoder)
+			assert.Equal(t, c.expected, actual)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestIngestSource_MarshalJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    settings.Routing
+		expected []byte
+	}{
+		{
+			name:  "minimal-fields-set",
+			input: minimalRouting,
+			expected: []byte(
+				`{
+				}`),
+		},
+		{
+			name:  "with entries",
+			input: routingWithEntries,
+			expected: []byte(
+				`{
+					"routingEntries": [
+						{
+							"enabled": true,	
+							"pipelineId": "pipelineId",
+							"pipelineType": "custom",
+							"matcher": "some matcher",
+							"description": "somedescription"
+						},
+						{
+							"enabled": false,
+							"builtinPipelineId": "builtinPipelineId",
+							"pipelineType": "builtin",
+							"matcher": "some matcher",
+							"description": "somedescription2"
+						},
+						{
+							"enabled": true,
+							"builtinPipelineId": "builtinPipelineId",
+							"pipelineType": "builtin",
+							"matcher": "some other matcher",
+							"description": "somedescription3"
+						}
+					]
+				}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+
+			var actualJSON map[string]interface{}
+			err = json.Unmarshal(actual, &actualJSON)
+			require.NoError(t, err)
+
+			var expectedJSON map[string]interface{}
+			err = json.Unmarshal(tc.expected, &expectedJSON)
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedJSON, actualJSON)
+		})
+	}
+}
+
+func TestRouting_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			input: map[string]interface{}{
+				"kind": "events",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with entries",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       "some matcher",
+						"description":   "somedescription",
+					},
+					map[string]interface{}{
+						"enabled":             false,
+						"builtin_pipeline_id": builtinPipelineId,
+						"pipeline_type":       "builtin",
+						"matcher":             "some matcher",
+						"description":         "somedescription2",
+					},
+					map[string]interface{}{
+						"enabled":             true,
+						"builtin_pipeline_id": builtinPipelineId,
+						"pipeline_type":       "builtin",
+						"matcher":             "some matcher",
+						"description":         "somedescription3",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "kind missing",
+			input:   map[string]interface{}{},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "kind invalid",
+			input: map[string]interface{}{
+				"kind": "invalid",
+			},
+			wantErr: true,
+			errMsg:  fmt.Sprintf("expected kind to be one of %q, got invalid", settings.AllowedKinds),
+		},
+		{
+			name: "description missing",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       "some matcher",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "description present but blank",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       "some matcher",
+						"description":   "",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected length of routing_entry.0.description to be in the range (1 - 512), got ",
+		},
+		{
+			name: "description starts with dt.",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       "some matcher",
+						"description":   "dt.asdf",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "routing_entry.0.description must not start with 'dt.' or 'dynatrace.'",
+		},
+		{
+			name: "description starts with dynatrace.",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       "some matcher",
+						"description":   "dynatrace.asdf",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "routing_entry.0.description must not start with 'dt.' or 'dynatrace.'",
+		},
+		{
+			name: "pipeline_type missing",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":     true,
+						"pipeline_id": pipelineId,
+						"matcher":     "some matcher",
+						"description": "somedescription",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "pipeline_type invalid",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "invalid",
+						"matcher":       "some matcher",
+						"description":   "somedescription",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected routing_entry.0.pipeline_type to be one of [\"custom\" \"builtin\"], got invalid",
+		},
+		{
+			name: "builtin_pipeline_id too long",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":             true,
+						"builtin_pipeline_id": strings.Repeat("a", settings.BuiltinPipelineIDMaxLength+1),
+						"pipeline_type":       "builtin",
+						"matcher":             "some matcher",
+						"description":         "somedescription",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected length of routing_entry.0.builtin_pipeline_id to be in the range (1 - 500), got " + strings.Repeat("a", settings.BuiltinPipelineIDMaxLength+1),
+		},
+		{
+			name: "matcher missing",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"description":   "somedescription",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "Missing required argument",
+		},
+		{
+			name: "matcher present but blank",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       "",
+						"description":   "somedescription",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected length of routing_entry.0.matcher to be in the range (1 - 1500), got ",
+		},
+		{
+			name: "matcher too long",
+			input: map[string]interface{}{
+				"kind": "events",
+				"routing_entry": []interface{}{
+					map[string]interface{}{
+						"enabled":       true,
+						"pipeline_id":   pipelineId,
+						"pipeline_type": "custom",
+						"matcher":       strings.Repeat("a", settings.MatcherMaxLength+1),
+						"description":   "somedescription",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected length of routing_entry.0.matcher to be in the range (1 - 1500), got " + strings.Repeat("a", settings.MatcherMaxLength+1),
+		},
+	}
+
+	r := &schema.Resource{Schema: new(settings.Routing).Schema()}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tt.input)
+
+			diags := r.Validate(c)
+			assert.Equal(t, tt.wantErr, diags.HasError())
+
+			if diags.HasError() {
+				assert.Equal(t, tt.errMsg, diags[0].Summary)
+			}
+		})
+	}
+}

--- a/dynatrace/api/builtin/openpipeline/routing/testdata/example.json
+++ b/dynatrace/api/builtin/openpipeline/routing/testdata/example.json
@@ -1,0 +1,21 @@
+{
+  "routingEntries": [ {
+    "enabled" : true,
+    "pipelineType" : "custom",
+    "pipelineId" : "pipelineId",
+    "matcher" : "true",
+    "description" : "test1"
+  }, {
+    "enabled" : false,
+    "pipelineType" : "custom",
+    "pipelineId" : "pipelineId",
+    "matcher" : "false",
+    "description" : "test2"
+  }, {
+    "enabled" : false,
+    "pipelineType" : "builtin",
+    "builtinPipelineId" : "builtin_pipelineId",
+    "matcher" : "true",
+    "description" : "test3"
+  } ]
+}

--- a/dynatrace/api/builtin/openpipeline/routing/testdata/example.tf
+++ b/dynatrace/api/builtin/openpipeline/routing/testdata/example.tf
@@ -1,0 +1,23 @@
+resource "dynatrace_openpipeline_v2_routing" "routing" {
+  kind = "events"
+  routing_entry {
+    pipeline_type = "custom"
+    pipeline_id = "pipelineId"
+    matcher = "true"
+    description = "test1"
+  }
+  routing_entry {
+    enabled     = false
+    pipeline_type = "custom"
+    pipeline_id = "pipelineId"
+    matcher = "false"
+    description = "test2"
+  }
+  routing_entry {
+    enabled     = false
+    pipeline_type = "builtin"
+    builtin_pipeline_id = "builtin_pipelineId"
+    matcher = "true"
+    description = "test3"
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
This PR adds support for the OpenPipeline Routing settings schemas.

#### **What** has changed?
The PR adds the HCL handling and the settings API access for the routing resource.

#### **How** does it do it?
The first commit introduces some example files: A JSON file which represents the payload expected by the settings API and a TF file which shows how the HCL representation of routing resources would look like.

The second commit introduces support for HCL handling of the routing resource.
Schema(), MarshalHCL(), and UnmarshalHCL() are implemented.

The third commit introduces a CRUD service, glueing the routing HCL and the settings API together.

#### How is it **tested**?
Tests for HCL-marshalling and unmarshalling, and HCL-verification are added.
CRUD service tests are still missing.

#### How does it affect **users**?
It doesn't yet. 

**Issue:**
CA-15951
