### PR TITLE
fix(segments): Skip ready-made segments in download

### DIFF
--- a/dynatrace/api/grail/segments/service.go
+++ b/dynatrace/api/grail/segments/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+
 	segmentsapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	segmentsclient "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 
@@ -67,8 +68,9 @@ func (me *service) SchemaID() string {
 }
 
 type SegmentStub struct {
-	UID  string `json:"uid"`
-	Name string `json:"name"`
+	UID         string `json:"uid"`
+	Name        string `json:"name"`
+	IsReadyMade bool   `json:"isReadyMade"`
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
@@ -89,6 +91,10 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	var stubs api.Stubs
 	for _, segment := range segments {
+		// Ready-made segments are unmodifiable, so we skip them in the listing
+		if segment.IsReadyMade {
+			continue
+		}
 		stubs = append(stubs, &api.Stub{ID: segment.UID, Name: segment.Name})
 	}
 

--- a/dynatrace/api/grail/segments/service_test.go
+++ b/dynatrace/api/grail/segments/service_test.go
@@ -18,11 +18,53 @@
 package segments_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/grail/segments"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccSegments(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestList(t *testing.T) {
+	t.Run("Returns an error if the client creation fails", func(t *testing.T) {
+		_, err := segments.Service(&rest.Credentials{}).List(t.Context())
+		assert.ErrorIs(t, err, rest.NoPlatformCredentialsErr)
+	})
+
+	t.Run("Returns the list of segments ignoring ready-made ones", func(t *testing.T) {
+		apiResponse := `{"filterSegments": [
+			{"uid": "1", "name": "ready-made-false", "isPublic": false, "isReadyMade": false},
+			{"uid": "2", "name": "ready-made-true", "isPublic": false, "isReadyMade": true},
+			{"uid": "3", "name": "ready-made-missing","isPublic": false}]}`
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodGet, r.Method)
+			require.Equal(t, "/platform/storage/filter-segments/v1/filter-segments:lean", r.URL.Path)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(apiResponse))
+		}))
+		defer server.Close()
+
+		result, err := segments.Service(&rest.Credentials{
+			OAuth: rest.OAuthCredentials{
+				EnvironmentURL: server.URL,
+				PlatformToken:  "token",
+			},
+		}).List(t.Context())
+
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		for _, segment := range result {
+			assert.True(t, segment.ID != "2", "ready-made segment must be ignored")
+		}
+	})
 }


### PR DESCRIPTION
#### **Why** this PR?
Since ready-made segments cannot be modified, they should also not be downloaded. This is consistent with other resource types such as unmodifiable settings and documents.

#### **What** has changed?
Ready-made segments are not downloaded any longer.

#### **How** does it do it?
In `List` of the segments service, segments which have `IsReadyMade` set to `true` are skipped.

#### **How** is it tested?
A unit test is added that verifies that ready-made segments are skipped on download.

#### How does it affect **users**?
Ready-made segments are not downloaded any longer.

**Issue:**
CA-16805