### PR TITLE
Fixed #791

### DIFF
--- a/dynatrace/api/v1/config/synthetic/monitors/loading_time_threshold.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/loading_time_threshold.go
@@ -28,7 +28,7 @@ type LoadingTimeThresholds []*LoadingTimeThreshold
 func (me *LoadingTimeThresholds) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"threshold": {
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 			Description: "The list of performance threshold rules",
 			Required:    true,
 			MinItems:    1,


### PR DESCRIPTION
#### **What** has changed?
The REST API seems to return loading time thresholds for HTTP Monitors now in arbitrary order

```
resource "dynatrace_http_monitor" "threshold_test" {
  name      = "threshold_test"
  enabled   = true
  frequency = 60
  locations = ["GEOLOCATION-03E96F97A389F96A"]
  anomaly_detection {
    loading_time_thresholds {
      enabled = true
      thresholds {
        threshold {
          value_ms      = 1000
          request_index = 1
          type          = "ACTION"
        }
        threshold {
          value_ms      = 2000
          request_index = 2
          type          = "ACTION"
        }
      }
    }
```

Terraform treads the list of thresholds however still as an ordered list.
It's therefore necessary to align with the REST API responses.

#### **How** does it do it?

The fix is simple for cases like these. The schema type for "threshold" needs to get changed to `TypeSet` instead of `TypeList`.

```
func (me *LoadingTimeThresholds) Schema() map[string]*schema.Schema {
	return map[string]*schema.Schema{
		"threshold": {
			Type:        schema.TypeSet,
			Description: "The list of performance threshold rules",
			Required:    true,
			MinItems:    1,
			Elem:        &schema.Resource{Schema: new(LoadingTimeThreshold).Schema()},
		},
	}
}
```

#### How is it **tested**?

Manual tests for updates. Automatic Tests currently just cover creation. 

#### How does it affect **users**?

**Issue:**
#791
