### PR TITLE
test: fix flaky attribute-masking and hub-subscription tests

### DIFF
--- a/dynatrace/api/builtin/attribute/masking/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/attribute/masking/testdata/terraform/example_a.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_attribute_masking" "#name#" {
   enabled = true
-  key = "attribute.example"
+  key = "attribute.#name#"
   masking = "MASK_ENTIRE_VALUE"
 }

--- a/dynatrace/api/builtin/hub/subscriptions/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/hub/subscriptions/testdata/terraform/example_a.tf
@@ -1,7 +1,7 @@
 resource "dynatrace_hub_subscriptions" "#name#" {
   token_subscriptions {
     token_subscription {
-      name        = "#name"
+      name        = "#name#"
       description = "Description"
       enabled     = true
       token       = "123456789012345678901234567890123456"


### PR DESCRIPTION
#### **Why** this PR?
Removed some race conditions for tests. Some settings require a unique name, so tests in parallel may interfere if the name is static. 

#### **What** has changed?
The attribute-masking and hub-subscription tests now have a unique identifier, so that they don't run into conflicts.

#### **How** does it do it?
By adding `#name#` to the fields that need to be unique.

#### How is it **tested**?
Current tests are still working with the unique adjustment

#### How does it affect **users**?
Doesn't affect users.
