### PR TITLE
fix(openpipeline-v2): remove empty set items

### DIFF
--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineBizeventsIngestSources(t *testing.T) {
 	t.Skip("Custom ingest sources not allowed")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineBizeventsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineBizeventsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineBizeventsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineDavisEventsIngestSources(t *testing.T) {
 	t.Skip("Custom ingest sources not allowed")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineDavisEventsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("field_extraction_entry", me)
+	if err := decoder.DecodeSlice("field_extraction_entry", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineDavisEventsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineDavisEventsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineDavisProblemsIngestSources(t *testing.T) {
 	t.Skip("Custom ingest sources not allowed")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineDavisProblemsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineDavisProblemsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineDavisProblemsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/service_test.go
@@ -20,9 +20,51 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/events/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineEventsIngestSources(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineEventsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/events/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineEventsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineEventsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service_test.go
@@ -20,9 +20,51 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineEventsSdlcIngestSources(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineEventsSdlcIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineEventsSdlcPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineEventsSdlcPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineEventsSecurityIngestSources(t *testing.T) {
 	t.Skip("Feature not enabled")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineEventsSecurityIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/service_test.go
@@ -20,11 +20,53 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineEventsSecurityPipelines(t *testing.T) {
 	t.Skip("Feature not enabled")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineEventsSecurityPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineLogsIngestSources(t *testing.T) {
 	t.Skip("Custom ingest sources not allowed")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineLogsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/logs/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineLogsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineLogsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineMetricsIngestSources(t *testing.T) {
 	t.Skip("Custom ingest sources not allowed")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineMetricsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineMetricsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineMetricsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service_test.go
@@ -20,9 +20,51 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineSecurityEventsIngestSources(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineSecurityEventsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineSecurityEventsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineSecurityEventsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineSpansIngestSources(t *testing.T) {
 	t.Skip("Feature not enabled")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineSpansIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/service_test.go
@@ -20,11 +20,53 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/spans/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineSpansPipelines(t *testing.T) {
 	t.Skip("Feature not enabled")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineSpansPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineSystemEventsIngestSources(t *testing.T) {
 	t.Skip("Custom ingest sources not allowed")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineSystemEventsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("field_extraction_entry", me)
+	if err := decoder.DecodeSlice("field_extraction_entry", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineSystemEventsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineSystemEventsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineUserEventsIngestSources(t *testing.T) {
 	t.Skip("Custom ingest sources not allowed")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineUserEventsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("field_extraction_entry", me)
+	if err := decoder.DecodeSlice("field_extraction_entry", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/service_test.go
@@ -20,9 +20,51 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineUserEventsPipelines(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineUserEventsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service_test.go
@@ -20,11 +20,53 @@ package ingestsources_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineUsersessionsIngestSources(t *testing.T) {
 	t.Skip("Feature not enabled")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineUsersessionsIngestSourcesUnmarshal(t *testing.T) {
+	entries := new(ingestsources.FieldExtractionEntries)
+	validEntries := []*ingestsources.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service_test.go
@@ -20,11 +20,53 @@ package pipelines_test
 import (
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenPipelineUsersessionsPipelines(t *testing.T) {
 	t.Skip("Feature not enabled")
 
 	api.TestAcc(t)
+}
+
+func TestOpenPipelineUsersessionsPipelinesUnmarshal(t *testing.T) {
+	entries := new(pipelines.FieldExtractionEntries)
+	validEntries := []*pipelines.FieldExtractionEntry{
+		{
+			DefaultValue:         testing2.ToPointer("value"),
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: testing2.ToPointer("value"),
+			SourceFieldName:      "",
+		},
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "value",
+		},
+		{
+			DefaultValue:         testing2.ToPointer("value1"),
+			DestinationFieldName: testing2.ToPointer("value2"),
+			SourceFieldName:      "value3",
+		},
+	}
+	validWithEmpty := pipelines.FieldExtractionEntries{
+		{
+			DefaultValue:         nil,
+			DestinationFieldName: nil,
+			SourceFieldName:      "",
+		},
+	}
+	validWithEmpty = append(validWithEmpty, validEntries...)
+	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
+	require.NoError(t, err)
+	assert.Len(t, *entries, len(validEntries))
+	assert.ElementsMatch(t, *entries, validEntries)
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction_entry.go
@@ -41,7 +41,19 @@ func (me FieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("dimension", me)
+	if err := decoder.DecodeSlice("dimension", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := FieldExtractionEntries{}
+	for _, entry := range *me {
+		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type FieldExtractionEntry struct {

--- a/dynatrace/testing/mockdecoder.go
+++ b/dynatrace/testing/mockdecoder.go
@@ -1,0 +1,61 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testing
+
+import (
+	"reflect"
+)
+
+type MockDecoder struct {
+	Elements map[string]any
+}
+
+func (m MockDecoder) GetOkExists(key string) (any, bool) {
+	panic("not implemented")
+}
+
+func (m MockDecoder) GetOk(key string) (any, bool) {
+	panic("not implemented")
+}
+
+func (m MockDecoder) Get(key string) any {
+	panic("not implemented")
+}
+
+func (m MockDecoder) Decode(key string, v any) error {
+	panic("not implemented")
+}
+
+func (m MockDecoder) DecodeAll(m2 map[string]any) error {
+	panic("not implemented")
+}
+
+func (m MockDecoder) DecodeAny(m2 map[string]any) (any, error) {
+	panic("not implemented")
+}
+
+func (m MockDecoder) DecodeSlice(key string, v any) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Ptr && !rv.IsNil() {
+		rv.Elem().Set(reflect.ValueOf(m.Elements[key]))
+	}
+	return nil
+}
+
+func (m MockDecoder) Path() string {
+	panic("not implemented")
+}

--- a/dynatrace/testing/utils.go
+++ b/dynatrace/testing/utils.go
@@ -1,0 +1,21 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testing
+
+func ToPointer[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
#### **Why** this PR?
For the dimensions of the OpenPipeline V2 resources, it happens that removing a dimension item results in an empty dimension item instead. This is because of a bug in the Terraform plugin SDK.
https://github.com/hashicorp/terraform-plugin-sdk/issues/895

#### **What** has changed?
Empty set items that are coming from the plugin-SDK diff (current API state vs HCL) are now removed when updating the resource

#### **How** does it do it?
By removing all empty dimension items when reading the state diff.

#### How is it **tested**?
Unit test added for every field_extraction_entry that checks if only the empty set item is removed.

#### How does it affect **users**?
They will now be able to remove dimensions of OpenPipeline ingest sources and pipeline resources

**Issue:** CA-16877
