### PR TITLE
fix: Correct description of `rules_maintained_externally` field in `dynatrace_autotag_v2` resource

### DIFF
--- a/dynatrace/api/builtin/tags/autotagging/settings/settings.go
+++ b/dynatrace/api/builtin/tags/autotagging/settings/settings.go
@@ -43,7 +43,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"rules_maintained_externally": {
 			Type:        schema.TypeBool,
-			Description: "If `true` this resource will not ",
+			Description: "If `true` the specified rules are ignored with the assumption that they're maintained externally or via `dynatrace_autotag_rules`",
 			Optional:    true,
 			Default:     false,
 		},


### PR DESCRIPTION
#### **Why** this PR?
The description of the `rules_maintained_externally` field in the `dynatrace_autotag_v2` resource was incomplete.

#### **What** has changed  **how** does it do it?
The description of the `rules_maintained_externally` field in the `dynatrace_autotag_v2` resource is now correct. 

#### How is it **tested**?
N/A

#### How does it affect **users**?
They will see the correct description in the documentation.

**Issue:** CA-16935
