### PR TITLE
Fixed panic and added asynchronous configuration when exporting dynat…

### DIFF
--- a/dynatrace/api/v1/config/customtags/list/list.go
+++ b/dynatrace/api/v1/config/customtags/list/list.go
@@ -6,9 +6,17 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 )
 
-const TIME_FRAME = "now-3y"
+const (
+	TIME_FRAME                                        = "now-3y"
+	DYNATRACE_MAX_CONCURRENT_CUSTOM_TAG_LIST_REQUESTS = "DYNATRACE_MAX_CONCURRENT_CUSTOM_TAG_LIST_REQUESTS"
+	DefaultMaxConcurrent                              = 4
+	MaxConcurrentMinValue                             = 1
+	MaxConcurrentMaxValue                             = 20
+)
 
 type EntityTags struct {
 	ID   string `json:"id"`
@@ -21,20 +29,22 @@ func List(ctx context.Context, client rest.Client) (api.Stubs, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	maxConcurrent := settings.GetIntEnvCtx(ctx, DYNATRACE_MAX_CONCURRENT_CUSTOM_TAG_LIST_REQUESTS, DefaultMaxConcurrent, MaxConcurrentMinValue, MaxConcurrentMaxValue)
+
+	// limiter shared by *all* downstream calls using the same client
+	limiter := make(chan struct{}, maxConcurrent)
+
 	channels := []chan EntityTags{}
 	for _, entityType := range entityTypes {
 		results := make(chan EntityTags, 100)
 		channels = append(channels, results)
-		go GetEntities(ctx, entityType, client, results)
+		go GetEntities(ctx, entityType, client, limiter, results)
 	}
 	m := map[string]EntityTags{}
 	for _, channel := range channels {
 		for entityTag := range channel {
 			m[entityTag.ID] = entityTag
-			// fmt.Println(entityTag.ID)
-			// for _, tag := range entityTag.Tags {
-			// 	fmt.Println("  -", tag.StringRepresentation)
-			// }
 		}
 	}
 	var stubs api.Stubs
@@ -44,34 +54,52 @@ func List(ctx context.Context, client rest.Client) (api.Stubs, error) {
 	return stubs, nil
 }
 
-func GetEntities(ctx context.Context, entityType EntityType, client rest.Client, results chan EntityTags) {
+// acquire blocks when maxConcurrent is reached; release frees a slot
+func acquire(limiter chan struct{}) { limiter <- struct{}{} }
+func release(limiter chan struct{}) { <-limiter }
+
+func GetEntities(ctx context.Context, entityType EntityType, client rest.Client, limiter chan struct{}, results chan EntityTags) {
 	defer close(results)
+
+	// Limit this remote call
+	acquire(limiter)
 	tags, err := entityType.GetCustomTags(ctx, client)
+	release(limiter)
 	if err != nil {
-		panic(err)
+		logging.Debug.Info.Printf("GetCustomTags(entityType=%s): %v", entityType.Type, err)
+		return
 	}
 	if len(tags) == 0 {
 		return
 	}
 	chanEntities := make(chan Entity, 100)
-	go GETEntitiesWithTags(ctx, entityType.Type, tags, client, chanEntities)
+	// Limit this remote call (spawns its own producer goroutine)
+	go func() {
+		acquire(limiter)
+		defer release(limiter)
+		GETEntitiesWithTags(ctx, entityType.Type, tags, client, chanEntities)
+	}()
+
 	for entity := range chanEntities {
 		if len(entity.Tags) == 0 {
 			continue
 		}
 		chanEntityTags := make(chan EntityTags, 100)
-		go GetCustomTags(ctx, entity, client, chanEntityTags)
+		go GetCustomTags(ctx, entity, client, limiter, chanEntityTags)
 		for entityTag := range chanEntityTags {
 			results <- entityTag
 		}
 	}
 }
 
-func GetCustomTags(ctx context.Context, entity Entity, client rest.Client, results chan EntityTags) {
+func GetCustomTags(ctx context.Context, entity Entity, client rest.Client, limiter chan struct{}, results chan EntityTags) {
 	defer close(results)
+	acquire(limiter)
 	tags, err := GETCustomTags(ctx, entity.ID, client)
+	release(limiter)
 	if err != nil {
-		panic(err)
+		logging.Debug.Info.Printf("GETCustomTags(entity=%s): %v", entity.ID, err)
+		return
 	}
 	if len(tags) > 0 {
 		results <- EntityTags{ID: entity.ID, Name: entity.Name, Tags: tags}

--- a/dynatrace/api/v1/config/customtags/list/list_test.go
+++ b/dynatrace/api/v1/config/customtags/list/list_test.go
@@ -1,0 +1,158 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+)
+
+const (
+	NUM_ENTITY_TYPES = 50
+	NUM_CUSTOM_TAGS  = 50
+	NUM_ENTITIES     = 50
+)
+
+type TestClient struct {
+	latency     time.Duration // artificial per-request delay inside Finish
+	inFlight    int64         // current in-flight
+	maxInFlight int64         // max observed in-flight
+	total       int64         // total Finish calls
+}
+
+func NewTestClient(latency time.Duration) *TestClient {
+	return &TestClient{latency: latency}
+}
+
+func (client *TestClient) Get(ctx context.Context, url string, expectedStatusCodes ...int) rest.Request {
+	return &Request{client: client, ctx: ctx}
+}
+func (client *TestClient) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) rest.Request {
+	panic("unsupported operation")
+}
+func (client *TestClient) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) rest.Request {
+	panic("unsupported operation")
+}
+func (client *TestClient) Delete(ctx context.Context, url string, expectedStatusCodes ...int) rest.Request {
+	panic("unsupported operation")
+}
+func (client *TestClient) Credentials() *rest.Credentials {
+	panic("unsupported operation")
+}
+
+// Accessors for assertions
+func (c *TestClient) MaxConcurrent() int64 { return atomic.LoadInt64(&c.maxInFlight) }
+func (c *TestClient) Total() int64         { return atomic.LoadInt64(&c.total) }
+func (c *TestClient) InFlight() int64      { return atomic.LoadInt64(&c.inFlight) }
+
+type Request struct {
+	client *TestClient
+	ctx    context.Context
+}
+
+func (request *Request) Finish(v ...any) error {
+	c := request.client
+
+	// increment in-flight
+	cur := atomic.AddInt64(&c.inFlight, 1)
+
+	// update maxInFlight if needed (lock-free CAS loop)
+	for {
+		max := atomic.LoadInt64(&c.maxInFlight)
+		if cur <= max {
+			break
+		}
+		if atomic.CompareAndSwapInt64(&c.maxInFlight, max, cur) {
+			break
+		}
+	}
+
+	// count total requests
+	atomic.AddInt64(&c.total, 1)
+	defer func() {
+		atomic.AddInt64(&c.inFlight, -1)
+	}()
+
+	// simulate work/latency so goroutines overlap
+	if c.latency > 0 {
+		select {
+		case <-time.After(c.latency):
+		case <-request.ctx.Done():
+			return request.ctx.Err()
+		}
+	}
+
+	if v == nil {
+		panic("unsupported operation for v == nil")
+	}
+	if len(v) == 0 {
+		panic("unsupported operation for empty v")
+	}
+	val := v[0]
+	if val == nil {
+		panic("unsupported operation for v[0] == nil")
+	}
+
+	switch typedValue := val.(type) {
+	case *GetEntityTypesResponse:
+		typedValue.TotalCount = NUM_ENTITY_TYPES
+		typedValue.NextPageKey = ""
+		for i := 0; i < typedValue.TotalCount; i++ {
+			typedValue.Types = append(typedValue.Types, EntityType{Type: fmt.Sprintf("entity-type-%d", i)})
+		}
+		return nil
+	case *GetCustomTagsResponse:
+		typedValue.TotalCount = NUM_CUSTOM_TAGS
+		for i := 0; i <= typedValue.TotalCount; i++ {
+			typedValue.Tags = append(typedValue.Tags, Tag{
+				StringRepresentation: fmt.Sprintf("tag.%d", i),
+				Value:                fmt.Sprintf("tag.value.%d", i),
+				Key:                  fmt.Sprintf("tag.key.%d", i),
+				Context:              fmt.Sprintf("tag.context.%d", i),
+			})
+		}
+		return nil
+	case *GETEntitiesResponse:
+		typedValue.TotalCount = NUM_ENTITIES
+		typedValue.NextPageKey = ""
+		for i := 0; i <= typedValue.TotalCount; i++ {
+			entity := Entity{ID: fmt.Sprintf("entity.id.%d", i), Name: fmt.Sprintf("entity.name.%d", i)}
+			for j := 0; j <= typedValue.TotalCount; j++ {
+				entity.Tags = append(entity.Tags, Tag{
+					StringRepresentation: fmt.Sprintf("entity.%d.tag.%d", i, j),
+					Value:                fmt.Sprintf("entity.%d.tag.value.%d", i, j),
+					Key:                  fmt.Sprintf("entity.%d.tag.key.%d", i, j),
+					Context:              fmt.Sprintf("entity.%d.tag.context.%d", i, j),
+				})
+			}
+			typedValue.Entities = append(typedValue.Entities, entity)
+		}
+		return nil
+	default:
+		panic(fmt.Sprintf("unsupported operation for v type %T", val))
+	}
+}
+
+func (request *Request) Expect(codes ...int) rest.Request {
+	panic("unsupported operation")
+
+}
+func (request *Request) OnResponse(onresponse func(resp *http.Response)) rest.Request {
+	panic("unsupported operation")
+}
+
+func TestCustomTagExport(t *testing.T) {
+	client := NewTestClient(time.Millisecond * 2)
+	_, err := List(t.Context(), client)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if got := client.MaxConcurrent(); got > DefaultMaxConcurrent {
+		t.Fatalf("saw %d concurrent requests; want <= 8", got)
+	}
+}

--- a/dynatrace/settings/get_env.go
+++ b/dynatrace/settings/get_env.go
@@ -1,12 +1,40 @@
 package settings
 
 import (
+	"context"
 	"os"
 	"strconv"
 )
 
 func GetIntEnv(name string, def, min, max int) int {
 	sValue := os.Getenv(name)
+	if len(sValue) == 0 {
+		return def
+	}
+	iValue, err := strconv.Atoi(sValue)
+	if err != nil {
+		return def
+	}
+	if iValue < min || iValue > max {
+		return def
+	}
+	return iValue
+}
+
+func GetCtxStringValue(ctx context.Context, name string) string {
+	if ctxValue := ctx.Value(name); ctxValue != nil {
+		if ctxSValue, ok := ctxValue.(string); ok {
+			return ctxSValue
+		}
+	}
+	return ""
+}
+
+func GetIntEnvCtx(ctx context.Context, name string, def, min, max int) int {
+	sValue := GetCtxStringValue(ctx, name)
+	if len(sValue) == 0 {
+		sValue = os.Getenv(name)
+	}
 	if len(sValue) == 0 {
 		return def
 	}


### PR DESCRIPTION
#### **Why** this PR?
Listing all the available settings for the resource `dynatrace_custom_tags` contained a `panic(err)` when one of the requests is failing.

It shows itself only when a lot of custom tags are about to get exported. Since this code is highly asynchronous - all entity types, all tags and all entities for these tags are getting pulled in parallel - a `Too Many Requests` response is bound to happen sooner or later.

#### **What** has changed?
* The export functionality sends at most 4 concurrent requests for this specific resource
* The number of these concurrent requests is configurable using the environment variable `DYNATRACE_MAX_CONCURRENT_CUSTOM_TAG_LIST_REQUESTS`. Default: 4. Max: 20. Min: 1
* This allows users to speed up the export if necessary
* In case the REST API / API Gateway nevertheless responds with "too many requests", the export doesn't break. The export functionality notes that down in the warnings log

#### **How** does it do it?

* A channel based rate limiter ensures that not more than 4 requests are getting executed at the same time.
* Changes are local to the custom tags service. No other services are affected

#### How is it **tested**?
* Introduced `list_test.go` that validates the rate limitation

#### How does it affect **users**?
The export functionality shouldn't panic anymore when `dynatrace_custom_tags` is getting exported.
We've excluded it from the default set of resources anyways, because it is pretty exotic (not a simple CRUD resource). But customer apparently love to export them nevertheless.