### PR TITLE
fix(openpipeline-v1): set correct download count

### DIFF
--- a/dynatrace/api/openpipeline/service.go
+++ b/dynatrace/api/openpipeline/service.go
@@ -26,6 +26,7 @@ import (
 	openpipeline "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/openpipeline/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+
 	cacapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	caclib "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 )
@@ -93,7 +94,14 @@ func (s *service) createClient(ctx context.Context) (*caclib.Client, error) {
 }
 
 func (s *service) List(ctx context.Context) (api.Stubs, error) {
-	//create exactly one stub for this ID
+	client, err := s.createClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// after migration the resource isn't available anymore (404)
+	if _, err = client.Get(ctx, s.kind); err != nil {
+		return nil, err
+	}
 
 	stub := api.Stub{ID: s.kind, Name: s.kind}
 	return api.Stubs{&stub}, nil

--- a/dynatrace/api/openpipeline/service_test.go
+++ b/dynatrace/api/openpipeline/service_test.go
@@ -18,9 +18,16 @@
 package openpipeline_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	api2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/openpipeline"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccOpenPipeline(t *testing.T) {
@@ -28,4 +35,43 @@ func TestAccOpenPipeline(t *testing.T) {
 	// - Seems like no kind currently supports the "azure_log_forwarding_processor" and "security_event_extraction_processor"
 	t.Skip("Tests skipped until REST API doesn't respond back with version conflicts any more")
 	api.TestAcc(t)
+}
+
+func TestList(t *testing.T) {
+	t.Run("Returns an error if the client creation fails", func(t *testing.T) {
+		_, err := openpipeline.EventsService(&rest.Credentials{}).List(t.Context())
+		assert.ErrorIs(t, err, rest.NoPlatformCredentialsErr)
+	})
+
+	t.Run("Returns an error if the config doesn't exist anymore", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(404)
+			_, err := w.Write([]byte("Not Found"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+		_, err := openpipeline.EventsService(&rest.Credentials{
+			OAuth: rest.OAuthCredentials{
+				EnvironmentURL: server.URL,
+				PlatformToken:  "token",
+			},
+		}).List(t.Context())
+		assert.ErrorContains(t, err, "Not Found")
+	})
+
+	t.Run("Returns the list of configs", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		}))
+		defer server.Close()
+
+		configs, err := openpipeline.EventsService(&rest.Credentials{
+			OAuth: rest.OAuthCredentials{
+				EnvironmentURL: server.URL,
+				PlatformToken:  "token",
+			},
+		}).List(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, configs, api2.Stubs{&api2.Stub{ID: "events", Name: "events"}})
+	})
 }


### PR DESCRIPTION
#### **Why** this PR?
The OpenPipeline export always contained "downloading 1 item". This is not always true, as the credentials may be invalid or the migration to OpenPipeline V2 may have happened

#### **What** has changed?
It's now checked if the credentials are valid and if the OpenPipeline V2 resource exists.

#### **How** does it do it?
By calling the endpoint if the config exists

#### How is it **tested**?
New tests added.

#### How does it affect **users**?
They will now correctly see errors and download counts for the Openpipeline V1 config.

