### PR TITLE
feat(openpipeline): Acceptance tests with settings object references

### DIFF
--- a/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_azure_logs_forwarding_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_azure_logs_forwarding_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_azure_logs_forwarding_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_azure_logs_forwarding_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_azure_logs_forwarding_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_azure_logs_forwarding_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_bizevents_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_bizevents_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_bizevents_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_bizevents_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_bizevents_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_bizevents_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_davis_events_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_davis_events_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_davis_events_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_davis_events_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_davis_events_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_davis_problems_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_davis_problems_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_davis_problems_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_davis_problems_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_events_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_events_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_events_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_events_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_events_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_events_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_events_sdlc_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_events_sdlc_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_events_sdlc_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_events_sdlc_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_events_security_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_events_security_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_events_security_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_events_security_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_events_security_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_events_security_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_logs_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_logs_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_logs_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/logs/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_logs_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_logs_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_logs_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_metrics_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_metrics_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_metrics_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_metrics_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_metrics_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_metrics_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_security_events_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_security_events_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_security_events_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_security_events_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_security_events_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_security_events_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_spans_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_spans_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_spans_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/spans/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_spans_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_spans_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_spans_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_system_events_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_system_events_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_system_events_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_system_events_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_system_events_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_system_events_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_user_events_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_user_events_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_user_events_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_user_events_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_user_events_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_user_events_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_usersessions_ingestsources" "ingest-source" {
+  enabled = true
+  display_name = "ingest-source"
+  path_segment = "ingestsource.path.tf.#name#"
+  static_routing {
+    pipeline_type = "custom"
+    pipeline_id = dynatrace_openpipeline_v2_usersessions_pipelines.pipeline.id
+  }
+  processing {
+  }
+}
+
+resource "dynatrace_openpipeline_v2_usersessions_pipelines" "pipeline" {
+  display_name = "Pipeline"
+  custom_id = "pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/testdata/terraform/custom-pipeline-example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_openpipeline_v2_usersessions_routing" "routing" {
+  routing_entries {
+    routing_entry {
+      enabled             = true
+      pipeline_type       = "custom"
+      pipeline_id = dynatrace_openpipeline_v2_usersessions_pipelines.pipeline.id
+      matcher             = "not matchesPhrase(record.title, \"Warning\")"
+      description         = "Default route"
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_usersessions_pipelines" "pipeline" {
+  display_name = "Minimal pipeline"
+  custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
+  processing {}
+  davis {}
+  metric_extraction {}
+  security_context {}
+  cost_allocation {}
+  product_allocation {}
+  storage {}
+  data_extraction {}
+}

--- a/dynatrace/settings/services/settings20/client.go
+++ b/dynatrace/settings/services/settings20/client.go
@@ -23,13 +23,16 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"golang.org/x/oauth2"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+
 	"github.com/go-logr/logr"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
 const endpointPath = "api/v2/settings/objects"
@@ -266,7 +269,7 @@ func (c client) create(ctx context.Context, data []byte) (*http.Response, error)
 }
 
 func IsSkipRepairSchemaID(schemaID string) bool {
-	return false
+	return strings.HasPrefix(schemaID, "builtin:openpipeline.")
 }
 
 func (c client) setRepairInput(options *rest.RequestOptions) {


### PR DESCRIPTION
#### **Why** this PR?
This PR is a follow-up to/builds upon the changes of #783 
For the OpenPipeline settings, we have a problem with resolving settings object IDs. These test cases are therefore not part of the original acceptance test PR, but will come with this follow-up PR here, as soon as the server-side issues have been fixed.

#### **What** has changed?
Additional test cases with settings object ID references are added.

#### How does it affect **users**?
It doesn't

**Issue:**
CA-15949