### PR TITLE
fix(dynatrace_aws_service): require field 'statistic'

### DIFF
--- a/dynatrace/api/v1/config/credentials/aws/services/settings/aws_monitored_metric.go
+++ b/dynatrace/api/v1/config/credentials/aws/services/settings/aws_monitored_metric.go
@@ -40,8 +40,7 @@ func (amm *AWSMonitoredMetric) Schema() map[string]*schema.Schema {
 		"statistic": {
 			Type:        schema.TypeString,
 			Description: "Possible values are `AVERAGE`, `AVG_MIN_MAX`, `MAXIMUM`, `MINIMUM`, `SAMPLE_COUNT` and `SUM`",
-			Optional:    true,
-			Default:     "AVERAGE",
+			Required:    true,
 		},
 		"dimensions": {
 			Type:        schema.TypeList,


### PR DESCRIPTION
#### **Why** this PR?
With an API change, the `statistic` field is now required and is no longer optional. By default, a `statistic` field would be set to `SUM`, which is a wrong assumption and now needs to be configured according to the documentation.

#### **What** has changed?
Resource `dynatrace_aws_service` field `statistic` is now set to required, and a default value is not provided.

#### **How** does it do it?

#### How is it **tested**?
It is manually tested locally by creating `dynatrace_aws_service` and pushing to dev environment.

#### How does it affect **users**?
Users will need to provide the correct value for the given metric, as specified in the Dynatrace [documentation](https://docs.dynatrace.com/docs/ingest-from/amazon-web-services/integrate-with-aws/aws-all-services/aws-service-cloudfront#available-metrics).

**Issue:** CA-16894
