### PR TITLE
Updating iam boundaries must not expect a JSON response

### DIFF
--- a/dynatrace/api/iam/boundaries/service.go
+++ b/dynatrace/api/iam/boundaries/service.go
@@ -126,11 +126,10 @@ func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.Polic
 
 func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
 	var err error
-	var responseBytes []byte
 
 	client := iam.NewIAMClient(me)
 
-	if responseBytes, err = client.PUT_MULTI_RESPONSE(
+	if _, err = client.PUT_MULTI_RESPONSE(
 		ctx,
 		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), id),
 		v,
@@ -138,15 +137,7 @@ func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *bound
 		false,
 	); err != nil {
 		return err
-	}
 
-	response := struct {
-		UUID string `json:"uuid"`
-		Name string `json:"name"`
-	}{}
-
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
#824 describes that the provider errors out after updating IAM boundaries.

Root cause here is, that the PUT request expects a response to come back - no matter what response code (201 or 204).

Solution: Unless the IAM client throws an error, the response must not be checked. It's irrelevant anyways for successful response codes. In case neither 201 nor 204 are the response code, the IAM client will throw an error as expected.