### PR TITLE
feat(openpipeline): All routing settings must implement Name() func

### DIFF
--- a/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_azure_logs_forwarding_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_bizevents_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_davis_events_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_davis_problems_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/events/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_events_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_events_sdlc_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_events_security_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/logs/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_logs_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_metrics_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_security_events_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/spans/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_spans_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_system_events_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_user_events_routing"
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/settings.go
@@ -50,3 +50,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"routing_entries": &me.RoutingEntries,
 	})
 }
+
+func (me *Settings) Name() string {
+	return "openpipeline_v2_usersessions_routing"
+}


### PR DESCRIPTION
#### **Why** this PR?
All structs used with the generic settings client implementation need to provide a name. If they don't, the provider crashes with a panic:
`<Type XYZ> does neither have a property 'Name', 'DisplayName', 'Label' or 'Key' nor does it offer a method 'Name()'`

This is a problem for all the OpenPipeline routing schemas, as they don't have such a property and they also don't implement the `Name()` func.

#### **What** has changed and **How**?
Therefore I decided to implement `Name()` for all routing schemas. It just statically returns the name of the resource (without the `dynatrace_` prefix), e.g. `openpipeline_v2_events_routing`. 
It should be okay to use a static string, as these settings objects only exist once per tenant.

#### How is it **tested**?
The provider doesn't crash anymore when trying to create routing resources.

#### How does it affect **users**?
It doesn't.

**Issue:**
CA-14694