### PR TITLE
test(eec): EEC Remote test needed to be skipped

### DIFF
--- a/dynatrace/api/builtin/eec/remote/service_test.go
+++ b/dynatrace/api/builtin/eec/remote/service_test.go
@@ -24,5 +24,7 @@ import (
 )
 
 func TestAccExtensionExecutionControllerRemote(t *testing.T) {
+	t.Skip("Skipped, as a valid environment ActiveGate scope is required. Can be enabled again, if/when we setup said ActiveGate for the e2e test tenant.")
+
 	api.TestAcc(t)
 }


### PR DESCRIPTION
#### **Why** this PR?
The environment ActiveGate referenced in the scope parameter of the `dynatrace_extension_execution_remote` resource must now actually exist. Otherwise, an applicability rule prevents settings creation. We cannot easily guarantee its existence in the E2E test execution. Therefore, the test needs to be skipped.

#### How does it affect **users**?
It doesn't.

**Issue:**
None
