### PR TITLE
feat(openpipeline): Renames "propertie" to "property"

### DIFF
--- a/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/davis_event_property.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/davis_event_property.go
@@ -26,7 +26,7 @@ type DavisEventProperties []*DavisEventProperty
 
 func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"propertie": {
+		"property": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -37,11 +37,11 @@ func (me *DavisEventProperties) Schema() map[string]*schema.Schema {
 }
 
 func (me DavisEventProperties) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("propertie", me)
+	return properties.EncodeSlice("property", me)
 }
 
 func (me *DavisEventProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("propertie", me)
+	return decoder.DecodeSlice("property", me)
 }
 
 type DavisEventProperty struct {


### PR DESCRIPTION
#### **Why** this PR?
The generated OpenPipeline code has some issues regarding how the name of a collection element block is derived from the name of the collection block.
In this specific case, the generator gave the name `propertie` to elements of the collection `properties`.

#### **What** has changed and how?
I changed all occurrences of `propertie` to `property`

#### How is it **tested**?
No tests yet, but will be with acceptance tests currently being developed.

#### How does it affect **users**?
The feature is not released yet, so it doesn't really.

**Issue:**
CA-15949