### PR TITLE
chore: deprecate and document IAM group permission usage

### DIFF
--- a/docs/resources/iam_group.md
+++ b/docs/resources/iam_group.md
@@ -14,6 +14,20 @@ description: |-
 
 -> This resource is excluded by default in the export utility, please explicitly specify the resource to retrieve existing configuration.
 
+## Conflicts
+~> **Warning** If this resource is used in combination with `dynatrace_iam_permission`, there is a potential for conflicts when both resources attempt to manage group permissions.
+It is recommended to manage group permissions with the `dynatrace_iam_permission` resource.
+To avoid conflicts when using the `dynatrace_iam_permission` resource, ensure to add the following lifecycle block to the `dynatrace_iam_group` resource:
+```terraform
+resource "dynatrace_iam_group" "Restricted" {
+    name = "Restricted"
+
+    lifecycle {
+      ignore_changes = [permissions]
+    }
+}
+```
+
 ## Dynatrace Documentation
 
 - Dynatrace IAM - https://www.dynatrace.com/support/help/how-to-use-dynatrace/user-management-and-sso/manage-groups-and-permissions
@@ -47,7 +61,7 @@ resource "dynatrace_iam_group" "Restricted" {
 
 - `description` (String)
 - `federated_attribute_values` (Set of String)
-- `permissions` (Block List, Max: 1) (see [below for nested schema](#nestedblock--permissions))
+- `permissions` (Block List, Max: 1, Deprecated) (see [below for nested schema](#nestedblock--permissions))
 
 ### Read-Only
 

--- a/docs/resources/iam_permission.md
+++ b/docs/resources/iam_permission.md
@@ -14,6 +14,20 @@ description: |-
 
 -> This resource is excluded by default in the export utility, please explicitly specify the resource to retrieve existing configuration.
 
+## Conflicts
+~> **Warning** If this resource is used in combination with `dynatrace_iam_group`, there is a potential for conflicts when both resources attempt to manage group permissions.
+It is recommended to manage group permissions with the `dynatrace_iam_permission` resource.
+To avoid conflicts when using the `dynatrace_iam_permission` resource, ensure to add the following lifecycle block to the `dynatrace_iam_group` resource:
+```terraform
+resource "dynatrace_iam_group" "Restricted" {
+    name = "Restricted"
+
+    lifecycle {
+      ignore_changes = [permissions]
+    }
+}
+```
+
 ## Dynatrace Documentation
 
 - Dynatrace IAM - https://www.dynatrace.com/support/help/how-to-use-dynatrace/user-management-and-sso/manage-groups-and-permissions

--- a/dynatrace/api/iam/groups/settings/group.go
+++ b/dynatrace/api/iam/groups/settings/group.go
@@ -30,11 +30,12 @@ func (me *Group) Schema() map[string]*schema.Schema {
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"permissions": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MinItems: 1,
-			MaxItems: 1,
-			Elem:     &schema.Resource{Schema: new(Permissions).Schema()},
+			Type:       schema.TypeList,
+			Deprecated: "Assigning permissions directly when creating a group is deprecated. Use the resource `dynatrace_iam_permission` instead.",
+			Optional:   true,
+			MinItems:   1,
+			MaxItems:   1,
+			Elem:       &schema.Resource{Schema: new(Permissions).Schema()},
 		},
 	}
 }

--- a/templates/resources/iam_group.md.tmpl
+++ b/templates/resources/iam_group.md.tmpl
@@ -14,6 +14,20 @@ description: |-
 
 -> This resource is excluded by default in the export utility, please explicitly specify the resource to retrieve existing configuration.
 
+## Conflicts
+~> **Warning** If this resource is used in combination with `dynatrace_iam_permission`, there is a potential for conflicts when both resources attempt to manage group permissions.
+It is recommended to manage group permissions with the `dynatrace_iam_permission` resource.
+To avoid conflicts when using the `dynatrace_iam_permission` resource, ensure to add the following lifecycle block to the `dynatrace_iam_group` resource:
+```terraform
+resource "dynatrace_iam_group" "Restricted" {
+    name = "Restricted"
+
+    lifecycle {
+      ignore_changes = [permissions]
+    }
+}
+```
+
 ## Dynatrace Documentation
 
 - Dynatrace IAM - https://www.dynatrace.com/support/help/how-to-use-dynatrace/user-management-and-sso/manage-groups-and-permissions

--- a/templates/resources/iam_permission.md.tmpl
+++ b/templates/resources/iam_permission.md.tmpl
@@ -14,6 +14,20 @@ description: |-
 
 -> This resource is excluded by default in the export utility, please explicitly specify the resource to retrieve existing configuration.
 
+## Conflicts
+~> **Warning** If this resource is used in combination with `dynatrace_iam_group`, there is a potential for conflicts when both resources attempt to manage group permissions.
+It is recommended to manage group permissions with the `dynatrace_iam_permission` resource.
+To avoid conflicts when using the `dynatrace_iam_permission` resource, ensure to add the following lifecycle block to the `dynatrace_iam_group` resource:
+```terraform
+resource "dynatrace_iam_group" "Restricted" {
+    name = "Restricted"
+
+    lifecycle {
+      ignore_changes = [permissions]
+    }
+}
+```
+
 ## Dynatrace Documentation
 
 - Dynatrace IAM - https://www.dynatrace.com/support/help/how-to-use-dynatrace/user-management-and-sso/manage-groups-and-permissions


### PR DESCRIPTION
#### **Why** this PR?
The resources `dynatrace_iam_group` and `dynatrace_iam_permission` are overwriting each other.

#### **What** has changed?
The group `permissions` field is now marked as deprecated, and conflicts are documented.
A change for the `permissions` field behavior would be a breaking change, e.g., that the permissions aren't considered/updated anymore.

#### **How** does it do it?
- By adding a deprecation notice to the group's `permissions` field.
- By updating both resources' documentation with the potential conflict.

#### How is it **tested**?


#### How does it affect **users**?
They will see a deprecation notice and will be referred to the other resource.


**Issue:** CA-16878
Resolves #843 

#### Docs preview
<img width="735" height="1047" alt="image" src="https://github.com/user-attachments/assets/50bc1a45-4f73-4467-ba3f-2686aaef521c" />
