### PR TITLE
fix: remove openpipeline exception for repairInput

### DIFF
--- a/dynatrace/settings/services/settings20/client.go
+++ b/dynatrace/settings/services/settings20/client.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -269,7 +268,7 @@ func (c client) create(ctx context.Context, data []byte) (*http.Response, error)
 }
 
 func IsSkipRepairSchemaID(schemaID string) bool {
-	return strings.HasPrefix(schemaID, "builtin:openpipeline.")
+	return false
 }
 
 func (c client) setRepairInput(options *rest.RequestOptions) {


### PR DESCRIPTION
#### **Why** this PR?
Due to a bug with the `repairInput` param and references in openpipeline schemas, it wasn't possible to create and update openpipeline settings. The bug has been fixed, so the workaround/exception can be removed

#### **What** has changed?
OpenPipeline update and create operations are now also executed with repairInput

#### **How** does it do it?
The exception for OpenPipelien repairInput has been removed.

#### How is it **tested**?
Current AC tests cover it.

#### How does it affect **users**?
Incomplete settings (due to version conflicts) may work