### PR TITLE
fix: Active Gate URL parsing

### DIFF
--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -106,7 +106,8 @@ func (me request) HandleResponse(client *rest.Client, u *url.URL, target any) (e
 	case http.MethodDelete:
 		response, err = client.DELETE(ctx, u.Path, rest.RequestOptions{QueryParams: u.Query()})
 	case http.MethodPost, http.MethodPatch, http.MethodPut:
-		body, err := readerFromPayload(me.payload)
+		var body io.Reader
+		body, err = readerFromPayload(me.payload)
 		if err != nil {
 			return err
 		}

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -10,12 +10,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/google/uuid"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
 var DYNATRACE_HTTP_LEGACY = (os.Getenv("DYNATRACE_HTTP_LEGACY") == "true")
@@ -95,20 +95,16 @@ func UnmarshalError(method string, url string, data []byte, response *http.Respo
 	return Error{Code: response.StatusCode, Method: method, URL: url, Message: response.Status}
 }
 
-var reManaged = regexp.MustCompile(`^/e/[0-9a-fA-F\-]{36}/`)
-
 func (me request) HandleResponse(client *rest.Client, u *url.URL, target any) (err error) {
 	var response *http.Response
 
 	ctx := context.WithValue(me.ctx, "request.id", uuid.NewString())
 
-	uPath := reManaged.ReplaceAllString(u.Path, "/")
-
 	switch me.method {
 	case http.MethodGet:
-		response, err = client.GET(ctx, uPath, rest.RequestOptions{QueryParams: u.Query()})
+		response, err = client.GET(ctx, u.Path, rest.RequestOptions{QueryParams: u.Query()})
 	case http.MethodDelete:
-		response, err = client.DELETE(ctx, uPath, rest.RequestOptions{QueryParams: u.Query()})
+		response, err = client.DELETE(ctx, u.Path, rest.RequestOptions{QueryParams: u.Query()})
 	case http.MethodPost, http.MethodPatch, http.MethodPut:
 		body, err := readerFromPayload(me.payload)
 		if err != nil {
@@ -116,11 +112,11 @@ func (me request) HandleResponse(client *rest.Client, u *url.URL, target any) (e
 		}
 		switch me.method {
 		case http.MethodPost:
-			response, err = client.POST(ctx, uPath, body, rest.RequestOptions{QueryParams: u.Query()})
+			response, err = client.POST(ctx, u.Path, body, rest.RequestOptions{QueryParams: u.Query()})
 		case http.MethodPut:
-			response, err = client.PUT(ctx, uPath, body, rest.RequestOptions{QueryParams: u.Query()})
+			response, err = client.PUT(ctx, u.Path, body, rest.RequestOptions{QueryParams: u.Query()})
 		case http.MethodPatch:
-			response, err = client.PATCH(ctx, uPath, body, rest.RequestOptions{QueryParams: u.Query()})
+			response, err = client.PATCH(ctx, u.Path, body, rest.RequestOptions{QueryParams: u.Query()})
 		}
 	default:
 		return fmt.Errorf("unsupported method %s", me.method)


### PR DESCRIPTION
#### **Why** this PR?
Active Gate URLs pointing to non UUID environment IDs weren't working. For `myhost:9999/e/my-env-id` the classic requests always attached another `/e/my-env-id`.

#### **What** has changed?
The URL is now correctly parsed. Active Gate URLs should work again.
The error handling for requests also slightly changed a bit. Errors of `POST/PUT/PATCH` request were swallowed. Because of this the error message pointed to the correct URL but the real request was pointing to a different one (the one with the additional `/e/env_id`).

#### **How** does it do it?
Instead of conditionally removing a URL path prefix, the initial path of the provided dt_env_url is not added again in the first place. The API client that's in use already contains this information (which host and which initial path like active gate). That's why the path was attached a second time.

#### How is it **tested**?
Added another test that checks for the correct URL

#### How does it affect **users**?
They should now be able to use Terraform when using Active Gate.

**Issue:** CA-16828, #832