### PR TITLE
feat(openpipeline): Renames "routing_entrie" to "routing_entry"

### DIFF
--- a/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
@@ -29,7 +29,7 @@ type RoutingEntries []*RoutingEntry
 
 func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"routing_entrie": {
+		"routing_entry": {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
@@ -40,11 +40,11 @@ func (me *RoutingEntries) Schema() map[string]*schema.Schema {
 }
 
 func (me RoutingEntries) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("routing_entrie", me)
+	return properties.EncodeSlice("routing_entry", me)
 }
 
 func (me *RoutingEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("routing_entrie", me)
+	return decoder.DecodeSlice("routing_entry", me)
 }
 
 type RoutingEntry struct {


### PR DESCRIPTION
#### **Why** this PR?
The generated OpenPipeline code has some issues regarding how the name of a collection element block is derived from the name of the collection block.
In this specific case, the generator gave the name `routing_entrie` to elements of the collection `routing_entries`.

#### **What** has changed and how?
I changed all occurrences of `routing_entrie` to `routing_entry`

#### How is it **tested**?
No tests yet, but will be with acceptance tests currently being developed.

#### How does it affect **users**?
The feature is not released yet, so it doesn't really.

**Issue:**
CA-15949