### PR TITLE
Fix for #813

### DIFF
--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -69,9 +69,12 @@ func validateCredentials(conf *ProviderConfiguration, CredentialValidation int) 
 		if len(conf.IAM.ClientSecret) == 0 {
 			return fmt.Errorf(" No OAuth Client Secret has been specified. Use either the environment variable `DT_CLIENT_SECRET` or the configuration attribute `iam_client_secret` of the provider for that")
 		}
-		if len(conf.IAM.TokenURL) == 0 {
-			return fmt.Errorf(" No OAuth TokenURL has been specified. Use either the environment variable `DT_TOKEN_URL` or the configuration attribute `iam_token_url` of the provider for that")
-		}
+		// We don't complain about a missing Token URL anymore
+		// It is either getting deducted from the Environment URL or assumed to be the default for a SaaS Production Tenant
+		//
+		// if len(conf.IAM.TokenURL) == 0 {
+		// 	return fmt.Errorf(" No OAuth TokenURL has been specified. Use either the environment variable `DT_TOKEN_URL` or the configuration attribute `iam_token_url` of the provider for that")
+		// }
 	case CredValCluster:
 		if len(conf.ClusterAPIToken) == 0 {
 			return fmt.Errorf(" No Cluster API Token has been specified. Use either the environment variable `DT_CLUSTER_API_TOKEN` or the configuration attribute `dt_cluster_api_token` of the provider for that")
@@ -215,13 +218,13 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnost
 
 	automation_client_id = streamlineOAuthCreds(automation_client_id, client_id, iam_client_id)
 	automation_client_secret = streamlineOAuthCreds(automation_client_secret, client_secret, iam_client_secret)
-	automation_token_url = streamlineOAuthCreds(automation_token_url, token_url, iam_token_url)
+	automation_token_url = streamlineOAuthCreds(automation_token_url, token_url, iam_token_url, rest.ProdTokenURL)
 
 	iam_client_id = streamlineOAuthCreds(iam_client_id, client_id, automation_client_id)
 	iam_client_secret = streamlineOAuthCreds(iam_client_secret, client_secret, automation_client_secret)
-	iam_token_url = streamlineOAuthCreds(iam_token_url, token_url, automation_token_url)
+	iam_token_url = streamlineOAuthCreds(iam_token_url, token_url, automation_token_url, rest.ProdTokenURL)
 	iam_account_id = streamlineOAuthCreds(iam_account_id, account_id)
-	iam_endpoint_url = streamlineOAuthCreds(iam_endpoint_url, oauth_endpoint_url)
+	iam_endpoint_url = streamlineOAuthCreds(iam_endpoint_url, oauth_endpoint_url, rest.ProdIAMEndpointURL)
 
 	var diags diag.Diagnostics
 

--- a/resources/generic.go
+++ b/resources/generic.go
@@ -166,8 +166,17 @@ func (me *Generic) Resource() *schema.Resource {
 }
 
 func (me *Generic) createCredentials(m any) (*rest.Credentials, error) {
+	// By default credential validation follows the default route
+	// (EnvURL, APIToken)
+	cv := config.CredValDefault
+	// Unless `me.CredentialValidation` vetoes it
+	// Example `dynatrace_iam_*` resources don't require environment URL
+	// But instead need OAuth Credentials
+	if me.CredentialValidation != cv {
+		cv = me.CredentialValidation
+	}
 	conf := m.(*config.ProviderConfiguration)
-	if _, err := config.Credentials(m, config.CredValDefault); err != nil {
+	if _, err := config.Credentials(m, cv); err != nil {
 		return nil, err
 	}
 	return &rest.Credentials{


### PR DESCRIPTION
These changes are supposed to take care of #813.

I've talked things through with @arthurpitman really quick.
The requirement for having an environment URL specified originates from the fact, that Token URL and API Endpoint can get deducted easily from them - which eases up things for Dynatrace internal users.

The core functionality for alternative Credential Validation for IAM resources was already implemented.
What this PR ensures now is, that if no Token URL or API Endpoint has been specified the ones for SaaS Prod Tenants will be used as defaults.