### PR TITLE
fix(openpipeline-v2): set correct enum values

### DIFF
--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Possible Values: `Exclude`, `Include`, `IncludeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Exclude`, `Include`, `IncludeAll`",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Possible Values: `Constant`, `Field`, `MultiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant`, `Field`, `MultiValueConstant`",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/processor.go
@@ -71,7 +71,7 @@ type Processor struct {
 	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
 	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
 	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`
+	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
 	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
 }
 
@@ -240,7 +240,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `AzureLogForwarding`, `Bizevent`, `BucketAssignment`, `CostAllocation`, `CounterMetric`, `Davis`, `Dql`, `Drop`, `FieldsAdd`, `FieldsRemove`, `FieldsRename`, `HistogramMetric`, `NoStorage`, `ProductAllocation`, `SamplingAwareCounterMetric`, `SamplingAwareValueMetric`, `SecurityContext`, `SecurityEvent`, `Technology`, `ValueMetric`",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `Disabled`, `Enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `Disabled`, `Enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -23,20 +23,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `Disabled`, `Enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `Duration`, `Field`
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `Disabled`, `Enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -59,7 +59,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Duration`, `Field`",
+			Description: "Possible Values: `duration`, `field`.",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +69,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Disabled`, `Enabled`",
+			Description: "Possible Values: `disabled`, `enabled`.",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Possible Values: `Builtin`, `Custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Builtin`, `Custom`",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
 			Required:    true,
 		},
 	}


### PR DESCRIPTION
#### **Why** this PR?
The enum values weren't correctly right. There were some casing issues, e.g., "Bizevent" => "bizevent" or "FieldsAdd" => "fieldsAdd".

#### **What** has changed?
- Enums in descriptions updated
- Also added the comment of the enum property in the schema if there is one.

#### **How** does it do it?
By updating every enum description property in the schema

#### How is it **tested**?
No tests needed, this is just visual.

#### How does it affect **users**?
They see the correct values in the documentation
