### PR TITLE
test: Azure service test produces empty plan

### DIFF
--- a/dynatrace/api/v1/config/credentials/azure/services/service_test.go
+++ b/dynatrace/api/v1/config/credentials/azure/services/service_test.go
@@ -24,5 +24,5 @@ import (
 )
 
 func TestAccAzureService(t *testing.T) {
-	api.TestAcc(t, api.TestAccOptions{ExpectNonEmptyPlan: true})
+	api.TestAcc(t)
 }

--- a/dynatrace/api/v1/config/credentials/azure/services/testdata/terraform/example.tf
+++ b/dynatrace/api/v1/config/credentials/azure/services/testdata/terraform/example.tf
@@ -4,7 +4,7 @@ resource "dynatrace_azure_credentials" "Example" {
   auto_tagging                               = true
   directory_id                               = "123456789"
   key                                        = "123456789"
-  label                                      = "Example"
+  label                                      = "#name#"
   monitor_only_tagged_entities               = false
 }
 


### PR DESCRIPTION
#### **Why** this PR?
The test was failing because it expected a non-empty plan despite the API having changed to no longer include default metrics. This means an empty plan is now expected.

**What** has changed and **how** does it do it?
- Expect an empty plan for `TestAccAzureService`
- Use a randomized name for associated Azure credentials in test

#### How is it **tested**?
The test is updated to expect an empty plan.

#### How does it affect **users**?
No effect.

**Issue:** CA-16756
