### PR TITLE
doc: Fix `page_title` value in documentation template front matter

### DIFF
--- a/templates/resources/activegate_token.md.tmpl
+++ b/templates/resources/activegate_token.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_activegate_token Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_activegate_token Resource - terraform-provider-dynatrace"
 subcategory: "Access Tokens"
 description: |-
   The resource `dynatrace_activegate_token` covers configuration for ActiveGate network security

--- a/templates/resources/activegate_updates.md.tmpl
+++ b/templates/resources/activegate_updates.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_activegate_updates Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_activegate_updates Resource - terraform-provider-dynatrace"
 subcategory: "Updates"
 description: |-
   The resource `dynatrace_activegate_updates` covers configuration for ActiveGate updates

--- a/templates/resources/ag_token.md.tmpl
+++ b/templates/resources/ag_token.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ag_token Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ag_token Resource - terraform-provider-dynatrace"
 subcategory: "Access Tokens"
 description: |-
   The resource `dynatrace_ag_token` covers configuration for Active Gate Tokens

--- a/templates/resources/aix_extension.md.tmpl
+++ b/templates/resources/aix_extension.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_aix_extension Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_aix_extension Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_aix_extension` covers configuration for AIX kernel extension

--- a/templates/resources/ansible_tower_notification.md.tmpl
+++ b/templates/resources/ansible_tower_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ansible_tower_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ansible_tower_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_ansible_tower_notification` covers configuration problem notifications sent to Ansible Tower

--- a/templates/resources/api_detection.md.tmpl
+++ b/templates/resources/api_detection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_api_detection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_api_detection Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_api_detection` covers configuration for API detection rules

--- a/templates/resources/api_token.md.tmpl
+++ b/templates/resources/api_token.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_api_token Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_api_token Resource - terraform-provider-dynatrace"
 subcategory: "Access Tokens"
 description: |-
   The resource `dynatrace_api_token` covers configuration for API tokens

--- a/templates/resources/app_monitoring.md.tmpl
+++ b/templates/resources/app_monitoring.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_app_monitoring Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_app_monitoring Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_app_monitoring` covers configuration for Dynatrace app monitoring

--- a/templates/resources/application_detection_rule_v2.md.tmpl
+++ b/templates/resources/application_detection_rule_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_application_detection_rule_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_application_detection_rule_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_application_detection_rule_v2` covers configuration for application detection rule

--- a/templates/resources/application_error_rules.md.tmpl
+++ b/templates/resources/application_error_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_application_error_rules Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_application_error_rules Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_application_error_rules` covers configuration for application error rules

--- a/templates/resources/appsec_notification.md.tmpl
+++ b/templates/resources/appsec_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_appsec_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_appsec_notification Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_appsec_notification` covers configuration for security notifications

--- a/templates/resources/attack_alerting.md.tmpl
+++ b/templates/resources/attack_alerting.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_attack_alerting Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_attack_alerting Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_attack_alerting` covers configuration for attack alerting profiles

--- a/templates/resources/attack_allowlist.md.tmpl
+++ b/templates/resources/attack_allowlist.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_attack_allowlist Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_attack_allowlist Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_attack_allowlist` covers configuration for application protection: allowlist

--- a/templates/resources/attack_rules.md.tmpl
+++ b/templates/resources/attack_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_attack_rules Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_attack_rules Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_attack_rules` covers configuration for application protection: monitoring rules

--- a/templates/resources/attack_settings.md.tmpl
+++ b/templates/resources/attack_settings.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_attack_settings Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_attack_settings Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_attack_settings` covers configuration for application protection: general settings 

--- a/templates/resources/attribute_allow_list.md.tmpl
+++ b/templates/resources/attribute_allow_list.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_attribute_allow_list Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_attribute_allow_list Resource - terraform-provider-dynatrace"
 subcategory: "OpenTelemetry & OpenTracing"
 description: |-
   The resource `dynatrace_attribute_allow_list` covers configuration for OpenTracing and OpenTelemetry attribute allow-list

--- a/templates/resources/attribute_block_list.md.tmpl
+++ b/templates/resources/attribute_block_list.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_attribute_block_list Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_attribute_block_list Resource - terraform-provider-dynatrace"
 subcategory: "OpenTelemetry & OpenTracing"
 description: |-
   The resource `dynatrace_attribute_block_list` covers configuration for OpenTracing and OpenTelemetry attribute block-list

--- a/templates/resources/attribute_masking.md.tmpl
+++ b/templates/resources/attribute_masking.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_attribute_masking Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_attribute_masking Resource - terraform-provider-dynatrace"
 subcategory: "OpenTelemetry & OpenTracing"
 description: |-
   The resource `dynatrace_attribute_masking` covers configuration for OpenTracing and OpenTelemetry attribute masking

--- a/templates/resources/attributes_preferences.md.tmpl
+++ b/templates/resources/attributes_preferences.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_attributes_preferences Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_attributes_preferences Resource - terraform-provider-dynatrace"
 subcategory: "OpenTelemetry & OpenTracing"
 description: |-
   The resource `dynatrace_attributes_preferences` covers configuration for OpenTracing and OpenTelemetry attribute preferences

--- a/templates/resources/audit_log.md.tmpl
+++ b/templates/resources/audit_log.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_audit_log Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_audit_log Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_audit_log` covers configuration for audit log

--- a/templates/resources/automation_approval.md.tmpl
+++ b/templates/resources/automation_approval.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Automation"
 description: |-
   The resource `{{ .Name }}` covers configuration for automation workflow approval

--- a/templates/resources/automation_approval.md.tmpl
+++ b/templates/resources/automation_approval.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Automation"
 description: |-
   The resource `{{ .Name }}` covers configuration for automation workflow approval

--- a/templates/resources/automation_controller_connections.md.tmpl
+++ b/templates/resources/automation_controller_connections.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_automation_controller_connections Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_automation_controller_connections Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_automation_controller_connections` covers configuration for Red Hat Ansible automation controller connections

--- a/templates/resources/automation_workflow_aws_connections.md.tmpl
+++ b/templates/resources/automation_workflow_aws_connections.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_automation_workflow_aws_connections Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_automation_workflow_aws_connections Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_automation_workflow_aws_connections` covers configuration for AWS connections for Workflows app

--- a/templates/resources/automation_workflow_jira.md.tmpl
+++ b/templates/resources/automation_workflow_jira.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_automation_workflow_jira Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_automation_workflow_jira Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_automation_workflow_jira` covers configuration for Jira for Workflows app

--- a/templates/resources/automation_workflow_k8s_connections.md.tmpl
+++ b/templates/resources/automation_workflow_k8s_connections.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_automation_workflow_k8s_connections Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_automation_workflow_k8s_connections Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_automation_workflow_k8s_connections` covers configuration for Kubernetes Automation for Workflows app

--- a/templates/resources/automation_workflow_slack.md.tmpl
+++ b/templates/resources/automation_workflow_slack.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_automation_workflow_slack Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_automation_workflow_slack Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_automation_workflow_slack` covers configuration for Slack for Workflows app

--- a/templates/resources/autotag.md.tmpl
+++ b/templates/resources/autotag.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_autotag Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_autotag Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_autotag` covers configuration for autotags

--- a/templates/resources/autotag_rules.md.tmpl
+++ b/templates/resources/autotag_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_autotag_rules Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_autotag_rules Resource - terraform-provider-dynatrace"
 subcategory: "Tags"
 description: |-
   The resource `dynatrace_autotag_rules` covers rule configuration of automatically applied tags

--- a/templates/resources/autotag_v2.md.tmpl
+++ b/templates/resources/autotag_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_autotag_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_autotag_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Tags"
 description: |-
   The resource `dynatrace_autotag_v2` covers configuration for automatically applied tags

--- a/templates/resources/aws_anomalies.md.tmpl
+++ b/templates/resources/aws_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_aws_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_aws_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_aws_anomalies` covers configuration for AWS anomaly detection

--- a/templates/resources/aws_credentials.md.tmpl
+++ b/templates/resources/aws_credentials.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_aws_credentials Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_aws_credentials Resource - terraform-provider-dynatrace"
 subcategory: "Credentials"
 description: |-
   The resource `dynatrace_aws_credentials` covers configuration for AWS credentials

--- a/templates/resources/aws_service.md.tmpl
+++ b/templates/resources/aws_service.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_aws_service Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_aws_service Resource - terraform-provider-dynatrace"
 subcategory: "Credentials"
 description: |-
   The resource `dynatrace_aws_service` covers configuration of Supported Services for AWS credentials

--- a/templates/resources/azure_credentials.md.tmpl
+++ b/templates/resources/azure_credentials.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_azure_credentials Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_azure_credentials Resource - terraform-provider-dynatrace"
 subcategory: "Credentials"
 description: |-
   The resource `dynatrace_azure_credentials` covers configuration for Azure credentials

--- a/templates/resources/azure_service.md.tmpl
+++ b/templates/resources/azure_service.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_azure_service Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_azure_service Resource - terraform-provider-dynatrace"
 subcategory: "Credentials"
 description: |-
   The resource `dynatrace_azure_service` covers configuration of Supported Services for Azure credentials

--- a/templates/resources/browser_monitor.md.tmpl
+++ b/templates/resources/browser_monitor.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_browser_monitor Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_browser_monitor Resource - terraform-provider-dynatrace"
 subcategory: "Browser Monitors"
 description: |-
   The resource `dynatrace_browser_monitor` covers configuration for browser monitors

--- a/templates/resources/browser_monitor_outage.md.tmpl
+++ b/templates/resources/browser_monitor_outage.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_browser_monitor_outage Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_browser_monitor_outage Resource - terraform-provider-dynatrace"
 subcategory: "Browser Monitors"
 description: |-
   The resource `dynatrace_browser_monitor_outage` covers configuration for browser monitor outage handling

--- a/templates/resources/browser_monitor_performance.md.tmpl
+++ b/templates/resources/browser_monitor_performance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_browser_monitor_performance Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_browser_monitor_performance Resource - terraform-provider-dynatrace"
 subcategory: "Browser Monitors"
 description: |-
   The resource `dynatrace_browser_monitor_performance` covers configuration for browser monitor performance thresholds

--- a/templates/resources/business_events_buckets.md.tmpl
+++ b/templates/resources/business_events_buckets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_business_events_buckets Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_business_events_buckets Resource - terraform-provider-dynatrace"
 subcategory: "Business Events"
 description: |-
   The resource `dynatrace_business_events_buckets` covers configuration for business event bucket assignment

--- a/templates/resources/business_events_capturing_variants.md.tmpl
+++ b/templates/resources/business_events_capturing_variants.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_business_events_capturing_variants Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_business_events_capturing_variants Resource - terraform-provider-dynatrace"
 subcategory: "Business Events"
 description: |-
   The resource `dynatrace_business_events_capturing_variants` covers configuration for OneAgent business event capturing variants

--- a/templates/resources/business_events_metrics.md.tmpl
+++ b/templates/resources/business_events_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_business_events_metrics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_business_events_metrics Resource - terraform-provider-dynatrace"
 subcategory: "Business Events"
 description: |-
   The resource `dynatrace_business_events_metrics` covers configuration for business event metric extraction

--- a/templates/resources/business_events_oneagent.md.tmpl
+++ b/templates/resources/business_events_oneagent.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_business_events_oneagent Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_business_events_oneagent Resource - terraform-provider-dynatrace"
 subcategory: "Business Events"
 description: |-
   The resource `dynatrace_business_events_oneagent` covers configuration for OneAgent business events based on incoming HTTP requests

--- a/templates/resources/business_events_oneagent_outgoing.md.tmpl
+++ b/templates/resources/business_events_oneagent_outgoing.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_business_events_oneagent_outgoing Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_business_events_oneagent_outgoing Resource - terraform-provider-dynatrace"
 subcategory: "Business Events"
 description: |-
   The resource `dynatrace_business_events_oneagent_outgoing` covers configuration for OneAgent business events based on outgoing HTTP requests

--- a/templates/resources/business_events_processing.md.tmpl
+++ b/templates/resources/business_events_processing.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_business_events_processing Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_business_events_processing Resource - terraform-provider-dynatrace"
 subcategory: "Business Events"
 description: |-
   The resource `dynatrace_business_events_processing` covers configuration for business event processing

--- a/templates/resources/business_events_security_context.md.tmpl
+++ b/templates/resources/business_events_security_context.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_business_events_security_context Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_business_events_security_context Resource - terraform-provider-dynatrace"
 subcategory: "Business Events"
 description: |-
   The resource `dynatrace_business_events_security_context` covers configuration for business security context

--- a/templates/resources/calculated_mobile_metric.md.tmpl
+++ b/templates/resources/calculated_mobile_metric.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: calculated_mobile_metric Resource - terraform-provider-dynatrace"
+page_title: "calculated_mobile_metric Resource - terraform-provider-dynatrace"
 subcategory: "Mobile & Custom Applications"
 description: |-
   The resource `calculated_mobile_metric` covers configuration for calculated mobile/custom app metrics

--- a/templates/resources/calculated_service_metric.md.tmpl
+++ b/templates/resources/calculated_service_metric.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_calculated_service_metric Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_calculated_service_metric Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_calculated_service_metric` covers configuration for calculated service metrics

--- a/templates/resources/calculated_synthetic_metric.md.tmpl
+++ b/templates/resources/calculated_synthetic_metric.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_calculated_synthetic_metric Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_calculated_synthetic_metric Resource - terraform-provider-dynatrace"
 subcategory: "Synthetic"
 description: |-
   The resource `dynatrace_calculated_synthetic_metric` covers configuration for calculated synthetic metrics

--- a/templates/resources/calculated_web_metric.md.tmpl
+++ b/templates/resources/calculated_web_metric.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_calculated_web_metric Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_calculated_web_metric Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_calculated_web_metric` covers configuration for calculated web app metrics

--- a/templates/resources/cloud_foundry.md.tmpl
+++ b/templates/resources/cloud_foundry.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_cloud_foundry Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_cloud_foundry Resource - terraform-provider-dynatrace"
 subcategory: "Cloud Platforms"
 description: |-
   The resource `dynatrace_cloud_foundry` covers configuration for Cloud Foundry monitoring

--- a/templates/resources/cloudfoundry_credentials.md.tmpl
+++ b/templates/resources/cloudfoundry_credentials.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_cloudfoundry_credentials Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_cloudfoundry_credentials Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_cloudfoundry_credentials` covers configuration for Cloud Foundry credentials

--- a/templates/resources/connectivity_alerts.md.tmpl
+++ b/templates/resources/connectivity_alerts.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_connectivity_alerts Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_connectivity_alerts Resource - terraform-provider-dynatrace"
 subcategory: "Alerting"
 description: |-
   The resource `dynatrace_connectivity_alerts` covers configuration for process group connectivity alerts

--- a/templates/resources/container_builtin_rule.md.tmpl
+++ b/templates/resources/container_builtin_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_container_builtin_rule Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_container_builtin_rule Resource - terraform-provider-dynatrace"
 subcategory: "Containers"
 description: |-
   The resource `dynatrace_container_builtin_rule` covers configuration for builtin monitoring rules for containers

--- a/templates/resources/container_registry.md.tmpl
+++ b/templates/resources/container_registry.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_container_registry Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_container_registry Resource - terraform-provider-dynatrace"
 subcategory: "Containers"
 description: |-
   The resource `dynatrace_container_registry` covers configuration for the URL of the public/private repository hosting container images

--- a/templates/resources/container_rule.md.tmpl
+++ b/templates/resources/container_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_container_rule Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_container_rule Resource - terraform-provider-dynatrace"
 subcategory: "Containers"
 description: |-
   The resource `dynatrace_container_rule` covers configuration for monitoring rules for containers

--- a/templates/resources/container_technology.md.tmpl
+++ b/templates/resources/container_technology.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_container_technology Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_container_technology Resource - terraform-provider-dynatrace"
 subcategory: "Containers"
 description: |-
   The resource `dynatrace_container_technology` covers configuration for container monitoring

--- a/templates/resources/credentials.md.tmpl
+++ b/templates/resources/credentials.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_credentials Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_credentials Resource - terraform-provider-dynatrace"
 subcategory: "Credentials"
 description: |-
   The resource `dynatrace_credentials` covers configuration for credentials

--- a/templates/resources/custom_anomalies.md.tmpl
+++ b/templates/resources/custom_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_custom_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_custom_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_custom_anomalies` covers configuration for custom metric events

--- a/templates/resources/custom_device.md.tmpl
+++ b/templates/resources/custom_device.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_custom_device Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_custom_device Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Entities"
 description: |-
   The resource `dynatrace_custom_device` covers configuration for custom devices.

--- a/templates/resources/custom_service.md.tmpl
+++ b/templates/resources/custom_service.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_custom_service Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_custom_service Resource - terraform-provider-dynatrace"
 subcategory: "Service Detection"
 description: |-
   The resource `dynatrace_custom_service` covers configuration for custom services

--- a/templates/resources/custom_service_order.md.tmpl
+++ b/templates/resources/custom_service_order.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_custom_service_order Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_custom_service_order Resource - terraform-provider-dynatrace"
 subcategory: "Service Detection"
 description: |-
   The resource `dynatrace_custom_service_order` covers defining the order of rules defined for custom services

--- a/templates/resources/custom_tags.md.tmpl
+++ b/templates/resources/custom_tags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_custom_tags Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_custom_tags Resource - terraform-provider-dynatrace"
 subcategory: "Tags"
 description: |-
   The resource `dynatrace_custom_tags` covers configuration for custom tags

--- a/templates/resources/custom_units.md.tmpl
+++ b/templates/resources/custom_units.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_custom_units Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_custom_units Resource - terraform-provider-dynatrace"
 subcategory: "Metrics"
 description: |-
   The resource `dynatrace_custom_units` covers configuration for custom units

--- a/templates/resources/dashboard.md.tmpl
+++ b/templates/resources/dashboard.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_dashboard Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_dashboard Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_dashboard` covers configuration for dashboards

--- a/templates/resources/dashboard_sharing.md.tmpl
+++ b/templates/resources/dashboard_sharing.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_dashboard_sharing Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_dashboard_sharing Resource - terraform-provider-dynatrace"
 subcategory: "Dashboards"
 description: |-
   The resource `dynatrace_dashboard_sharing` covers configuration for dashboard sharing

--- a/templates/resources/dashboards_allowlist.md.tmpl
+++ b/templates/resources/dashboards_allowlist.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_dashboards_allowlist Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_dashboards_allowlist Resource - terraform-provider-dynatrace"
 subcategory: "Dashboards"
 description: |-
   The resource `dynatrace_dashboards_allowlist` covers dashboard configuration for allowed URL pattern rules

--- a/templates/resources/dashboards_general.md.tmpl
+++ b/templates/resources/dashboards_general.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_dashboards_general Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_dashboards_general Resource - terraform-provider-dynatrace"
 subcategory: "Dashboards"
 description: |-
   The resource `dynatrace_dashboards_general` covers configuration for general dashboard settings

--- a/templates/resources/dashboards_presets.md.tmpl
+++ b/templates/resources/dashboards_presets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_dashboards_presets Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_dashboards_presets Resource - terraform-provider-dynatrace"
 subcategory: "Dashboards"
 description: |-
   The resource `dynatrace_dashboards_presets` covers configuration for dashboard preset settings

--- a/templates/resources/database_anomalies.md.tmpl
+++ b/templates/resources/database_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_database_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_database_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_database_anomalies` covers configuration for database anomaly detection

--- a/templates/resources/database_anomalies_v2.md.tmpl
+++ b/templates/resources/database_anomalies_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_database_anomalies_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_database_anomalies_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_database_anomalies_v2` covers configuration for database anomaly detection

--- a/templates/resources/davis_anomaly_detectors.md.tmpl
+++ b/templates/resources/davis_anomaly_detectors.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_davis_anomaly_detectors Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_davis_anomaly_detectors Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_davis_anomaly_detectors` covers configuration for Davis anomaly detectors

--- a/templates/resources/davis_copilot.md.tmpl
+++ b/templates/resources/davis_copilot.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_davis_copilot Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_davis_copilot Resource - terraform-provider-dynatrace"
 subcategory: "Service Settings"
 description: |-
   The resource `dynatrace_davis_copilot` covers configuration for Davis CoPilot

--- a/templates/resources/db_app_feature_flags.md.tmpl
+++ b/templates/resources/db_app_feature_flags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_db_app_feature_flags Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_db_app_feature_flags Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_db_app_feature_flags` covers configuration for database app feature flags

--- a/templates/resources/declarative_grouping.md.tmpl
+++ b/templates/resources/declarative_grouping.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_declarative_grouping Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_declarative_grouping Resource - terraform-provider-dynatrace"
 subcategory: "Process Group Monitoring"
 description: |-
   The resource `dynatrace_declarative_grouping` covers configuration for declarative process grouping

--- a/templates/resources/default_launchpad.md.tmpl
+++ b/templates/resources/default_launchpad.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_default_launchpad Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_default_launchpad Resource - terraform-provider-dynatrace"
 subcategory: "Documents"
 description: |-
   The resource `dynatrace_default_launchpad` covers configuration to set default Launchpads by user group

--- a/templates/resources/devobs_agent_optin.md.tmpl
+++ b/templates/resources/devobs_agent_optin.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_devobs_agent_optin Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_devobs_agent_optin Resource - terraform-provider-dynatrace"
 subcategory: "Developer Observability"
 description: |-
   The resource `dynatrace_devobs_agent_optin` covers configuration for Developer Observability agent opt-in

--- a/templates/resources/devobs_data_masking.md.tmpl
+++ b/templates/resources/devobs_data_masking.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_devobs_data_masking Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_devobs_data_masking Resource - terraform-provider-dynatrace"
 subcategory: "Developer Observability"
 description: |-
   The resource `dynatrace_devobs_data_masking` covers configuration for Developer Observability sensitive data masking

--- a/templates/resources/devobs_git_onprem.md.tmpl
+++ b/templates/resources/devobs_git_onprem.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_devobs_git_onprem Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_devobs_git_onprem Resource - terraform-provider-dynatrace"
 subcategory: "Developer Observability"
 description: |-
   The resource `dynatrace_devobs_git_onprem` covers configuration for Developer Observability git on-premise servers

--- a/templates/resources/direct_shares.md.tmpl
+++ b/templates/resources/direct_shares.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Documents"
 description: |-
   The resource `{{ .Name }}` covers configuration of direct shares for Documents (dashboards and notebooks) in Dynatrace.

--- a/templates/resources/direct_shares.md.tmpl
+++ b/templates/resources/direct_shares.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Documents"
 description: |-
   The resource `{{ .Name }}` covers configuration of direct shares for Documents (dashboards and notebooks) in Dynatrace.

--- a/templates/resources/discovery_default_rules.md.tmpl
+++ b/templates/resources/discovery_default_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_discovery_default_rules Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_discovery_default_rules Resource - terraform-provider-dynatrace"
 subcategory: "AppEngine"
 description: |-
   The resource `dynatrace_discovery_default_rules` covers configuration for discovery findings default rules 

--- a/templates/resources/discovery_feature_flags.md.tmpl
+++ b/templates/resources/discovery_feature_flags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_discovery_feature_flags Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_discovery_feature_flags Resource - terraform-provider-dynatrace"
 subcategory: "AppEngine"
 description: |-
   The resource `dynatrace_discovery_feature_flags` covers configuration for Discovery and Coverage app feature flags

--- a/templates/resources/disk_analytics.md.tmpl
+++ b/templates/resources/disk_analytics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_disk_analytics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_disk_analytics Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_disk_analytics` covers configuration for Disk Analytics extension

--- a/templates/resources/disk_anomalies.md.tmpl
+++ b/templates/resources/disk_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_disk_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_disk_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_disk_anomalies` covers configuration for disk anomaly detection

--- a/templates/resources/disk_anomalies_v2.md.tmpl
+++ b/templates/resources/disk_anomalies_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_disk_anomalies_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_disk_anomalies_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_disk_anomalies_v2` covers configuration for disk anomaly detection

--- a/templates/resources/disk_anomaly_rules.md.tmpl
+++ b/templates/resources/disk_anomaly_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_disk_anomaly_rules Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_disk_anomaly_rules Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_disk_anomaly_rules` covers configuration for disk anomaly detection rules 

--- a/templates/resources/disk_edge_anomaly_detectors.md.tmpl
+++ b/templates/resources/disk_edge_anomaly_detectors.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_disk_edge_anomaly_detectors Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_disk_edge_anomaly_detectors Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_disk_edge_anomaly_detectors` covers configuration for disk edge anomaly detection

--- a/templates/resources/disk_options.md.tmpl
+++ b/templates/resources/disk_options.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_disk_options Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_disk_options Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_disk_options` covers configuration for host disk visibility settings

--- a/templates/resources/disk_specific_anomalies_v2.md.tmpl
+++ b/templates/resources/disk_specific_anomalies_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_disk_specific_anomalies_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_disk_specific_anomalies_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_disk_specific_anomalies_v2` covers configuration for disk specific anomaly detection

--- a/templates/resources/document.md.tmpl
+++ b/templates/resources/document.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Documents"
 description: |-
   The resource `{{ .Name }}` covers configuration of Documents (dashboards and notebooks) in Dynatrace.

--- a/templates/resources/document.md.tmpl
+++ b/templates/resources/document.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Documents"
 description: |-
   The resource `{{ .Name }}` covers configuration of Documents (dashboards and notebooks) in Dynatrace.

--- a/templates/resources/ebpf_service_discovery.md.tmpl
+++ b/templates/resources/ebpf_service_discovery.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ebpf_service_discovery Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ebpf_service_discovery Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_ebpf_service_discovery` covers configuration for enabling discovery of active services on the network

--- a/templates/resources/email_notification.md.tmpl
+++ b/templates/resources/email_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_email_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_email_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_email_notification` covers configuration problem notifications sent via Email

--- a/templates/resources/endpoint_detection_rules.md.tmpl
+++ b/templates/resources/endpoint_detection_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for endpoint detection rules

--- a/templates/resources/endpoint_detection_rules.md.tmpl
+++ b/templates/resources/endpoint_detection_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for endpoint detection rules

--- a/templates/resources/endpoint_detection_rules_optin.md.tmpl
+++ b/templates/resources/endpoint_detection_rules_optin.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for endpoint detection rules opt-in

--- a/templates/resources/endpoint_detection_rules_optin.md.tmpl
+++ b/templates/resources/endpoint_detection_rules_optin.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for endpoint detection rules opt-in

--- a/templates/resources/environment.md.tmpl
+++ b/templates/resources/environment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_environment Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_environment Resource - terraform-provider-dynatrace"
 subcategory: "Cluster Management"
 description: |-
   The resource `dynatrace_environment` covers configuration for environments

--- a/templates/resources/eula_settings.md.tmpl
+++ b/templates/resources/eula_settings.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_eula_settings Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_eula_settings Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_eula_settings` covers configuration for display of the clickwrap agreement

--- a/templates/resources/event_driven_ansible_connections.md.tmpl
+++ b/templates/resources/event_driven_ansible_connections.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_event_driven_ansible_connections Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_event_driven_ansible_connections Resource - terraform-provider-dynatrace"
 subcategory: "AppEngine"
 description: |-
   The resource `dynatrace_event_driven_ansible_connections` covers configuration for Red Hat event-driven Ansible connections

--- a/templates/resources/extension_execution_controller.md.tmpl
+++ b/templates/resources/extension_execution_controller.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_extension_execution_controller Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_extension_execution_controller Resource - terraform-provider-dynatrace"
 subcategory: "Extensions"
 description: |-
   The resource `dynatrace_extension_execution_controller` covers Extension Execution Controller configuration for OneAgent deployment

--- a/templates/resources/extension_execution_remote.md.tmpl
+++ b/templates/resources/extension_execution_remote.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_extension_execution_remote Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_extension_execution_remote Resource - terraform-provider-dynatrace"
 subcategory: "Extensions"
 description: |-
   The resource `dynatrace_extension_execution_remote` covers configuration for Extension Execution Controller configuration for ActiveGate deployment

--- a/templates/resources/failure_detection_parameters.md.tmpl
+++ b/templates/resources/failure_detection_parameters.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_failure_detection_parameters Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_failure_detection_parameters Resource - terraform-provider-dynatrace"
 subcategory: "Failure Detection"
 description: |-
   The resource `dynatrace_failure_detection_parameters` covers configuration for failure detection parameters

--- a/templates/resources/failure_detection_rule_sets.md.tmpl
+++ b/templates/resources/failure_detection_rule_sets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for failure detection rule sets

--- a/templates/resources/failure_detection_rule_sets.md.tmpl
+++ b/templates/resources/failure_detection_rule_sets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for failure detection rule sets

--- a/templates/resources/failure_detection_rules.md.tmpl
+++ b/templates/resources/failure_detection_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_failure_detection_rules Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_failure_detection_rules Resource - terraform-provider-dynatrace"
 subcategory: "Failure Detection"
 description: |-
   The resource `dynatrace_failure_detection_rules` covers configuration for failure detection rules

--- a/templates/resources/frequent_issues.md.tmpl
+++ b/templates/resources/frequent_issues.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_frequent_issues Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_frequent_issues Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_frequent_issues` covers configuration for frequent issue detection

--- a/templates/resources/generic_setting.md.tmpl
+++ b/templates/resources/generic_setting.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_generic_setting Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_generic_setting Resource - terraform-provider-dynatrace"
 subcategory: "Platform"
 description: |-
   The resource `dynatrace_generic_setting` covers configuration for Schemas contributed by Custom Platform Apps

--- a/templates/resources/geolocation.md.tmpl
+++ b/templates/resources/geolocation.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_geolocation Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_geolocation Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_geolocation` covers configuration for geolocation settings

--- a/templates/resources/github_connection.md.tmpl
+++ b/templates/resources/github_connection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_github_connection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_github_connection Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_github_connection` covers configuration for GitHub connections

--- a/templates/resources/gitlab_connection.md.tmpl
+++ b/templates/resources/gitlab_connection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_gitlab_connection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_gitlab_connection Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_gitlab_connection` covers configuration for GitLab connections

--- a/templates/resources/golden_state.md.tmpl
+++ b/templates/resources/golden_state.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_golden_state Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_golden_state Resource - terraform-provider-dynatrace"
 subcategory: "Incubator"
 description: |-
   The resource `dynatrace_golden_state` allows for identifying configuration within a Dynatrace environment that isn't managed by Terraform

--- a/templates/resources/grail_metrics_allowall.md.tmpl
+++ b/templates/resources/grail_metrics_allowall.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_grail_metrics_allowall Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_grail_metrics_allowall Resource - terraform-provider-dynatrace"
 subcategory: "Platform"
 description: |-
   The resource `dynatrace_grail_metrics_allowall` covers configuration to allow all custom metric ingestion to Grail

--- a/templates/resources/grail_metrics_allowlist.md.tmpl
+++ b/templates/resources/grail_metrics_allowlist.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_grail_metrics_allowlist Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_grail_metrics_allowlist Resource - terraform-provider-dynatrace"
 subcategory: "Platform"
 description: |-
   The resource `dynatrace_grail_metrics_allowlist` covers allow list configuration of custom metric ingestion to Grail

--- a/templates/resources/histogram_metrics.md.tmpl
+++ b/templates/resources/histogram_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_histogram_metrics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_histogram_metrics Resource - terraform-provider-dynatrace"
 subcategory: "Metrics"
 description: |-
   The resource `dynatrace_histogram_metrics` covers configuration for histogram data ingestion

--- a/templates/resources/host_anomalies.md.tmpl
+++ b/templates/resources/host_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_host_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_host_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_host_anomalies` covers configuration for host anomaly detection

--- a/templates/resources/host_anomalies_v2.md.tmpl
+++ b/templates/resources/host_anomalies_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_host_anomalies_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_host_anomalies_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_host_anomalies_v2` covers configuration for host anomaly detection

--- a/templates/resources/host_monitoring.md.tmpl
+++ b/templates/resources/host_monitoring.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_host_monitoring Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_host_monitoring Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_host_monitoring` covers configuration for host monitoring

--- a/templates/resources/host_monitoring_advanced.md.tmpl
+++ b/templates/resources/host_monitoring_advanced.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_host_monitoring_advanced Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_host_monitoring_advanced Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_host_monitoring_advanced` covers advanced configuration for host monitoring

--- a/templates/resources/host_monitoring_mode.md.tmpl
+++ b/templates/resources/host_monitoring_mode.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_host_monitoring_mode Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_host_monitoring_mode Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_host_monitoring_mode` covers configuration for host monitoring mode

--- a/templates/resources/host_naming.md.tmpl
+++ b/templates/resources/host_naming.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_host_naming Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_host_naming Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_host_naming` covers configuration for host naming

--- a/templates/resources/host_naming_order.md.tmpl
+++ b/templates/resources/host_naming_order.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_host_naming_order Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_host_naming_order Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_host_naming_order` covers defining the order of rules defined for host naming

--- a/templates/resources/host_process_group_monitoring.md.tmpl
+++ b/templates/resources/host_process_group_monitoring.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_host_process_group_monitoring Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_host_process_group_monitoring Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_host_process_group_monitoring` covers configuration of host level process group monitoring rules

--- a/templates/resources/http_monitor.md.tmpl
+++ b/templates/resources/http_monitor.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_http_monitor Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_http_monitor Resource - terraform-provider-dynatrace"
 subcategory: "HTTP Monitors"
 description: |-
   The resource `dynatrace_http_monitor` covers configuration for HTTP monitors

--- a/templates/resources/http_monitor_cookies.md.tmpl
+++ b/templates/resources/http_monitor_cookies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_http_monitor_cookies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_http_monitor_cookies Resource - terraform-provider-dynatrace"
 subcategory: "HTTP Monitors"
 description: |-
   The resource `dynatrace_http_monitor_cookies` covers configuration for HTTP monitor cookies

--- a/templates/resources/http_monitor_outage.md.tmpl
+++ b/templates/resources/http_monitor_outage.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_http_monitor_outage Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_http_monitor_outage Resource - terraform-provider-dynatrace"
 subcategory: "HTTP Monitors"
 description: |-
   The resource `dynatrace_http_monitor_outage` covers configuration for HTTP monitor outage handling

--- a/templates/resources/http_monitor_performance.md.tmpl
+++ b/templates/resources/http_monitor_performance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_http_monitor_performance Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_http_monitor_performance Resource - terraform-provider-dynatrace"
 subcategory: "HTTP Monitors"
 description: |-
   The resource `dynatrace_http_monitor_performance` covers configuration for HTTP monitor performance thresholds

--- a/templates/resources/http_monitor_script.md.tmpl
+++ b/templates/resources/http_monitor_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_http_monitor_script Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_http_monitor_script Resource - terraform-provider-dynatrace"
 subcategory: "HTTP Monitors"
 description: |-
   The resource `dynatrace_http_monitor_script` covers configuration for HTTP monitor scripts

--- a/templates/resources/hub_extension_active_version.md.tmpl
+++ b/templates/resources/hub_extension_active_version.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_hub_extension_active_version Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_hub_extension_active_version Resource - terraform-provider-dynatrace"
 subcategory: "Extensions"
 description: |-
   The resource `dynatrace_hub_extension_active_version` covers activating a specific version of an Extension

--- a/templates/resources/hub_extension_config.md.tmpl
+++ b/templates/resources/hub_extension_config.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_hub_extension_config Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_hub_extension_config Resource - terraform-provider-dynatrace"
 subcategory: "Extensions"
 description: |-
   The resource `dynatrace_hub_extension_config` covers installing Extensions from the Dynatrace Hub and configuring Monitoring Settings

--- a/templates/resources/hub_permissions.md.tmpl
+++ b/templates/resources/hub_permissions.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_hub_permissions Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_hub_permissions Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_hub_permissions` covers configuration for hub permissions

--- a/templates/resources/hub_subscriptions.md.tmpl
+++ b/templates/resources/hub_subscriptions.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_hub_subscriptions Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_hub_subscriptions Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_hub_subscriptions` covers configuration for hub subscriptions

--- a/templates/resources/ibm_mq_filters.md.tmpl
+++ b/templates/resources/ibm_mq_filters.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ibm_mq_filters Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ibm_mq_filters Resource - terraform-provider-dynatrace"
 subcategory: "Mainframe"
 description: |-
   The resource `dynatrace_ibm_mq_filters` covers configuration for IBM MQ filters

--- a/templates/resources/ims_bridges.md.tmpl
+++ b/templates/resources/ims_bridges.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ims_bridges Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ims_bridges Resource - terraform-provider-dynatrace"
 subcategory: "Mainframe"
 description: |-
   The resource `dynatrace_ims_bridges` covers configuration for IBM MQ IMS bridges

--- a/templates/resources/infraops_app_feature_flags.md.tmpl
+++ b/templates/resources/infraops_app_feature_flags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_infraops_app_feature_flags Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_infraops_app_feature_flags Resource - terraform-provider-dynatrace"
 subcategory: "AppEngine"
 description: |-
   The resource `dynatrace_infraops_app_feature_flags` covers configuration for infrastructure and operations app feature flags

--- a/templates/resources/infraops_app_settings.md.tmpl
+++ b/templates/resources/infraops_app_settings.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_infraops_app_settings Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_infraops_app_settings Resource - terraform-provider-dynatrace"
 subcategory: "AppEngine"
 description: |-
   The resource `dynatrace_infraops_app_settings` covers configuration for infrastructure and operations app settings

--- a/templates/resources/issue_tracking.md.tmpl
+++ b/templates/resources/issue_tracking.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_issue_tracking Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_issue_tracking Resource - terraform-provider-dynatrace"
 subcategory: "Integrations"
 description: |-
   The resource `dynatrace_issue_tracking` covers configuration for issue-tracking integrations

--- a/templates/resources/jenkins_connection.md.tmpl
+++ b/templates/resources/jenkins_connection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_jenkins_connection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_jenkins_connection Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_jenkins_connection` covers configuration for Jenkins connections

--- a/templates/resources/jira_notification.md.tmpl
+++ b/templates/resources/jira_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_jira_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_jira_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_jira_notification` covers configuration problem notifications sent to Jira

--- a/templates/resources/json_dashboard.md.tmpl
+++ b/templates/resources/json_dashboard.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_json_dashboard Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_json_dashboard Resource - terraform-provider-dynatrace"
 subcategory: "Dashboards"
 description: |-
   The resource `dynatrace_json_dashboard` covers configuration for dashboards in JSON format

--- a/templates/resources/k8s_cluster_anomalies.md.tmpl
+++ b/templates/resources/k8s_cluster_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_k8s_cluster_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_k8s_cluster_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_k8s_cluster_anomalies` covers configuration for Kubernetes cluster anomalies

--- a/templates/resources/k8s_credentials.md.tmpl
+++ b/templates/resources/k8s_credentials.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_k8s_credentials Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_k8s_credentials Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_k8s_credentials` covers configuration for Kubernetes credentials

--- a/templates/resources/k8s_monitoring.md.tmpl
+++ b/templates/resources/k8s_monitoring.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_k8s_monitoring Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_k8s_monitoring Resource - terraform-provider-dynatrace"
 subcategory: "Cloud Platforms"
 description: |-
   The resource `dynatrace_k8s_monitoring` covers configuration for Kubernetes monitoring settings

--- a/templates/resources/k8s_namespace_anomalies.md.tmpl
+++ b/templates/resources/k8s_namespace_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_k8s_namespace_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_k8s_namespace_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_k8s_namespace_anomalies` covers configuration for Kubernetes namespace anomalies

--- a/templates/resources/k8s_node_anomalies.md.tmpl
+++ b/templates/resources/k8s_node_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_k8s_node_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_k8s_node_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_k8s_node_anomalies` covers configuration for Kubernetes node anomalies

--- a/templates/resources/k8s_pvc_anomalies.md.tmpl
+++ b/templates/resources/k8s_pvc_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_k8s_pvc_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_k8s_pvc_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_k8s_pvc_anomalies` covers configuration for Kubernetes persistent volume claim anomalies

--- a/templates/resources/k8s_workload_anomalies.md.tmpl
+++ b/templates/resources/k8s_workload_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_k8s_workload_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_k8s_workload_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_k8s_workload_anomalies` covers configuration for Kubernetes workload anomalies

--- a/templates/resources/key_requests.md.tmpl
+++ b/templates/resources/key_requests.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_key_requests Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_key_requests Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_key_requests` covers configuration for key requests

--- a/templates/resources/key_user_action.md.tmpl
+++ b/templates/resources/key_user_action.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_key_user_action Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_key_user_action Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_key_user_action` covers configuration of Key User Actions for web applications

--- a/templates/resources/kubernetes.md.tmpl
+++ b/templates/resources/kubernetes.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_kubernetes Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_kubernetes Resource - terraform-provider-dynatrace"
 subcategory: "Cloud Platforms"
 description: |-
   The resource `dynatrace_kubernetes` covers configuration for Kubernetes connection settings

--- a/templates/resources/kubernetes_app.md.tmpl
+++ b/templates/resources/kubernetes_app.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_kubernetes_app Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_kubernetes_app Resource - terraform-provider-dynatrace"
 subcategory: "Cloud Platforms"
 description: |-
   The resource `dynatrace_kubernetes_app` covers configuration to enable the new Kubernetes app

--- a/templates/resources/kubernetes_enrichment.md.tmpl
+++ b/templates/resources/kubernetes_enrichment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_kubernetes_enrichment Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_kubernetes_enrichment Resource - terraform-provider-dynatrace"
 subcategory: "Cloud Platforms"
 description: |-
   The resource `dynatrace_kubernetes_enrichment` covers configuration for generic metadata enrichment rules for Kubernetes

--- a/templates/resources/kubernetes_spm.md.tmpl
+++ b/templates/resources/kubernetes_spm.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_kubernetes_spm Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_kubernetes_spm Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_kubernetes_spm` covers configuration for Kubernetes security posture management

--- a/templates/resources/limit_outbound_connections.md.tmpl
+++ b/templates/resources/limit_outbound_connections.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_limit_outbound_connections Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_limit_outbound_connections Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_limit_outbound_connections` covers configuration for limiting outbound connections running in the Dynatrace JavaScript runtime

--- a/templates/resources/log_agent_feature_flags.md.tmpl
+++ b/templates/resources/log_agent_feature_flags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_agent_feature_flags Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_agent_feature_flags Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_agent_feature_flags` covers configuration for log agent feature flags

--- a/templates/resources/log_buckets.md.tmpl
+++ b/templates/resources/log_buckets.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_buckets Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_buckets Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_buckets` covers configuration for log buckets

--- a/templates/resources/log_custom_attribute.md.tmpl
+++ b/templates/resources/log_custom_attribute.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_custom_attribute Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_custom_attribute Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_custom_attribute` covers configuration for [custom log attributes](https://www.dynatrace.com/support/help/observe-and-explore/logs/log-monitoring/analyze-log-data/log-custom-attributes) ([Log Monitoring Classic](https://www.dynatrace.com/support/help/observe-and-explore/logs/log-monitoring))

--- a/templates/resources/log_custom_source.md.tmpl
+++ b/templates/resources/log_custom_source.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_custom_source Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_custom_source Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_custom_source` covers configuration for custom log sources

--- a/templates/resources/log_debug_settings.md.tmpl
+++ b/templates/resources/log_debug_settings.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_debug_settings Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_debug_settings Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_debug_settings` covers configuration for log debug settings

--- a/templates/resources/log_events.md.tmpl
+++ b/templates/resources/log_events.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_events Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_events Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_events` covers configuration for log events

--- a/templates/resources/log_grail.md.tmpl
+++ b/templates/resources/log_grail.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_grail Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_grail Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_log_grail` covers configuration for log powered by Grail

--- a/templates/resources/log_metrics.md.tmpl
+++ b/templates/resources/log_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_metrics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_metrics Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_metrics` covers configuration for log metrics

--- a/templates/resources/log_oneagent.md.tmpl
+++ b/templates/resources/log_oneagent.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_oneagent Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_oneagent Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_oneagent` covers configuration for OneAgent settings for Log Monitoring

--- a/templates/resources/log_processing.md.tmpl
+++ b/templates/resources/log_processing.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_processing Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_processing Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_processing` covers configuration for log processing

--- a/templates/resources/log_security_context.md.tmpl
+++ b/templates/resources/log_security_context.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_security_context Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_security_context Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_security_context` covers configuration for log security context rules

--- a/templates/resources/log_sensitive_data_masking.md.tmpl
+++ b/templates/resources/log_sensitive_data_masking.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_sensitive_data_masking Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_sensitive_data_masking Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_sensitive_data_masking` covers configuration for [Sensitive Data Masking for Logs](https://www.dynatrace.com/support/help/observe-and-explore/logs/log-monitoring/log-monitoring-configuration/sensitive-data-masking) ([Log Monitoring Classic](https://www.dynatrace.com/support/help/observe-and-explore/logs/log-monitoring))

--- a/templates/resources/log_storage.md.tmpl
+++ b/templates/resources/log_storage.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_storage Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_storage Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_storage` covers configuration for log ingest rules

--- a/templates/resources/log_timestamp.md.tmpl
+++ b/templates/resources/log_timestamp.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_log_timestamp Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_log_timestamp Resource - terraform-provider-dynatrace"
 subcategory: "Log Monitoring"
 description: |-
   The resource `dynatrace_log_timestamp` covers configuration for log timestamp/splitting patterns

--- a/templates/resources/mainframe_transaction_monitoring.md.tmpl
+++ b/templates/resources/mainframe_transaction_monitoring.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_mainframe_transaction_monitoring Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_mainframe_transaction_monitoring Resource - terraform-provider-dynatrace"
 subcategory: "Mainframe"
 description: |-
   The resource `dynatrace_mainframe_transaction_monitoring` covers additional monitoring settings for CICS and IMS transactions

--- a/templates/resources/maintenance.md.tmpl
+++ b/templates/resources/maintenance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_maintenance Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_maintenance Resource - terraform-provider-dynatrace"
 subcategory: "Alerting"
 description: |-
   The resource `dynatrace_maintenance` covers configuration for maintenance windows

--- a/templates/resources/maintenance_window.md.tmpl
+++ b/templates/resources/maintenance_window.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_maintenance_window Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_maintenance_window Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_maintenance_window` covers configuration for maintenance windows

--- a/templates/resources/managed_backup.md.tmpl
+++ b/templates/resources/managed_backup.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_managed_backup Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_managed_backup Resource - terraform-provider-dynatrace"
 subcategory: "Cluster Management"
 description: |-
   The resource `dynatrace_managed_backup` covers configuration for cluster backup

--- a/templates/resources/managed_internet_proxy.md.tmpl
+++ b/templates/resources/managed_internet_proxy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_managed_internet_proxy Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_managed_internet_proxy Resource - terraform-provider-dynatrace"
 subcategory: "Cluster Management"
 description: |-
   The resource `dynatrace_managed_internet_proxy` covers configuration for cluster proxy

--- a/templates/resources/managed_network_zones.md.tmpl
+++ b/templates/resources/managed_network_zones.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_managed_network_zones Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_managed_network_zones Resource - terraform-provider-dynatrace"
 subcategory: "Cluster Management"
 description: |-
   The resource `dynatrace_managed_network_zones` covers configuration for Managed cluster network zones

--- a/templates/resources/managed_preferences.md.tmpl
+++ b/templates/resources/managed_preferences.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_managed_preferences Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_managed_preferences Resource - terraform-provider-dynatrace"
 subcategory: "Cluster Management"
 description: |-
   The resource `dynatrace_managed_preferences` covers configuration for cluster preferences

--- a/templates/resources/managed_public_endpoints.md.tmpl
+++ b/templates/resources/managed_public_endpoints.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_managed_public_endpoints Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_managed_public_endpoints Resource - terraform-provider-dynatrace"
 subcategory: "Cluster Management"
 description: |-
   The resource `dynatrace_managed_public_endpoints` covers configuration for cluster public endpoints

--- a/templates/resources/managed_remote_access.md.tmpl
+++ b/templates/resources/managed_remote_access.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_managed_remote_access Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_managed_remote_access Resource - terraform-provider-dynatrace"
 subcategory: "Cluster Management"
 description: |-
   The resource `dynatrace_managed_remote_access` covers configuration for remote access requests

--- a/templates/resources/managed_smtp.md.tmpl
+++ b/templates/resources/managed_smtp.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_managed_smtp Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_managed_smtp Resource - terraform-provider-dynatrace"
 subcategory: "Cluster Management"
 description: |-
   The resource `dynatrace_managed_smtp` covers configuration for cluster SMTP settings

--- a/templates/resources/management_zone.md.tmpl
+++ b/templates/resources/management_zone.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_management_zone Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_management_zone Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_management_zone` covers configuration for management zones

--- a/templates/resources/management_zone_v2.md.tmpl
+++ b/templates/resources/management_zone_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_management_zone_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_management_zone_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Management Zones"
 description: |-
   The resource `dynatrace_management_zone_v2` covers configuration for management zones

--- a/templates/resources/metric_events.md.tmpl
+++ b/templates/resources/metric_events.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_metric_events Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_metric_events Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_metric_events` covers configuration for custom metric events

--- a/templates/resources/metric_metadata.md.tmpl
+++ b/templates/resources/metric_metadata.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_metric_metadata Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_metric_metadata Resource - terraform-provider-dynatrace"
 subcategory: "Metrics"
 description: |-
   The resource `dynatrace_metric_metadata` covers configuration for metric metadata

--- a/templates/resources/metric_query.md.tmpl
+++ b/templates/resources/metric_query.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_metric_query Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_metric_query Resource - terraform-provider-dynatrace"
 subcategory: "Metrics"
 description: |-
   The resource `dynatrace_metric_query` covers configuration for metric query

--- a/templates/resources/mgmz_permission.md.tmpl
+++ b/templates/resources/mgmz_permission.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_mgmz_permission Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_mgmz_permission Resource - terraform-provider-dynatrace"
 subcategory: "IAM"
 description: |-
   The resource `dynatrace_mgmz_permission` covers permissions to user groups / management zones within managed environments

--- a/templates/resources/mobile_app_key_performance.md.tmpl
+++ b/templates/resources/mobile_app_key_performance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_mobile_app_key_performance Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_mobile_app_key_performance Resource - terraform-provider-dynatrace"
 subcategory: "Mobile & Custom Applications"
 description: |-
   The resource `dynatrace_mobile_app_key_performance` covers apdex threshold configuration for mobile/custom applications

--- a/templates/resources/mobile_notifications.md.tmpl
+++ b/templates/resources/mobile_notifications.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_mobile_notifications Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_mobile_notifications Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_mobile_notifications` covers configuration problem notifications sent via Web Hook

--- a/templates/resources/monitored_technologies_apache.md.tmpl
+++ b/templates/resources/monitored_technologies_apache.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_apache Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_apache Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_apache` covers configuration to enable/disable Apache HTTP Server monitoring

--- a/templates/resources/monitored_technologies_dotnet.md.tmpl
+++ b/templates/resources/monitored_technologies_dotnet.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_dotnet Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_dotnet Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_dotnet` covers configuration to enable/disable .NET monitoring

--- a/templates/resources/monitored_technologies_go.md.tmpl
+++ b/templates/resources/monitored_technologies_go.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_go Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_go Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_go` covers configuration to enable/disable Go monitoring

--- a/templates/resources/monitored_technologies_iis.md.tmpl
+++ b/templates/resources/monitored_technologies_iis.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_iis Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_iis Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_iis` covers configuration to enable/disable IIS monitoring

--- a/templates/resources/monitored_technologies_java.md.tmpl
+++ b/templates/resources/monitored_technologies_java.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_java Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_java Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_java` covers configuration to enable/disable Java monitoring

--- a/templates/resources/monitored_technologies_nginx.md.tmpl
+++ b/templates/resources/monitored_technologies_nginx.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_nginx Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_nginx Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_nginx` covers configuration to enable/disable NGINX monitoring

--- a/templates/resources/monitored_technologies_nodejs.md.tmpl
+++ b/templates/resources/monitored_technologies_nodejs.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_nodejs Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_nodejs Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_nodejs` covers configuration to enable/disable Node.js monitoring

--- a/templates/resources/monitored_technologies_opentracing.md.tmpl
+++ b/templates/resources/monitored_technologies_opentracing.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_opentracing Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_opentracing Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_opentracing` covers configuration to enable/disable OpenTracing monitoring

--- a/templates/resources/monitored_technologies_php.md.tmpl
+++ b/templates/resources/monitored_technologies_php.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_php Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_php Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_php` covers configuration to enable/disable PHP monitoring

--- a/templates/resources/monitored_technologies_python.md.tmpl
+++ b/templates/resources/monitored_technologies_python.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_python Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_python Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_python` covers configuration to enable/disable Python monitoring

--- a/templates/resources/monitored_technologies_varnish.md.tmpl
+++ b/templates/resources/monitored_technologies_varnish.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_varnish Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_varnish Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_varnish` covers configuration to enable/disable Varnish monitoring

--- a/templates/resources/monitored_technologies_wsmb.md.tmpl
+++ b/templates/resources/monitored_technologies_wsmb.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_monitored_technologies_wsmb Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_monitored_technologies_wsmb Resource - terraform-provider-dynatrace"
 subcategory: "Monitored Technologies"
 description: |-
   The resource `dynatrace_monitored_technologies_wsmb` covers configuration to enable/disable IBM Integration Bus | IBM App Connect Enterprise monitoring

--- a/templates/resources/ms365_email_connection.md.tmpl
+++ b/templates/resources/ms365_email_connection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ms365_email_connection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ms365_email_connection Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_ms365_email_connection` covers configuration for Microsoft 365 email connections

--- a/templates/resources/msentraid_connection.md.tmpl
+++ b/templates/resources/msentraid_connection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_msentraid_connection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_msentraid_connection Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_msentraid_connection` covers configuration for Microsoft Entra ID connections

--- a/templates/resources/msteams_connection.md.tmpl
+++ b/templates/resources/msteams_connection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_msteams_connection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_msteams_connection Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_msteams_connection` covers configuration for Microsoft Teams connections

--- a/templates/resources/muted_requests.md.tmpl
+++ b/templates/resources/muted_requests.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_muted_requests Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_muted_requests Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_muted_requests` covers configuration for muted requests

--- a/templates/resources/nettracer.md.tmpl
+++ b/templates/resources/nettracer.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_nettracer Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_nettracer Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_nettracer` covers configuration for NetTracer traffic

--- a/templates/resources/network_monitor.md.tmpl
+++ b/templates/resources/network_monitor.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_network_monitor Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_network_monitor Resource - terraform-provider-dynatrace"
 subcategory: "Network Availability Monitors"
 description: |-
   The resource `dynatrace_network_monitor` covers configuration for network availability monitors

--- a/templates/resources/network_monitor_outage.md.tmpl
+++ b/templates/resources/network_monitor_outage.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_network_monitor_outage Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_network_monitor_outage Resource - terraform-provider-dynatrace"
 subcategory: "Network Availability Monitors"
 description: |-
   The resource `dynatrace_network_monitor_outage` covers configuration for network availability monitor outage handling

--- a/templates/resources/network_traffic.md.tmpl
+++ b/templates/resources/network_traffic.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_network_traffic Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_network_traffic Resource - terraform-provider-dynatrace"
 subcategory: "Host Monitoring"
 description: |-
   The resource `dynatrace_network_traffic` covers configuration for excluding network traffic from host monitoring

--- a/templates/resources/network_zone.md.tmpl
+++ b/templates/resources/network_zone.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_network_zone Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_network_zone Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_network_zone` covers configuration for network zones

--- a/templates/resources/network_zones.md.tmpl
+++ b/templates/resources/network_zones.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_network_zones Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_network_zones Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_network_zones` covers configuration for network zones

--- a/templates/resources/notification.md.tmpl
+++ b/templates/resources/notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_notification Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_notification` covers configuration for notifications

--- a/templates/resources/oneagent_default_mode.md.tmpl
+++ b/templates/resources/oneagent_default_mode.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_oneagent_default_mode Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_oneagent_default_mode Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_oneagent_default_mode` covers configuration for OneAgent default mode

--- a/templates/resources/oneagent_default_version.md.tmpl
+++ b/templates/resources/oneagent_default_version.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_oneagent_default_version Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_oneagent_default_version Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
     The resource `dynatrace_oneagent_default_version` just exists for backwards compatibility. The settings it addresses are no longer configurable. The resource `dynatrace_oneagent_updates` covers this functionality now.

--- a/templates/resources/oneagent_features.md.tmpl
+++ b/templates/resources/oneagent_features.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_oneagent_features Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_oneagent_features Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_oneagent_features` allows for enabling and disabling OneAgent Features (Sensors, ...)

--- a/templates/resources/oneagent_side_masking.md.tmpl
+++ b/templates/resources/oneagent_side_masking.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_oneagent_side_masking Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_oneagent_side_masking Resource - terraform-provider-dynatrace"
 subcategory: "Environment Settings"
 description: |-
   The resource `dynatrace_oneagent_side_masking` covers configuration for OneAgent data masking

--- a/templates/resources/oneagent_updates.md.tmpl
+++ b/templates/resources/oneagent_updates.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_oneagent_updates Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_oneagent_updates Resource - terraform-provider-dynatrace"
 subcategory: "Updates"
 description: |-
   The resource `dynatrace_oneagent_updates` covers configuration for OneAgent updates

--- a/templates/resources/opentelemetry_metrics.md.tmpl
+++ b/templates/resources/opentelemetry_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_opentelemetry_metrics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_opentelemetry_metrics Resource - terraform-provider-dynatrace"
 subcategory: "OpenTelemetry & OpenTracing"
 description: |-
   The resource `dynatrace_opentelemetry_metrics` covers configuration for OpenTelemetry metrics

--- a/templates/resources/ops_genie_notification.md.tmpl
+++ b/templates/resources/ops_genie_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ops_genie_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ops_genie_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_ops_genie_notification` covers configuration problem notifications sent to OpsGenie

--- a/templates/resources/ownership_config.md.tmpl
+++ b/templates/resources/ownership_config.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ownership_config Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ownership_config Resource - terraform-provider-dynatrace"
 subcategory: "Ownership"
 description: |-
   The resource `dynatrace_ownership_config` covers configuration for ownership

--- a/templates/resources/ownership_teams.md.tmpl
+++ b/templates/resources/ownership_teams.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_ownership_teams Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_ownership_teams Resource - terraform-provider-dynatrace"
 subcategory: "Ownership"
 description: |-
   The resource `dynatrace_ownership_teams` covers configuration for ownership teams

--- a/templates/resources/pager_duty_notification.md.tmpl
+++ b/templates/resources/pager_duty_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_pager_duty_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_pager_duty_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_pager_duty_notification` covers configuration problem notifications sent to Pager Duty

--- a/templates/resources/pagerduty_connection.md.tmpl
+++ b/templates/resources/pagerduty_connection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_pagerduty_connection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_pagerduty_connection Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_pagerduty_connection` covers configuration for PagerDuty connections

--- a/templates/resources/pg_alerting.md.tmpl
+++ b/templates/resources/pg_alerting.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_pg_alerting Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_pg_alerting Resource - terraform-provider-dynatrace"
 subcategory: "Process Group Monitoring"
 description: |-
   The resource `dynatrace_pg_alerting` covers configuration for process group availability monitoring

--- a/templates/resources/pg_anomalies.md.tmpl
+++ b/templates/resources/pg_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_pg_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_pg_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_pg_anomalies` covers configuration for process group anomaly detection

--- a/templates/resources/platform_slo.md.tmpl
+++ b/templates/resources/platform_slo.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Service-level Objective"
 description: |-
   The resource `{{ .Name }}` covers configuration for platform service-level objectives

--- a/templates/resources/platform_slo.md.tmpl
+++ b/templates/resources/platform_slo.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Service-level Objective"
 description: |-
   The resource `{{ .Name }}` covers configuration for platform service-level objectives

--- a/templates/resources/problem_fields.md.tmpl
+++ b/templates/resources/problem_fields.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_problem_fields Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_problem_fields Resource - terraform-provider-dynatrace"
 subcategory: "Platform"
 description: |-
   The resource `dynatrace_problem_fields` covers configuration for problem fields

--- a/templates/resources/problem_record_propagation_rules.md.tmpl
+++ b/templates/resources/problem_record_propagation_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_problem_record_propagation_rules Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_problem_record_propagation_rules Resource - terraform-provider-dynatrace"
 subcategory: "Platform"
 description: |-
   The resource `dynatrace_problem_record_propagation_rules` covers configuration for problem record propagation rules

--- a/templates/resources/process_group_detection_flags.md.tmpl
+++ b/templates/resources/process_group_detection_flags.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_process_group_detection_flags Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_process_group_detection_flags Resource - terraform-provider-dynatrace"
 subcategory: "Process Group Monitoring"
 description: |-
   The resource `dynatrace_process_group_detection_flags` covers configuration to enable or disable built-in process group detection rules

--- a/templates/resources/process_group_monitoring.md.tmpl
+++ b/templates/resources/process_group_monitoring.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_process_group_monitoring Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_process_group_monitoring Resource - terraform-provider-dynatrace"
 subcategory: "Process Group Monitoring"
 description: |-
   The resource `dynatrace_process_group_monitoring` covers configuration to enable or disable monitoring for certain process groups

--- a/templates/resources/process_group_rum.md.tmpl
+++ b/templates/resources/process_group_rum.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_process_group_rum Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_process_group_rum Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_process_group_rum` covers real user monitoring configuration for process groups

--- a/templates/resources/processgroup_naming.md.tmpl
+++ b/templates/resources/processgroup_naming.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_processgroup_naming Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_processgroup_naming Resource - terraform-provider-dynatrace"
 subcategory: "Process Group Monitoring"
 description: |-
   The resource `dynatrace_processgroup_naming` covers configuration for process group naming

--- a/templates/resources/processgroup_naming_order.md.tmpl
+++ b/templates/resources/processgroup_naming_order.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_processgroup_naming_order Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_processgroup_naming_order Resource - terraform-provider-dynatrace"
 subcategory: "Process Group Monitoring"
 description: |-
   The resource `dynatrace_processgroup_naming_order` covers defining the order of rules defined for process group naming

--- a/templates/resources/queue_sharing_groups.md.tmpl
+++ b/templates/resources/queue_sharing_groups.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_queue_sharing_groups Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_queue_sharing_groups Resource - terraform-provider-dynatrace"
 subcategory: "Mainframe"
 description: |-
   The resource `dynatrace_queue_sharing_groups` covers configuration for IBM MQ queue sharing groups

--- a/templates/resources/remote_environments.md.tmpl
+++ b/templates/resources/remote_environments.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_remote_environments Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_remote_environments Resource - terraform-provider-dynatrace"
 subcategory: "Integrations"
 description: |-
   The resource `dynatrace_remote_environments` covers configuration for remote Dynatrace environments

--- a/templates/resources/report.md.tmpl
+++ b/templates/resources/report.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_report Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_report Resource - terraform-provider-dynatrace"
 subcategory: "Dashboards"
 description: |-
   The resource `dynatrace_report` covers configuration for dashboard reports

--- a/templates/resources/request_attribute.md.tmpl
+++ b/templates/resources/request_attribute.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_request_attribute Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_request_attribute Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_request_attribute` covers configuration for request attributes

--- a/templates/resources/request_naming.md.tmpl
+++ b/templates/resources/request_naming.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_request_naming Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_request_naming Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_request_naming` covers configuration for request naming

--- a/templates/resources/request_namings.md.tmpl
+++ b/templates/resources/request_namings.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_request_namings Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_request_namings Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_request_namings` covers configuration for request naming order

--- a/templates/resources/resource_attributes.md.tmpl
+++ b/templates/resources/resource_attributes.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_resource_attributes Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_resource_attributes Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_resource_attributes` covers configuration for resource attributes

--- a/templates/resources/rpc_based_sampling.md.tmpl
+++ b/templates/resources/rpc_based_sampling.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Service Monitoring"
 description: |-
   The resource `{{ .Name }}` covers configuration for trace sampling for RPC requests

--- a/templates/resources/rpc_based_sampling.md.tmpl
+++ b/templates/resources/rpc_based_sampling.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Service Monitoring"
 description: |-
   The resource `{{ .Name }}` covers configuration for trace sampling for RPC requests

--- a/templates/resources/rum_advanced_correlation.md.tmpl
+++ b/templates/resources/rum_advanced_correlation.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_rum_advanced_correlation Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_rum_advanced_correlation Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_rum_advanced_correlation` covers configuration for real user monitoring advanced correlation

--- a/templates/resources/rum_host_headers.md.tmpl
+++ b/templates/resources/rum_host_headers.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_rum_host_headers Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_rum_host_headers Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_rum_host_headers` covers configuration for identifying host names for real user monitoring

--- a/templates/resources/rum_ip_determination.md.tmpl
+++ b/templates/resources/rum_ip_determination.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_rum_ip_determination Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_rum_ip_determination Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_rum_ip_determination` covers configuration for identifying client IP addresses for real user monitoring

--- a/templates/resources/rum_ip_locations.md.tmpl
+++ b/templates/resources/rum_ip_locations.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_rum_ip_locations Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_rum_ip_locations Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_rum_ip_locations` covers configuration for IP address mapping rules for real user monitoring

--- a/templates/resources/rum_overload_prevention.md.tmpl
+++ b/templates/resources/rum_overload_prevention.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_rum_overload_prevention Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_rum_overload_prevention Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_rum_overload_prevention` covers configuration for real user monitoring overload prevention

--- a/templates/resources/rum_provider_breakdown.md.tmpl
+++ b/templates/resources/rum_provider_breakdown.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_rum_provider_breakdown Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_rum_provider_breakdown Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_rum_provider_breakdown` covers configuration for provider breakdown rules for real user monitoring

--- a/templates/resources/security_context.md.tmpl
+++ b/templates/resources/security_context.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_security_context Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_security_context Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_security_context` covers configuration for security context settings

--- a/templates/resources/segment.md.tmpl
+++ b/templates/resources/segment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Grail"
 description: |-
   The resource `{{ .Name }}` covers configuration of segments to logically structure and conveniently filter observability data across apps on the Dynatrace platform

--- a/templates/resources/segment.md.tmpl
+++ b/templates/resources/segment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Grail"
 description: |-
   The resource `{{ .Name }}` covers configuration of segments to logically structure and conveniently filter observability data across apps on the Dynatrace platform

--- a/templates/resources/service_anomalies.md.tmpl
+++ b/templates/resources/service_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_service_anomalies` covers configuration for service anomaly detection

--- a/templates/resources/service_anomalies_v2.md.tmpl
+++ b/templates/resources/service_anomalies_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_anomalies_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_anomalies_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_service_anomalies_v2` covers configuration for service anomaly detection

--- a/templates/resources/service_detection_rules.md.tmpl
+++ b/templates/resources/service_detection_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for service detection rules

--- a/templates/resources/service_detection_rules.md.tmpl
+++ b/templates/resources/service_detection_rules.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for service detection rules

--- a/templates/resources/service_external_web_request.md.tmpl
+++ b/templates/resources/service_external_web_request.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_external_web_request Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_external_web_request Resource - terraform-provider-dynatrace"
 subcategory: "Service Detection"
 description: |-
   The resource `dynatrace_service_external_web_request` covers service detection rules for external web requests

--- a/templates/resources/service_external_web_service.md.tmpl
+++ b/templates/resources/service_external_web_service.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_external_web_service Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_external_web_service Resource - terraform-provider-dynatrace"
 subcategory: "Service Detection"
 description: |-
   The resource `dynatrace_service_external_web_service` covers service detection rules for external web services

--- a/templates/resources/service_failure.md.tmpl
+++ b/templates/resources/service_failure.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_failure Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_failure Resource - terraform-provider-dynatrace"
 subcategory: "Failure Detection"
 description: |-
   The resource `dynatrace_service_failure` covers configuration for service-level general failure detection parameters

--- a/templates/resources/service_full_web_request.md.tmpl
+++ b/templates/resources/service_full_web_request.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_full_web_request Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_full_web_request Resource - terraform-provider-dynatrace"
 subcategory: "Service Detection"
 description: |-
   The resource `dynatrace_service_full_web_request` covers service detection rules for full web requests

--- a/templates/resources/service_full_web_service.md.tmpl
+++ b/templates/resources/service_full_web_service.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_full_web_service Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_full_web_service Resource - terraform-provider-dynatrace"
 subcategory: "Service Detection"
 description: |-
   The resource `dynatrace_service_full_web_service` covers service detection rules for full web services

--- a/templates/resources/service_http_failure.md.tmpl
+++ b/templates/resources/service_http_failure.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_http_failure Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_http_failure Resource - terraform-provider-dynatrace"
 subcategory: "Failure Detection"
 description: |-
   The resource `dynatrace_service_http_failure` covers configuration for service-level HTTP failure detection parameters

--- a/templates/resources/service_naming.md.tmpl
+++ b/templates/resources/service_naming.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_naming Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_naming Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_service_naming` covers configuration for service naming

--- a/templates/resources/service_naming_order.md.tmpl
+++ b/templates/resources/service_naming_order.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_naming_order Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_naming_order Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_service_naming_order` covers defining the order of rules defined for service naming

--- a/templates/resources/service_now_notification.md.tmpl
+++ b/templates/resources/service_now_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_service_now_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_service_now_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_service_now_notification` covers configuration problem notifications sent to Service Now

--- a/templates/resources/service_splitting.md.tmpl
+++ b/templates/resources/service_splitting.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for service splitting

--- a/templates/resources/service_splitting.md.tmpl
+++ b/templates/resources/service_splitting.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Service Detection"
 description: |-
   The resource `{{ .Name }}` covers configuration for service splitting

--- a/templates/resources/servicenow_connection.md.tmpl
+++ b/templates/resources/servicenow_connection.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_servicenow_connection Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_servicenow_connection Resource - terraform-provider-dynatrace"
 subcategory: "Connections"
 description: |-
   The resource `dynatrace_servicenow_connection` covers configuration for ServiceNow connections

--- a/templates/resources/session_replay_resource_capture.md.tmpl
+++ b/templates/resources/session_replay_resource_capture.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_session_replay_resource_capture Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_session_replay_resource_capture Resource - terraform-provider-dynatrace"
 subcategory: "Session Replay"
 description: |-
   The resource `dynatrace_session_replay_resource_capture` covers configuration for Session Replay resource capture

--- a/templates/resources/session_replay_web_privacy.md.tmpl
+++ b/templates/resources/session_replay_web_privacy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_session_replay_web_privacy Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_session_replay_web_privacy Resource - terraform-provider-dynatrace"
 subcategory: "Session Replay"
 description: |-
   The resource `dynatrace_session_replay_web_privacy` covers configuration for Session Replay data privacy

--- a/templates/resources/settings_permissions.md.tmpl
+++ b/templates/resources/settings_permissions.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_settings_permissions Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_settings_permissions Resource - terraform-provider-dynatrace"
 subcategory: "Platform"
 description: |-
   The resource `dynatrace_settings_permissions` covers access configurations for Settings 2.0 objects

--- a/templates/resources/slack_notification.md.tmpl
+++ b/templates/resources/slack_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_slack_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_slack_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_slack_notification` covers configuration problem notifications sent to Slack

--- a/templates/resources/slo.md.tmpl
+++ b/templates/resources/slo.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_slo Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_slo Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_slo` covers configuration for service-level objectives

--- a/templates/resources/slo_v2.md.tmpl
+++ b/templates/resources/slo_v2.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_slo_v2 Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_slo_v2 Resource - terraform-provider-dynatrace"
 subcategory: "Service-level Objective"
 description: |-
   The resource `dynatrace_slo_v2` covers configuration for service-level objectives

--- a/templates/resources/span_attribute.md.tmpl
+++ b/templates/resources/span_attribute.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_span_attribute Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_span_attribute Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_span_attribute` covers configuration for span attributes

--- a/templates/resources/span_capture_rule.md.tmpl
+++ b/templates/resources/span_capture_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_span_capture_rule Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_span_capture_rule Resource - terraform-provider-dynatrace"
 subcategory: "OpenTelemetry & OpenTracing"
 description: |-
   The resource `dynatrace_span_capture_rule` covers configuration for span capture rules

--- a/templates/resources/span_context_propagation.md.tmpl
+++ b/templates/resources/span_context_propagation.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_span_context_propagation Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_span_context_propagation Resource - terraform-provider-dynatrace"
 subcategory: "OpenTelemetry & OpenTracing"
 description: |-
   The resource `dynatrace_span_context_propagation` covers configuration for span context propagation

--- a/templates/resources/span_entry_point.md.tmpl
+++ b/templates/resources/span_entry_point.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_span_entry_point Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_span_entry_point Resource - terraform-provider-dynatrace"
 subcategory: "OpenTelemetry & OpenTracing"
 description: |-
   The resource `dynatrace_span_entry_point` covers configuration for span entry points

--- a/templates/resources/span_events.md.tmpl
+++ b/templates/resources/span_events.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_span_events Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_span_events Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_span_events` covers configuration for span events

--- a/templates/resources/synthetic_availability.md.tmpl
+++ b/templates/resources/synthetic_availability.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_synthetic_availability Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_synthetic_availability Resource - terraform-provider-dynatrace"
 subcategory: "Synthetic"
 description: |-
   Dynatrace offers the possibility to configure maintenance windows. By default maintenance windows only affect problem detection and alerting. You can change this behavior and calculate availability including/excluding maintenance window periods

--- a/templates/resources/synthetic_location.md.tmpl
+++ b/templates/resources/synthetic_location.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_synthetic_location Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_synthetic_location Resource - terraform-provider-dynatrace"
 subcategory: "Synthetic"
 description: |-
   The resource `dynatrace_synthetic_location` covers configuration of private synthetic locations

--- a/templates/resources/token_settings.md.tmpl
+++ b/templates/resources/token_settings.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_token_settings Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_token_settings Resource - terraform-provider-dynatrace"
 subcategory: "Access Tokens"
 description: |-
   The resource `dynatrace_token_settings` covers configuration for access token settings

--- a/templates/resources/transaction_start_filters.md.tmpl
+++ b/templates/resources/transaction_start_filters.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_transaction_start_filters Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_transaction_start_filters Resource - terraform-provider-dynatrace"
 subcategory: "Mainframe"
 description: |-
   The resource `dynatrace_transaction_start_filters` covers customization of CICS and IMS Monitoring

--- a/templates/resources/trello_notification.md.tmpl
+++ b/templates/resources/trello_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_trello_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_trello_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_trello_notification` covers configuration problem notifications sent to Trello

--- a/templates/resources/unified_services_metrics.md.tmpl
+++ b/templates/resources/unified_services_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_unified_services_metrics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_unified_services_metrics Resource - terraform-provider-dynatrace"
 subcategory: "Service Detection"
 description: |-
   The resource `dynatrace_unified_services_metrics` allows to enable/disable endpoint metrics for Unified services

--- a/templates/resources/unified_services_opentel.md.tmpl
+++ b/templates/resources/unified_services_opentel.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_unified_services_opentel Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_unified_services_opentel Resource - terraform-provider-dynatrace"
 subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_unified_services_opentel` allows to enable/disable unified services for OpenTelemetry

--- a/templates/resources/update_windows.md.tmpl
+++ b/templates/resources/update_windows.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_update_windows Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_update_windows Resource - terraform-provider-dynatrace"
 subcategory: "Updates"
 description: |-
   The resource `dynatrace_update_windows` covers configuration for maintenance windows for OneAgent updates

--- a/templates/resources/url_based_sampling.md.tmpl
+++ b/templates/resources/url_based_sampling.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_url_based_sampling Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_url_based_sampling Resource - terraform-provider-dynatrace"
 subcategory: "Service Monitoring"
 description: |-
   The resource `dynatrace_url_based_sampling` covers configuration for URL-based sampling

--- a/templates/resources/usability_analytics.md.tmpl
+++ b/templates/resources/usability_analytics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_usability_analytics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_usability_analytics Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_usability_analytics` covers detection of usability issues within your application. User action types that commonly reflect user frustration include dead clicks, rage clicks, rage rotates, and page refreshes

--- a/templates/resources/user.md.tmpl
+++ b/templates/resources/user.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_user Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_user Resource - terraform-provider-dynatrace"
 subcategory: "IAM"
 description: |-
   The resource `dynatrace_user` covers configuration for users

--- a/templates/resources/user_action_metrics.md.tmpl
+++ b/templates/resources/user_action_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_user_action_metrics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_user_action_metrics Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_user_action_metrics` covers configuration for user action custom metrics

--- a/templates/resources/user_experience_score.md.tmpl
+++ b/templates/resources/user_experience_score.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_user_experience_score Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_user_experience_score Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_user_experience_score` covers configuration for real user monitoring user experience score

--- a/templates/resources/user_group.md.tmpl
+++ b/templates/resources/user_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_user_group Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_user_group Resource - terraform-provider-dynatrace"
 subcategory: "IAM"
 description: |-
   The resource `dynatrace_user_group` covers configuration for user groups

--- a/templates/resources/user_session_metrics.md.tmpl
+++ b/templates/resources/user_session_metrics.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_user_session_metrics Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_user_session_metrics Resource - terraform-provider-dynatrace"
 subcategory: "Real User Monitoring"
 description: |-
   The resource `dynatrace_user_session_metrics` covers configuration for user session custom metrics

--- a/templates/resources/user_settings.md.tmpl
+++ b/templates/resources/user_settings.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_user_settings Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_user_settings Resource - terraform-provider-dynatrace"
 subcategory: "User Settings"
 description: |-
   The resource `dynatrace_user_settings` covers user settings of an individual user

--- a/templates/resources/victor_ops_notification.md.tmpl
+++ b/templates/resources/victor_ops_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_victor_ops_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_victor_ops_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_victor_ops_notification` covers configuration problem notifications sent to VictorOps

--- a/templates/resources/vmware.md.tmpl
+++ b/templates/resources/vmware.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_vmware Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_vmware Resource - terraform-provider-dynatrace"
 subcategory: "Virtualization"
 description: |-
   The resource `dynatrace_vmware` covers configuration for VMware

--- a/templates/resources/vmware_anomalies.md.tmpl
+++ b/templates/resources/vmware_anomalies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_vmware_anomalies Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_vmware_anomalies Resource - terraform-provider-dynatrace"
 subcategory: "Anomaly Detection"
 description: |-
   The resource `dynatrace_vmware_anomalies` covers configuration for VMware anomaly detection

--- a/templates/resources/vulnerability_alerting.md.tmpl
+++ b/templates/resources/vulnerability_alerting.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_vulnerability_alerting Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_vulnerability_alerting Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_vulnerability_alerting` covers configuration for vulnerability alerting profiles

--- a/templates/resources/vulnerability_code.md.tmpl
+++ b/templates/resources/vulnerability_code.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_vulnerability_code Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_vulnerability_code Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_vulnerability_code` covers configuration for vulnerability analytics: monitoring rules for code-level vulnerabilities

--- a/templates/resources/vulnerability_settings.md.tmpl
+++ b/templates/resources/vulnerability_settings.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_vulnerability_settings Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_vulnerability_settings Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_vulnerability_settings` covers configuration for vulnerability analytics: general settings

--- a/templates/resources/vulnerability_third_party.md.tmpl
+++ b/templates/resources/vulnerability_third_party.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_vulnerability_third_party Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_vulnerability_third_party Resource - terraform-provider-dynatrace"
 subcategory: "Application Security"
 description: |-
   The resource `dynatrace_vulnerability_third_party` covers configuration for vulnerability analytics: monitoring rules for third-party vulnerabilities 

--- a/templates/resources/vulnerability_third_party_attr.md.tmpl
+++ b/templates/resources/vulnerability_third_party_attr.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Application Security"
 description: |-
   The resource `{{ .Name }}` covers configuration for vulnerability analytics: monitoring rules for third-party vulnerabilities 

--- a/templates/resources/vulnerability_third_party_attr.md.tmpl
+++ b/templates/resources/vulnerability_third_party_attr.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Application Security"
 description: |-
   The resource `{{ .Name }}` covers configuration for vulnerability analytics: monitoring rules for third-party vulnerabilities 

--- a/templates/resources/vulnerability_third_party_k8s.md.tmpl
+++ b/templates/resources/vulnerability_third_party_k8s.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Application Security"
 description: |-
   The resource `{{ .Name }}` covers configuration for vulnerability analytics: Kubernetes monitoring rules for third-party vulnerabilities

--- a/templates/resources/vulnerability_third_party_k8s.md.tmpl
+++ b/templates/resources/vulnerability_third_party_k8s.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Application Security"
 description: |-
   The resource `{{ .Name }}` covers configuration for vulnerability analytics: Kubernetes monitoring rules for third-party vulnerabilities

--- a/templates/resources/web_app_custom_prop_restrictions.md.tmpl
+++ b/templates/resources/web_app_custom_prop_restrictions.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Web Applications"
 description: |-
   The resource `{{ .Name }}` covers configuration for custom properties capture restrictions

--- a/templates/resources/web_app_custom_prop_restrictions.md.tmpl
+++ b/templates/resources/web_app_custom_prop_restrictions.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Web Applications"
 description: |-
   The resource `{{ .Name }}` covers configuration for custom properties capture restrictions

--- a/templates/resources/web_app_ip_address_exclusion.md.tmpl
+++ b/templates/resources/web_app_ip_address_exclusion.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Web Applications"
 description: |-
   The resource `{{ .Name }}` covers configuration for web application IP address exclusions

--- a/templates/resources/web_app_ip_address_exclusion.md.tmpl
+++ b/templates/resources/web_app_ip_address_exclusion.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Web Applications"
 description: |-
   The resource `{{ .Name }}` covers configuration for web application IP address exclusions

--- a/templates/resources/web_app_javascript_filename.md.tmpl
+++ b/templates/resources/web_app_javascript_filename.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Web Applications"
 description: |-
   The resource `{{ .Name }}` covers configuration for RUM monitoring code filename

--- a/templates/resources/web_app_javascript_filename.md.tmpl
+++ b/templates/resources/web_app_javascript_filename.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Web Applications"
 description: |-
   The resource `{{ .Name }}` covers configuration for RUM monitoring code filename

--- a/templates/resources/web_app_key_performance_custom.md.tmpl
+++ b/templates/resources/web_app_key_performance_custom.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_web_app_key_performance_custom Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_web_app_key_performance_custom Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_web_app_key_performance_custom` covers apdex threshold configuration for custom actions

--- a/templates/resources/web_app_key_performance_load.md.tmpl
+++ b/templates/resources/web_app_key_performance_load.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_web_app_key_performance_load Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_web_app_key_performance_load Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_web_app_key_performance_load` covers apdex threshold configuration for load actions

--- a/templates/resources/web_app_key_performance_xhr.md.tmpl
+++ b/templates/resources/web_app_key_performance_xhr.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_web_app_key_performance_xhr Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_web_app_key_performance_xhr Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_web_app_key_performance_xhr` covers apdex threshold configuration for XHR actions

--- a/templates/resources/web_app_manual_insertion.md.tmpl
+++ b/templates/resources/web_app_manual_insertion.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title:  {{.Type}} - {{.ProviderName}}"
+page_title: " {{.Type}} - {{.ProviderName}}"
 subcategory: "Web Applications"
 description: |-
   The resource `{{ .Name }}` covers configuration for web application manual insertion

--- a/templates/resources/web_app_manual_insertion.md.tmpl
+++ b/templates/resources/web_app_manual_insertion.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: " {{.Type}} - {{.ProviderName}}"
+page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Web Applications"
 description: |-
   The resource `{{ .Name }}` covers configuration for web application manual insertion

--- a/templates/resources/web_app_resource_cleanup.md.tmpl
+++ b/templates/resources/web_app_resource_cleanup.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_web_app_resource_cleanup Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_web_app_resource_cleanup Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_web_app_resource_cleanup` covers configuration for resource URL cleanup rules for real user monitoring

--- a/templates/resources/web_application.md.tmpl
+++ b/templates/resources/web_application.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_web_application Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_web_application Resource - terraform-provider-dynatrace"
 subcategory: "Web Applications"
 description: |-
   The resource `dynatrace_web_application` covers configuration for web applications

--- a/templates/resources/webhook_notification.md.tmpl
+++ b/templates/resources/webhook_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_webhook_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_webhook_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_webhook_notification` covers configuration problem notifications sent via Web Hook

--- a/templates/resources/xmatters_notification.md.tmpl
+++ b/templates/resources/xmatters_notification.md.tmpl
@@ -1,6 +1,6 @@
 ---
 layout: ""
-page_title: dynatrace_xmatters_notification Resource - terraform-provider-dynatrace"
+page_title: "dynatrace_xmatters_notification Resource - terraform-provider-dynatrace"
 subcategory: "Notifications"
 description: |-
   The resource `dynatrace_xmatters_notification` covers configuration problem notifications sent via xMatters


### PR DESCRIPTION
#### **Why** this PR?
I notice some inconsistencies in many `page_title` values.

#### **What** has changed and **how** does it do it?
- Each `page_title` value is always enclosed in double-quotes
- If using template variables, there is no extra space at the beginning of the value

#### How is it **tested**?
NA

#### How does it affect **users**?
Little or no effect on the actual rendered documentation - this PR is just for consistency

**Issue:** NA
