### PR TITLE
feat(document): support custom IDs 

### DIFF
--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+
 	docapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	docclient "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 
@@ -56,6 +57,7 @@ func (me *service) Get(ctx context.Context, id string, v *documents.Document) (e
 		if strings.Contains(err.Error(), "unexpected EOF") {
 			cfg := ctx.Value(settings.ContextKeyStateConfig)
 			if stateDocument, ok := cfg.(*documents.Document); ok {
+				v.ID = stateDocument.ID
 				v.Name = stateDocument.Name
 				v.Content = stateDocument.Content
 				v.IsPrivate = stateDocument.IsPrivate
@@ -82,6 +84,7 @@ func (me *service) get(ctx context.Context, id string, v *documents.Document) (e
 		return err
 	}
 
+	v.ID = result.ID
 	v.Content = string(result.Data)
 	v.IsPrivate = result.IsPrivate
 	v.Name = result.Name
@@ -149,7 +152,7 @@ func (me *service) createPrivate(ctx context.Context, v *documents.Document) (st
 	if err != nil {
 		return nil, err
 	}
-	response, err := c.Create(ctx, v.Name, v.IsPrivate, "", []byte(v.Content), docclient.DocumentType(v.Type))
+	response, err := c.Create(ctx, v.Name, v.IsPrivate, v.ID, []byte(v.Content), docclient.DocumentType(v.Type))
 	if err != nil {
 		if apiError, ok := err.(docapi.APIError); ok {
 			return nil, rest.Error{Code: apiError.StatusCode, Message: string(apiError.Body)}

--- a/dynatrace/api/documents/document/service_test.go
+++ b/dynatrace/api/documents/document/service_test.go
@@ -18,11 +18,96 @@
 package documents_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestAccDocuments(t *testing.T) {
+	// this also tests "no custom ID" => "no change after apply & plan"
 	api.TestAcc(t)
+}
+
+func TestAccDocumentsCustomID(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	const resourceName = "dynatrace_document.this"
+	configNoID, _ := api.ReadTfConfig(t, "testdata-2/without-custom-id.tf")
+	configCustomID, customID := api.ReadTfConfig(t, "testdata-2/with-custom-id.tf")
+	configCustomID2, customID2 := api.ReadTfConfig(t, "testdata-2/with-custom-id.tf")
+	configUUID, _ := api.ReadTfConfig(t, "testdata-2/with-custom-uuid.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("No ID to custom ID works", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configNoID},
+				{Config: configCustomID, ExpectNonEmptyPlan: true, PlanOnly: true},
+				{
+					Config: configCustomID,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "custom_id", customID),
+						resource.TestCheckResourceAttr(resourceName, "id", customID),
+					),
+				},
+			},
+		}
+		resource.Test(t, testCase)
+	})
+
+	t.Run("Custom ID to a different custom ID works", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCustomID},
+				{Config: configCustomID2, ExpectNonEmptyPlan: true, PlanOnly: true},
+				{
+					Config: configCustomID2,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "custom_id", customID2),
+					),
+				},
+			},
+		}
+		resource.Test(t, testCase)
+	})
+
+	t.Run("Custom ID to nothing results in no change", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCustomID},
+				{
+					Config: configNoID,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "custom_id", customID),
+					),
+					PlanOnly: true,
+				},
+			},
+		}
+		resource.Test(t, testCase)
+	})
+
+	t.Run("A UUID as a custom ID results in an error", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configUUID, ExpectError: regexp.MustCompile("not be a UUID"), PlanOnly: true},
+			},
+		}
+		resource.Test(t, testCase)
+	})
 }

--- a/dynatrace/api/documents/document/settings/validation.go
+++ b/dynatrace/api/documents/document/settings/validation.go
@@ -1,0 +1,44 @@
+/**
+* @license
+* Copyright 2020 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package documents
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+var ValidateIsUUID = func(id string) bool {
+	_, err := uuid.Parse(id)
+	return err == nil
+}
+
+var ValidateNotUUID = func(i any, p cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if ValidateIsUUID(i.(string)) {
+		diag := diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "The value must not be a UUID",
+			Detail:   fmt.Sprintf("%v is a UUID", i),
+		}
+		diags = append(diags, diag)
+	}
+	return diags
+}

--- a/dynatrace/api/documents/document/testdata-2/with-custom-id.tf
+++ b/dynatrace/api/documents/document/testdata-2/with-custom-id.tf
@@ -1,0 +1,12 @@
+resource "dynatrace_document" "this" {
+  type = "dashboard"
+  name = "Example Dashboard"
+  custom_id = "#name#"
+  content = jsonencode(
+    {
+      "version" : 13,
+      "variables" : [],
+      "tiles" : {}
+    }
+  )
+}

--- a/dynatrace/api/documents/document/testdata-2/with-custom-uuid.tf
+++ b/dynatrace/api/documents/document/testdata-2/with-custom-uuid.tf
@@ -1,0 +1,12 @@
+resource "dynatrace_document" "this" {
+  type = "dashboard"
+  name = "Example Dashboard"
+  custom_id = "00000000-0000-0000-0000-000000000000"
+  content = jsonencode(
+    {
+      "version" : 13,
+      "variables" : [],
+      "tiles" : {}
+    }
+  )
+}

--- a/dynatrace/api/documents/document/testdata-2/without-custom-id.tf
+++ b/dynatrace/api/documents/document/testdata-2/without-custom-id.tf
@@ -1,0 +1,11 @@
+resource "dynatrace_document" "this" {
+  type = "dashboard"
+  name = "Example Dashboard"
+  content = jsonencode(
+    {
+      "version" : 13,
+      "variables" : [],
+      "tiles" : {}
+    }
+  )
+}

--- a/dynatrace/api/documents/document/testdata/terraform/example-a.tf
+++ b/dynatrace/api/documents/document/testdata/terraform/example-a.tf
@@ -1,6 +1,7 @@
 resource "dynatrace_document" "this" {
   type = "dashboard"
   name = "Example Dashboard"
+  custom_id = "#name#"
   content = jsonencode(
     {
       "version" : 13,

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
 
 	"github.com/google/uuid"
 )
@@ -202,66 +203,97 @@ type TestAccOptions struct {
 	ExpectNonEmptyPlan bool
 }
 
+func AccEnvsGiven(t *testing.T) bool {
+	t.Helper()
+	if v := os.Getenv("TF_ACC"); v == "" {
+		t.Skip("TF_ACC has not been set for acceptance tests")
+		return false
+	}
+	if v := os.Getenv("DYNATRACE_ENV_URL"); v == "" {
+		t.Skip("DYNATRACE_ENV_URL has not been set for acceptance tests")
+		return false
+	}
+	return true
+}
+
+// RandomizeResource replaces "#name#" and "${randomize}" with a random string
+// Returns:
+// 	- The replaced config
+//  - The random string that was used
+func RandomizeResource(config string) (replacedConfig string, identifier string) {
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	config = strings.ReplaceAll(config, "#name#", name)
+	return strings.ReplaceAll(config, "${randomize}", name), name
+}
+
+// ReadTfConfig reads a config and replaces "#name#" and "${randomize}" with a random string
+// Returns:
+// 	- The replaced config
+//  - The random string that was used
+func ReadTfConfig(t *testing.T, file string) (config string, identifier string) {
+	t.Helper()
+	content, err := os.ReadFile(file)
+	require.NoError(t, err)
+
+	return RandomizeResource(string(content))
+}
+
+func readTestData(t *testing.T) []string {
+	t.Helper()
+	testDataFolders, _ := os.ReadDir("testdata")
+	allFiles := make([]string, 0)
+
+	for _, entry := range testDataFolders {
+		if !entry.IsDir() {
+			continue
+		}
+		folder := path.Join("testdata", entry.Name())
+
+		entries, err := os.ReadDir(folder)
+		require.NoError(t, err)
+
+		for _, entry := range entries {
+			if !strings.HasSuffix(entry.Name(), ".tf") || strings.HasSuffix(entry.Name(), "__providers__.tf") {
+				continue
+			}
+			allFiles = append(allFiles, path.Join(folder, entry.Name()))
+		}
+	}
+	return allFiles
+}
+
 func TestAcc(t *testing.T, opts ...TestAccOptions) {
 	var options TestAccOptions
 	if len(opts) > 0 {
 		options = opts[0]
 	}
 	t.Helper()
-	if v := os.Getenv("TF_ACC"); v == "" {
-		t.Skip("TF_ACC has not been set for acceptance tests")
-		return
-	}
-	if v := os.Getenv("DYNATRACE_ENV_URL"); v == "" {
-		t.Skip("DYNATRACE_ENV_URL has not been set for acceptance tests")
+
+	if !AccEnvsGiven(t) {
 		return
 	}
 
-	entries, _ := os.ReadDir("testdata")
-	for _, entry := range entries {
-		if entry.IsDir() {
-			var err error
-			folder := path.Join("testdata", entry.Name())
-			allFiles := []string{}
+	allFiles := readTestData(t)
 
-			var entries []fs.DirEntry
-			if entries, err = os.ReadDir(folder); err != nil {
-				t.Error(err)
-				return
-			}
-			for _, entry := range entries {
-				if !strings.HasSuffix(entry.Name(), ".tf") || strings.HasSuffix(entry.Name(), "__providers__.tf") {
-					continue
-				}
-				allFiles = append(allFiles, path.Join(folder, entry.Name()))
-			}
-			for _, file := range allFiles {
-				subTestName := strings.TrimPrefix(file, "testdata/")
-				t.Run(subTestName, func(t *testing.T) {
-					t.Helper()
-					var err error
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
 
-					var content []byte
-					if content, err = os.ReadFile(file); err != nil {
-						t.Error(err)
-						return
-					}
-					config := string(content)
-					name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-					config = strings.ReplaceAll(config, "#name#", name)
-					config = strings.ReplaceAll(config, "${randomize}", name)
-					provider := provider.Provider()
-					testCase := &resource.TestCase{
-						ProviderFactories: map[string]func() (*schema.Provider, error){
-							"dynatrace": func() (*schema.Provider, error) {
-								return provider, nil
-							},
-						},
-						Steps: []resource.TestStep{{Config: config, ExpectNonEmptyPlan: options.ExpectNonEmptyPlan}},
-					}
-					resource.Test(t, *testCase)
-				})
+	for _, file := range allFiles {
+		subTestName := strings.TrimPrefix(file, "testdata/")
+
+		t.Run(subTestName, func(t *testing.T) {
+			t.Helper()
+
+			config, _ := ReadTfConfig(t, file)
+
+			testCase := resource.TestCase{
+				ProviderFactories: providerFactories,
+				Steps:             []resource.TestStep{{Config: config, ExpectNonEmptyPlan: options.ExpectNonEmptyPlan}},
 			}
-		}
+			resource.Test(t, testCase)
+		})
 	}
 }


### PR DESCRIPTION
#### **Why** this PR?
The documents API supports setting a custom ID. Therefore, the provider needs to be adapted to support this case.

#### **What** has changed?
An optional `custom_id` can now be set for the document.

#### **How** does it do it?
By adding it to the HCL schema and forwarding it to the dashboard API

#### How is it **tested**?
New tests were added, and the testing utilities were also extended and refactored.

#### How does it affect **users**?
Users can now define a custom ID for their documents.

**Issue:** CA-16591

### Notes to the reviewer
`id` can't be used for the HCL schema, as this seems to be a reserved (import) property