### PR TITLE
fix: Typos in descriptions for `credentials_id` in `dynatrace_aws_service` and `dynatrace_azure_service`

### DIFF
--- a/dynatrace/api/v1/config/credentials/aws/services/settings/settings.go
+++ b/dynatrace/api/v1/config/credentials/aws/services/settings/settings.go
@@ -41,7 +41,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"credentials_id": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "the ID of the azure credentials this supported service belongs to",
+			Description: "the ID of the AWS credentials this supported service belongs to",
 			ForceNew:    true,
 		},
 		"name": {

--- a/dynatrace/api/v1/config/credentials/azure/services/settings/settings.go
+++ b/dynatrace/api/v1/config/credentials/azure/services/settings/settings.go
@@ -45,7 +45,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"credentials_id": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "the ID of the azure credentials this supported service belongs to",
+			Description: "the ID of the Azure credentials this supported service belongs to",
 			ForceNew:    true,
 		},
 		"name": {


### PR DESCRIPTION
#### **Why** this PR?
Some typos were found in the rendered documentation, these come from the field descriptions in a couple of resources. This PR fixes two such instances.

#### **What** has changed and **how** does it do it?
- Reference `AWS` rather than `azure` in `credentials_id` description in `dynatrace/api/v1/config/credentials/aws/services/settings/settings.go`
- Use `Azure` rather than `azure` in `credentials_id` description in  `dynatrace/api/v1/config/credentials/azure/services/settings/settings.go`

#### How is it **tested**?
Not applicable.

#### How does it affect **users**?
Better experience.

**Issue:** CA-16637
