### PR TITLE
fix(document): Ensure `owner` can't be set and remove non-existent `actor`

### DIFF
--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -62,7 +62,6 @@ func (me *service) Get(ctx context.Context, id string, v *documents.Document) (e
 				v.Type = stateDocument.Type
 				v.Owner = stateDocument.Owner
 				v.Version = stateDocument.Version
-				v.SchemaVersion = stateDocument.SchemaVersion
 				return nil
 			}
 		}

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -60,7 +60,6 @@ func (me *service) Get(ctx context.Context, id string, v *documents.Document) (e
 				v.Content = stateDocument.Content
 				v.IsPrivate = stateDocument.IsPrivate
 				v.Type = stateDocument.Type
-				v.Actor = stateDocument.Actor
 				v.Owner = stateDocument.Owner
 				v.Version = stateDocument.Version
 				v.SchemaVersion = stateDocument.SchemaVersion
@@ -84,7 +83,6 @@ func (me *service) get(ctx context.Context, id string, v *documents.Document) (e
 		return err
 	}
 
-	v.Actor = result.Actor
 	v.Content = string(result.Data)
 	v.IsPrivate = result.IsPrivate
 	v.Name = result.Name

--- a/dynatrace/api/documents/document/settings/document.go
+++ b/dynatrace/api/documents/document/settings/document.go
@@ -57,11 +57,9 @@ func (me *Document) Schema() map[string]*schema.Schema {
 			ValidateDiagFunc: ValidateTypePossibleValues([]string{"dashboard", "notebook", "launchpad"}),
 		},
 		"owner": {
-			Type:             schema.TypeString,
-			Description:      "The ID of the owner of this document",
-			Optional:         true,
-			Computed:         true,
-			ValidateDiagFunc: ValidateUUIDOrEmpty,
+			Type:        schema.TypeString,
+			Description: "The ID of the owner of this document",
+			Computed:    true,
 		},
 		"content": {
 			Type:        schema.TypeString,

--- a/dynatrace/api/documents/document/settings/document.go
+++ b/dynatrace/api/documents/document/settings/document.go
@@ -24,8 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const SchemaVersion = 3
-
 type Document struct {
 	Name          string `json:"name" maxlength:"200"`
 	Content       string `json:"content,omitempty"`
@@ -98,22 +96,20 @@ func (me *Document) UnmarshalHCL(decoder hcl.Decoder) error {
 
 func (me *Document) MarshalJSON() ([]byte, error) {
 	d := struct {
-		Name          string `json:"name"`
-		Content       string `json:"content,omitempty"`
-		Private       bool   `json:"isPrivate,omitempty"`
-		Type          string `json:"type"`
-		Actor         string `json:"actor,omitempty"`
-		Owner         string `json:"owner,omitempty"`
-		Version       int    `json:"version,omitempty"`
-		SchemaVersion int    `json:"schemaVersion,omitempty"`
+		Name    string `json:"name"`
+		Content string `json:"content,omitempty"`
+		Private bool   `json:"isPrivate,omitempty"`
+		Type    string `json:"type"`
+		Actor   string `json:"actor,omitempty"`
+		Owner   string `json:"owner,omitempty"`
+		Version int    `json:"version,omitempty"`
 	}{
-		SchemaVersion: SchemaVersion,
-		Name:          me.Name,
-		Private:       me.IsPrivate,
-		Content:       me.Content,
-		Type:          me.Type,
-		Owner:         me.Owner,
-		Version:       me.Version,
+		Name:    me.Name,
+		Private: me.IsPrivate,
+		Content: me.Content,
+		Type:    me.Type,
+		Owner:   me.Owner,
+		Version: me.Version,
 	}
 	return json.Marshal(d)
 }

--- a/dynatrace/api/documents/document/settings/document.go
+++ b/dynatrace/api/documents/document/settings/document.go
@@ -31,7 +31,6 @@ type Document struct {
 	Content       string `json:"content,omitempty"`
 	IsPrivate     bool   `json:"isPrivate,omitempty"`
 	Type          string `json:"type"`
-	Actor         string `json:"actor,omitempty" maxlength:"36" format:"uuid"`
 	Owner         string `json:"owner,omitempty" format:"uuid"`
 	Version       int    `json:"version,omitempty"`
 	SchemaVersion int    `json:"schemaVersion,omitempty"`
@@ -56,13 +55,6 @@ func (me *Document) Schema() map[string]*schema.Schema {
 			Description:      "Type of the document. Possible Values are `dashboard`, `launchpad` and `notebook`",
 			Required:         true,
 			ValidateDiagFunc: ValidateTypePossibleValues([]string{"dashboard", "notebook", "launchpad"}),
-		},
-		"actor": {
-			Type:             schema.TypeString,
-			Description:      "The user context the executions of the document will happen with",
-			Optional:         true,
-			Computed:         true,
-			ValidateDiagFunc: Validate(ValidateUUIDOrEmpty, ValidateMaxLength(36)),
 		},
 		"owner": {
 			Type:             schema.TypeString,
@@ -90,7 +82,6 @@ func (me *Document) MarshalHCL(properties hcl.Properties) error {
 		"content": me.Content,
 		"private": me.IsPrivate,
 		"type":    me.Type,
-		"actor":   me.Actor,
 		"owner":   me.Owner,
 		"version": me.Version,
 	})
@@ -102,7 +93,6 @@ func (me *Document) UnmarshalHCL(decoder hcl.Decoder) error {
 		"content": &me.Content,
 		"private": &me.IsPrivate,
 		"type":    &me.Type,
-		"actor":   &me.Actor,
 		"owner":   &me.Owner,
 		"version": &me.Version,
 	})
@@ -124,7 +114,6 @@ func (me *Document) MarshalJSON() ([]byte, error) {
 		Private:       me.IsPrivate,
 		Content:       me.Content,
 		Type:          me.Type,
-		Actor:         me.Actor,
 		Owner:         me.Owner,
 		Version:       me.Version,
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/dlclark/regexp2 v1.11.4
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250909143246-7fb4c95b93f2
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250929124837-64123fbe037b
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250909143246-7fb4c95b93f2 h1:o3Qk+FADLz3RQ4mVslL+IEeZXkW9rMb/V68gtUZjDus=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250909143246-7fb4c95b93f2/go.mod h1:WS25NEP6eSgnnj3Uul4aJKE3ozR6SLeCLcs2f01v1vU=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250929124837-64123fbe037b h1:9XjZQIaH6zvytrO4EaNql8B3EvHwO0qus360wcmwK0g=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20250929124837-64123fbe037b/go.mod h1:WS25NEP6eSgnnj3Uul4aJKE3ozR6SLeCLcs2f01v1vU=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
#### **Why** this PR?
This PR tidies up the `dynatrace_document` resource, removing several inconsistencies with the API

#### **What** has changed and **how** does it do it?
 - As the `owner` field can't be used to update the owner of the document, this is marked as solely computed
 - The `actor` field is removed as the API doesn't actually support this.
 - The `schemaVersion` is removed as it is not used by the API or exposed via HCL.
 
#### How is it **tested**?
Existing acceptance tests.

#### How does it affect **users**?
Very little, except that users will no longer be able to set the `owner` field, which didn't work anyway. Furthermore, an error is now emitted, if the `actor` field is used.

**Issue:** CA-16604
