### PR TITLE
fix(openpipeline-v2): delete routing configuration

### DIFF
--- a/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/azure/logs/forwarding/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.azure.logs.forwarding.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.bizevents.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.davis.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.davis.problems.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.events.sdlc.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.events.security.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/logs/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.logs.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.metrics.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.security.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/spans/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.spans.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.system.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.user.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
@@ -28,5 +28,8 @@ const SchemaVersion = "1.6"
 const SchemaID = "builtin:openpipeline.usersessions.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+	defaultValue := new(service.Settings)
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*service.Settings]{
+		UpdateOnDelete: &defaultValue,
+	})
 }

--- a/dynatrace/settings/services/settings20/service.go
+++ b/dynatrace/settings/services/settings20/service.go
@@ -550,6 +550,9 @@ func (me *service[T]) Delete(ctx context.Context, id string) error {
 }
 
 func (me *service[T]) delete(ctx context.Context, id string, numRetries int) error {
+	if me.options != nil && me.options.UpdateOnDelete != nil {
+		return me.Update(ctx, id, *me.options.UpdateOnDelete)
+	}
 	err := me.client.Delete(ctx, fmt.Sprintf("/api/v2/settings/objects/%s", url.PathEscape(id)), 204).Finish()
 	if err != nil && strings.Contains(err.Error(), "Deletion of value(s) is not allowed") {
 		return nil

--- a/dynatrace/settings/services/settings20/service_options.go
+++ b/dynatrace/settings/services/settings20/service_options.go
@@ -28,6 +28,8 @@ type ServiceOptions[T settings.Settings] struct {
 	LegacyID       func(id string) string
 	Name           func(ctx context.Context, id string, v T) (string, error)
 	HijackOnCreate func(err error, service settings.RService[T], v T) (*api.Stub, error)
+	// instead of calling the delete, it's calling update with the given value. This is useful for single configuration objects (multiObject: false)
+	UpdateOnDelete *T
 	CreateRetry    func(v T, err error) T
 	UpdateRetry    func(v T, err error) T
 	Duplicates     func(ctx context.Context, service settings.RService[T], v T) (*api.Stub, error)


### PR DESCRIPTION
#### **Why** this PR?
OpenPipeline routing configurations could not be deleted.
Because routing is a single object, and deleting is not supported, we have to update it to the default state

#### **What** has changed?
Routing configurations are now set to default (no routes) on destroy

#### **How** does it do it?
By adding an option to the ServiceOptions to do an update with a certain value instead of a delete.

#### How is it **tested**?
Manual tests

#### How does it affect **users**?
Terraform destroy is now working for routing configurations.

