### PR TITLE
chore: publish releases as draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'
-          args: release --clean
+          args: release --clean --draft
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### **Why** this PR?
Releases were always published, so changes to the release notes had to be made after the release was published. With this, we can update the release notes before the actual release is published

#### **What** has changed?
GoReleaser now publishes releases as draft

#### **How** does it do it?
By adding an argument to the execution in the workflow file

#### How is it **tested**?

I just took a look at the documentation and added the argument
https://goreleaser.com/cmd/goreleaser_release/