### PR TITLE
chore: deprecate automation AWS connector

### DIFF
--- a/docs/resources/automation_workflow_aws_connections.md
+++ b/docs/resources/automation_workflow_aws_connections.md
@@ -1,12 +1,16 @@
 ---
 layout: ""
 page_title: dynatrace_automation_workflow_aws_connections Resource - terraform-provider-dynatrace"
-subcategory: "Connections"
+subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_automation_workflow_aws_connections` covers configuration for AWS connections for Workflows app
 ---
 
 # dynatrace_automation_workflow_aws_connections (Resource)
+
+~> **Warning** This resource is deprecated and will be removed in a future release.
+We recommend using the `dynatrace_aws_connection` and `dynatrace_aws_role_arn` resources to manage AWS connections.
+
 
 -> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
 

--- a/dynatrace/api/builtin/hyperscalerauthentication/awsconnection/settings/settings.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/awsconnection/settings/settings.go
@@ -30,6 +30,10 @@ type Settings struct {
 	WebIdentity *WebIdentity `json:"webIdentity,omitempty"`
 }
 
+func (me *Settings) Deprecated() string {
+	return "This resource is deprecated. Please use the `dynatrace_aws_connection` and `dynatrace_aws_role_arn` resources instead."
+}
+
 func (me *Settings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {

--- a/templates/resources/automation_workflow_aws_connections.md.tmpl
+++ b/templates/resources/automation_workflow_aws_connections.md.tmpl
@@ -1,12 +1,16 @@
 ---
 layout: ""
 page_title: dynatrace_automation_workflow_aws_connections Resource - terraform-provider-dynatrace"
-subcategory: "Connections"
+subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_automation_workflow_aws_connections` covers configuration for AWS connections for Workflows app
 ---
 
 # dynatrace_automation_workflow_aws_connections (Resource)
+
+~> **Warning** This resource is deprecated and will be removed in a future release.
+We recommend using the `dynatrace_aws_connection` and `dynatrace_aws_role_arn` resources to manage AWS connections.
+
 
 -> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
 


### PR DESCRIPTION
#### **Why** this PR?
This resource is deprecated and marked as read-only in the UI.

#### **What** has changed?
A deprecation notice is now shown when using the resource and when looking at the documentation

#### **How** does it do it?
By adding a deprecation notice to the resource and to the docs.

#### How is it **tested**?

#### How does it affect **users**?
They will see the deprecation notice

**Issue:**
