### PR TITLE
test: set unique identifiers for some resource examples

### DIFF
--- a/dynatrace/api/app/dynatrace/sitereliabilityguardian/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/sitereliabilityguardian/testdata/terraform/example_a.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_site_reliability_guardian" "#name#" {
-  name = "Test"
+  name = "#name#"
   tags = [ "stage:staging" ]
   event_kind = "BIZ_EVENT"
   objectives {

--- a/dynatrace/api/builtin/monitoring/slo/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/monitoring/slo/testdata/terraform/example_a.tf
@@ -6,7 +6,7 @@ resource "dynatrace_slo_v2" "#name#" {
   evaluation_window  = "-1w"
   filter             = "type(SERVICE),serviceType(WEB_SERVICE,WEB_REQUEST_SERVICE)"
   metric_expression  = "100*(builtin:service.requestCount.server:splitBy())/(builtin:service.requestCount.server:splitBy())"
-  metric_name        = "terraform_test"
+  metric_name        = "terraform_test#name#"
   target_success     = 95
   target_warning     = 98
   error_budget_burn_rate {

--- a/dynatrace/api/builtin/ownership/teams/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/ownership/teams/testdata/terraform/example_a.tf
@@ -2,7 +2,7 @@
 resource "dynatrace_ownership_teams" "#name#" {
   name        = "#name#"
   description = "Created by Terraform"
-  identifier  = "Terraform"
+  identifier  = "Terraform_#name#"
   additional_information {
     additional_information {
       key   = "HashiCorp"


### PR DESCRIPTION
#### **Why** this PR?
Some tests aren't working because some resources weren't cleaned up.

#### **What** has changed?
The unique identifiers for some examples were adjusted to be randomized, so that they don't interfere.

#### **How** does it do it?
By adding `#name#` to all affected fields.

#### How is it **tested**?
Tests still succeed, so all good.

#### How does it affect **users**?
They will just see a different field value for the example

**Issue:**
