### PR TITLE
test: disable openpipeline-v1 tests again

### DIFF
--- a/dynatrace/api/openpipeline/service_test.go
+++ b/dynatrace/api/openpipeline/service_test.go
@@ -26,5 +26,6 @@ import (
 func TestAccOpenPipeline(t *testing.T) {
 	// Notes:
 	// - Seems like no kind currently supports the "azure_log_forwarding_processor" and "security_event_extraction_processor"
+	t.Skip("Tests skipped until REST API doesn't respond back with version conflicts any more")
 	api.TestAcc(t)
 }


### PR DESCRIPTION
#### **Why** this PR?
Flaky OpenPipeline test execution.
Even if the core lib retries 10 times, the test sometimes still runs into version conflicts.
I enabled this test last week in the hope that everything is working. Seems not.
https://github.com/dynatrace-oss/terraform-provider-dynatrace/actions/runs/18034688540/job/51337298859

#### **What** has changed?
The test is skipped

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?

**Issue:**
