### PR TITLE
fix: AWS service metrics require dimensions 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3517,6 +3517,20 @@ jobs:
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
           DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
         run: go test -v ./dynatrace/api/v1/config/credentials/azure
+      - name: TestAzureService
+        if: success() || failure()
+        env:
+          GOPROXY: "https://proxy.golang.org"
+          TF_ACC: true
+          DYNATRACE_DEBUG: true
+          DYNATRACE_HTTP_OAUTH_PREFERENCE: true
+          DT_NO_REPAIR_INPUT: false
+          DYNATRACE_ENV_URL: ${{ secrets.DYNATRACE_ENV_URL }}
+          DYNATRACE_API_TOKEN: ${{ secrets.DYNATRACE_API_TOKEN }}
+          DT_CLIENT_ID: ${{ secrets.DT_CLIENT_ID }}
+          DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
+          DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
+        run: go test -v ./dynatrace/api/v1/config/credentials/azure/services
       - name: TestCloudFoundryCredentials
         if: success() || failure()
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3489,6 +3489,20 @@ jobs:
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
           DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
         run: go test -v ./dynatrace/api/v1/config/credentials/aws
+      - name: TestAWSService
+        if: success() || failure()
+        env:
+          GOPROXY: "https://proxy.golang.org"
+          TF_ACC: true
+          DYNATRACE_DEBUG: true
+          DYNATRACE_HTTP_OAUTH_PREFERENCE: true
+          DT_NO_REPAIR_INPUT: false
+          DYNATRACE_ENV_URL: ${{ secrets.DYNATRACE_ENV_URL }}
+          DYNATRACE_API_TOKEN: ${{ secrets.DYNATRACE_API_TOKEN }}
+          DT_CLIENT_ID: ${{ secrets.DT_CLIENT_ID }}
+          DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
+          DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
+        run: go test -v ./dynatrace/api/v1/config/credentials/aws/services
       - name: TestAzureCredentials
         if: success() || failure()
         env:

--- a/dynatrace/api/v1/config/credentials/aws/services/service_test.go
+++ b/dynatrace/api/v1/config/credentials/aws/services/service_test.go
@@ -1,0 +1,28 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccAWSService(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/v1/config/credentials/aws/services/settings/aws_monitored_metric.go
+++ b/dynatrace/api/v1/config/credentials/aws/services/settings/aws_monitored_metric.go
@@ -46,7 +46,8 @@ func (amm *AWSMonitoredMetric) Schema() map[string]*schema.Schema {
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "a list of metric's dimensions names",
-			Optional:    true,
+			MinItems:    1,
+			Required:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 	}

--- a/dynatrace/api/v1/config/credentials/aws/services/testdata/terraform/example.tf
+++ b/dynatrace/api/v1/config/credentials/aws/services/testdata/terraform/example.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_aws_credentials" "Example" {
+  label                                 = "#name#"
+  partition_type                        = "AWS_DEFAULT"
+  tagged_only                           = false
+  authentication_data {
+    account_id = "123456789"
+    iam_role   = "aws-monitoring-role"
+  }
+}
+
+resource "dynatrace_aws_service" "ElastiCache" {
+  name           = "ElastiCache"
+  credentials_id = dynatrace_aws_credentials.Example.id
+  metric {
+    name       = "NetworkBandwidthOutAllowanceExceeded"
+    dimensions = [ "CacheClusterId" ]
+    statistic  = "SUM"
+  }
+  metric {
+    name       = "CPUUtilization"
+    dimensions = [ "CacheClusterId" ]
+    statistic  = "AVG_MIN_MAX"
+  }
+}

--- a/dynatrace/api/v1/config/credentials/azure/services/service_test.go
+++ b/dynatrace/api/v1/config/credentials/azure/services/service_test.go
@@ -24,5 +24,5 @@ import (
 )
 
 func TestAccAzureService(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAcc(t, api.TestAccOptions{ExpectNonEmptyPlan: true})
 }

--- a/dynatrace/api/v1/config/credentials/azure/services/service_test.go
+++ b/dynatrace/api/v1/config/credentials/azure/services/service_test.go
@@ -1,0 +1,28 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccAzureService(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/v1/config/credentials/azure/services/testdata/terraform/example.tf
+++ b/dynatrace/api/v1/config/credentials/azure/services/testdata/terraform/example.tf
@@ -1,0 +1,27 @@
+resource "dynatrace_azure_credentials" "Example" {
+  active                                     = true
+  app_id                                     = "123456789"
+  auto_tagging                               = true
+  directory_id                               = "123456789"
+  key                                        = "123456789"
+  label                                      = "Example"
+  monitor_only_tagged_entities               = false
+}
+
+
+resource "dynatrace_azure_service" "ContainerService" {
+  name           = "cloud:azure:containerservice:managedcluster"
+  credentials_id = dynatrace_azure_credentials.Example.id
+  metric {
+    name = "kube_pod_status_ready"
+    dimensions = []
+  }
+  metric {
+    name       = "kube_node_status_condition"
+    dimensions = [ "condition", "status", "node" ]
+  }
+  metric {
+    name       = "kube_pod_status_phase"
+    dimensions = [ "phase", "namespace" ]
+  }
+}

--- a/templates/resources/aws_service.md.tmpl
+++ b/templates/resources/aws_service.md.tmpl
@@ -16,6 +16,8 @@ description: |-
 
 - Amazon Web Services - https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-cloud-platforms/amazon-web-services/amazon-web-services-integrations/aws-service-metrics
 
+- The dimensions and statistics for metrics for individual services - https://docs.dynatrace.com/docs/ingest-from/amazon-web-services/integrate-with-aws/aws-all-services
+
 - AWS credentials API - https://www.dynatrace.com/support/help/dynatrace-api/configuration-api/aws-credentials-api
 
 ## Resource Example Usage

--- a/templates/resources/aws_service.md.tmpl
+++ b/templates/resources/aws_service.md.tmpl
@@ -25,9 +25,6 @@ description: |-
 This example utilizes the data source `dynatrace_aws_supported_services` in order to query for a full list of all supported services.
 The `for_each` loop within the resource `dynatrace_aws_service` configures each of these services to get utilized with the default metrics recommended by Dynatrace (`use_recommended_metrics`).
 
-If you want to configure a different set of metrics for a specific service, a separate resource `dynatrace_aws_service` will be necessary for that. That allows you to configure the `metric` blocks according to your wishes.
-Just be aware of the fact, that Dynatrace enforces for most services a recommended set of metrics. All of them need to be part of your configuration in order to end up with a non-empty plan.
-
 ```terraform
 resource "dynatrace_aws_credentials" "TERRAFORM_SAMPLE" {
   label          = "TERRAFORM-TEST-001"
@@ -50,6 +47,11 @@ resource "dynatrace_aws_service" "TERRAFORM_SAMPLE_services" {
   name           = each.key
 }
 ```
+
+If you want to configure a different set of metrics for a specific service, a separate resource `dynatrace_aws_service` will be necessary for that. That allows you to configure the `metric` blocks according to your wishes.
+Just be aware of the fact, that Dynatrace enforces for most services a recommended set of metrics. All of them need to be part of your configuration in order to end up with a non-empty plan.
+
+{{ tffile "dynatrace/api/v1/config/credentials/aws/services/testdata/terraform/example.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
  

--- a/templates/resources/azure_service.md.tmpl
+++ b/templates/resources/azure_service.md.tmpl
@@ -16,6 +16,8 @@ description: |-
 
 - Microsoft Azure monitoring - https://www.dynatrace.com/support/help/how-to-use-dynatrace/infrastructure-monitoring/cloud-platform-monitoring/microsoft-azure-services-monitoring
 
+- The dimensions for metrics for individual services - https://docs.dynatrace.com/docs/ingest-from/microsoft-azure-services/azure-integrations/azure-cloud-services-metrics
+
 - Azure credentials API - https://www.dynatrace.com/support/help/dynatrace-api/configuration-api/azure-credentials-api
 
 ## Resource Example Usage

--- a/templates/resources/azure_service.md.tmpl
+++ b/templates/resources/azure_service.md.tmpl
@@ -25,9 +25,6 @@ description: |-
 This example utilizes the data source `dynatrace_azure_supported_services` in order to query for a full list of all supported services.
 The `for_each` loop within the resource `dynatrace_azure_service` configures each of these services to get utilized with the default metrics recommended by Dynatrace (`use_recommended_metrics`).
 
-If you want to configure a different set of metrics for a specific service, a separate resource `dynatrace_azure_service` will be necessary for that. That allows you to configure the `metric` blocks according to your wishes.
-Just be aware of the fact, that Dynatrace enforces for most services a recommended set of metrics. All of them need to be part of your configuration in order to end up with a non-empty plan.
-
 ```terraform
 resource "dynatrace_azure_credentials" "TERRAFORM_SAMPLE" {
   active                       = false
@@ -55,6 +52,11 @@ resource "dynatrace_azure_service" "TERRAFORM_SAMPLE_services" {
   name           = each.key
 }
 ```
+
+If you want to configure a different set of metrics for a specific service, a separate resource `dynatrace_azure_service` will be necessary for that. That allows you to configure the `metric` blocks according to your wishes.
+Just be aware of the fact, that Dynatrace enforces for most services a recommended set of metrics. All of them need to be part of your configuration in order to end up with a non-empty plan.
+
+{{ tffile "dynatrace/api/v1/config/credentials/azure/services/testdata/terraform/example.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
  


### PR DESCRIPTION
#### **Why** this PR?
The API requires that AWS service metrics specify at least one dimension. This PR updates the schema of the  `dynatrace_aws_service` resource to enforce that.

This resource is similar to the `dynatrace_azure_service`, however, this resource does not have that restriction.

#### **What** has changed and **how** does it do it?
- Updates the schema of `dynatrace_aws_service` to require at least one dimension for metrics.
- Adds examples for these resources that include specifying metrics.
- Adds further links to Dynatrace documentation for the AWS and Azure services.

#### How is it **tested**?
New tests are added for `dynatrace_aws_service` and `dynatrace_azure_service` resources.

#### How does it affect **users**?
Invalid `dynatrace_aws_service` resources will fail earlier during planning, before the API is called.
Documentation is improved, making the resources easier to use.

**Issue:** CA-16636
