### PR TITLE
#778

### DIFF
--- a/dynatrace/export.go
+++ b/dynatrace/export.go
@@ -75,6 +75,13 @@ func runExport(cfgGetter config.Getter) (err error) {
 	}()
 	os.Remove("terraform-provider-dynatrace.export.log")
 	os.Remove("terraform-provider-dynatrace.warnings.log")
+
+	// This ensures that every Settings 2.0 resource
+	// that offers ordering using the `insert_after`
+	// attribute won't produce hardcoded IDs
+	// when exported.
+	export.AddInsertAfterWeakIDDependencies()
+
 	var environment *export.Environment
 	if environment, err = export.Initialize(cfgGetter); err != nil {
 		return err


### PR DESCRIPTION
#### **Why** this PR?

This is about ticket #778.

We want to avoid having hardcoded IDs for settings that are orderable via the Settings 2.0 API, like this.

```
resource "dynatrace_log_storage" "_Built-in_Ingest_Journald_logs" {
  name            = "[Built-in] Ingest Journald logs"
  enabled         = true
  insert_after    = "vu9U3hXa3q0AAAABACpidWlsdGluOmxvZ21vbml0b3JpbmcubG9nLXN0b3JhZ2Utc2V0dGluZ3MABnRlbmFudAAGdGVuYW50ACQ3MmViZDViYS1lOTY0LTMzNzAtYWMzZS03NjhjODAxNDM0Yzi-71TeFdrerQ"
  ..
}
```
The produced HCL code should look like this - using the reference to the ID of another resource, if it has been part of the export.
```
resource "dynatrace_log_storage" "_Built-in_Ingest_all_logs" {
  name            = "[Built-in] Ingest all logs"
  enabled         = true
  insert_after    = "${dynatrace_log_storage._Built-in_Linux_system_logs.id}"
  ..
} 
```

#### **How** does it do it?

The necessary plumbing for that was already there. It had even been specified for one resource

```
	ResourceTypes.LogProcessing: NewResourceDescriptor(
		logdpprules.Service,
		// Dependency onto other LogProcessing resources only exists because of `insertAfter`
		// Using `WeakID` here enforces that dependencies are only supposed to get replaced
		// when the LogProcessing rule that is referred to is also a candidate for the export
		Dependencies.WeakID(ResourceTypes.LogProcessing),
	),
```

Instead of explicitly specifying `Dependencies.WeakID(ResourceTypes.LogProcessing)` within the dependencies of a resource descriptor this change injects these `WeakID` dependencies to every resource that
* Is based on Settings 2.0
* Offers the `insert_after` attribute

#### How is it **tested**?

We don't have test coverage for the export functionality. Therefore I ran local tests for these resources:
* `dynatrace_log_processing`
* `dynatrace_devobs_data_masking`
* `dynatrace_rum_ip_determination`
* `dynatrace_vulnerability_third_party_attr`
* `dynatrace_span_capture_rule`
* `dynatrace_log_security_context`
* `dynatrace_log_timestamp`
* `dynatrace_service_external_web_service`
* `dynatrace_application_detection_rule_v2`
* `dynatrace_business_events_processing`
* `dynatrace_service_full_web_service`
with and without that change applied and validated the results.

I also ran a default export against my personal tenant as a sanity check.

#### How does it affect **users**?

Utilizing the export functionality will produce fewer hardcorded IDs within the generated HCL code.

**Issue:**
#778