### PR TITLE
feat(openpipeline-v1): support "multi value constant" value assignment type

### DIFF
--- a/docs/resources/openpipeline_business_events.md
+++ b/docs/resources/openpipeline_business_events.md
@@ -284,6 +284,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -297,6 +298,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -567,6 +569,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_davis_events.md
+++ b/docs/resources/openpipeline_davis_events.md
@@ -284,6 +284,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -297,6 +298,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -567,6 +569,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_davis_problems.md
+++ b/docs/resources/openpipeline_davis_problems.md
@@ -287,6 +287,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -300,6 +301,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -570,6 +572,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_events.md
+++ b/docs/resources/openpipeline_events.md
@@ -173,6 +173,18 @@ resource "dynatrace_openpipeline_events" "events" {
             }
           }
         }
+        processor {
+          security_context_processor {
+            description = "Custom security context 3"
+            enabled     = true
+            id          = "processor_Custom_security_context_2_9053"
+            matcher     = "true"
+            value {
+              type  = "multiValueConstant"
+              multi_value_constant = ["multi", "value"]
+            }
+          }
+        }
       }
       storage {
         catch_all_bucket_name = "default_events"
@@ -442,6 +454,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -455,6 +468,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -725,6 +739,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_logs.md
+++ b/docs/resources/openpipeline_logs.md
@@ -287,6 +287,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -300,6 +301,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -570,6 +572,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_metrics.md
+++ b/docs/resources/openpipeline_metrics.md
@@ -283,6 +283,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -296,6 +297,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -566,6 +568,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_sdlc_events.md
+++ b/docs/resources/openpipeline_sdlc_events.md
@@ -259,6 +259,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -272,6 +273,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -542,6 +544,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_security_events.md
+++ b/docs/resources/openpipeline_security_events.md
@@ -284,6 +284,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -297,6 +298,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -567,6 +569,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_spans.md
+++ b/docs/resources/openpipeline_spans.md
@@ -308,6 +308,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -321,6 +322,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -591,6 +593,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_system_events.md
+++ b/docs/resources/openpipeline_system_events.md
@@ -299,6 +299,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -312,6 +313,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -582,6 +584,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_user_events.md
+++ b/docs/resources/openpipeline_user_events.md
@@ -287,6 +287,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -300,6 +301,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -570,6 +572,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/docs/resources/openpipeline_user_sessions.md
+++ b/docs/resources/openpipeline_user_sessions.md
@@ -287,6 +287,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--event_type"></a>
@@ -300,6 +301,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 <a id="nestedblock--pipelines--pipeline--data_extraction--processor--bizevent_extraction_processor--field_extraction"></a>
@@ -570,6 +572,7 @@ Optional:
 
 - `constant` (String) Strategy to assign a value
 - `field` (String) Strategy to assign a value
+- `multi_value_constant` (List of String) Strategy to assign a value
 
 
 

--- a/dynatrace/api/openpipeline/settings/processor.go
+++ b/dynatrace/api/openpipeline/settings/processor.go
@@ -1,6 +1,8 @@
 package openpipeline
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -507,27 +509,42 @@ func (ep *ValueAssignment) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Strategy to assign a value",
+			Description: "Strategy to assign a value. Possible values: 'constant', 'field', 'multiValueConstant'",
 			Required:    true,
 		},
 		"field": {
 			Type:        schema.TypeString,
-			Description: "Strategy to assign a value",
+			Description: "Assign a value extracted from a field. Can only be used if 'type' is set to 'field'",
 			Optional:    true,
 		},
 		"constant": {
 			Type:        schema.TypeString,
-			Description: "Strategy to assign a value",
+			Description: "Assign a constant value. Can only be used if 'type' is set to 'constant'",
 			Optional:    true,
 		},
 		"multi_value_constant": {
 			Type:        schema.TypeList,
 			Elem:        &schema.Schema{Type: schema.TypeString},
-			Description: "Strategy to assign a value",
+			Description: "The constant multi value to assign. Can only be used if 'type' is set to 'multiValueConstant'",
 			Optional:    true, // precondition
 		},
 	}
+}
 
+func (ep *ValueAssignment) HandlePreconditions() error {
+	if (ep.Field == nil) && (string(ep.Type) == "field") {
+		return fmt.Errorf("'field' must be specified if 'type' is set to '%v'", ep.Type)
+	}
+
+	if (ep.Constant == nil) && (string(ep.Type) == "constant") {
+		return fmt.Errorf("'constant' must be specified if 'type' is set to '%v'", ep.Type)
+	}
+
+	if (ep.MultiValueConstant == nil) && (string(ep.Type) == "multiValueConstant") {
+		return fmt.Errorf("'multi_value_constant' must be specified if 'type' is set to '%v'", ep.Type)
+	}
+
+	return nil
 }
 
 func (ep *ValueAssignment) MarshalHCL(properties hcl.Properties) error {

--- a/dynatrace/api/openpipeline/settings/processor.go
+++ b/dynatrace/api/openpipeline/settings/processor.go
@@ -497,9 +497,10 @@ func (ep *DavisEventProperty) UnmarshalHCL(decoder hcl.Decoder) error {
 
 type ValueAssignment struct {
 	// Type Defines the actual set of fields depending on the value. See one of the following objects:
-	Type     string  `json:"type"`
-	Field    *string `json:"field"`
-	Constant *string `json:"constant,omitempty"`
+	Type               string   `json:"type"`
+	Field              *string  `json:"field"`
+	Constant           *string  `json:"constant,omitempty"`
+	MultiValueConstant []string `json:"multiValueConstant,omitempty"`
 }
 
 func (ep *ValueAssignment) Schema() map[string]*schema.Schema {
@@ -519,24 +520,32 @@ func (ep *ValueAssignment) Schema() map[string]*schema.Schema {
 			Description: "Strategy to assign a value",
 			Optional:    true,
 		},
+		"multi_value_constant": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Strategy to assign a value",
+			Optional:    true, // precondition
+		},
 	}
 
 }
 
 func (ep *ValueAssignment) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"type":     ep.Type,
-		"field":    ep.Field,
-		"constant": ep.Constant,
+		"type":                 ep.Type,
+		"field":                ep.Field,
+		"constant":             ep.Constant,
+		"multi_value_constant": ep.MultiValueConstant,
 	})
 }
 
 func (ep *ValueAssignment) UnmarshalHCL(decoder hcl.Decoder) error {
 
 	return decoder.DecodeAll(map[string]any{
-		"type":     &ep.Type,
-		"field":    &ep.Field,
-		"constant": &ep.Constant,
+		"type":                 &ep.Type,
+		"field":                &ep.Field,
+		"constant":             &ep.Constant,
+		"multi_value_constant": &ep.MultiValueConstant,
 	})
 }
 

--- a/dynatrace/api/openpipeline/testdata/example.tf
+++ b/dynatrace/api/openpipeline/testdata/example.tf
@@ -116,6 +116,18 @@ resource "dynatrace_openpipeline" "this" {
               }
             }
           }
+          processor {
+            security_context_processor {
+              description = "Custom security context 3"
+              enabled     = true
+              id          = "processor_Custom_security_context_2_9053"
+              matcher     = "true"
+              value {
+                type  = "multiValueConstant"
+                multi_value_constant = ["multi", "value"]
+              }
+            }
+          }
         }
         storage {
           editable              = true

--- a/templates/resources/openpipeline_events.md.tmpl
+++ b/templates/resources/openpipeline_events.md.tmpl
@@ -173,6 +173,18 @@ resource "dynatrace_openpipeline_events" "events" {
             }
           }
         }
+        processor {
+          security_context_processor {
+            description = "Custom security context 3"
+            enabled     = true
+            id          = "processor_Custom_security_context_2_9053"
+            matcher     = "true"
+            value {
+              type  = "multiValueConstant"
+              multi_value_constant = ["multi", "value"]
+            }
+          }
+        }
       }
       storage {
         catch_all_bucket_name = "default_events"


### PR DESCRIPTION
#### **Why** this PR?
The API also returns and supports a `multiValueConstant` `ValueAssignment` type. Therefore, adjustments are needed so that the export and deploy is working correctly.
Current behavior: Downloading a `multiValueConstant` doesn't set the multi-value-constant value (string array). Deploying it won't work, as the `multiValueConstant` field is required if the type is set.
Now: Download sets the `multi_value_constant` field, and it also deploys it.

#### **What** has changed?
The `multiValueConstant` value type is now supported.

#### **How** does it do it?
By adding a new `multi_value_constant` field

#### How is it **tested**?
Manual tests (download & deploy)

#### How does it affect **users**?
They are now able to download and deploy multi-value-constant values assignments.

**Issue:** CA-16528
