### PR TITLE
doc: Add deprecation notice to `dynatrace_oneagent_default_version` resource

### DIFF
--- a/templates/resources/oneagent_default_version.md.tmpl
+++ b/templates/resources/oneagent_default_version.md.tmpl
@@ -5,3 +5,7 @@ subcategory: "Deprecated"
 description: |-
     The resource `dynatrace_oneagent_default_version` just exists for backwards compatibility. The settings it addresses are no longer configurable. The resource `dynatrace_oneagent_updates` covers this functionality now.
 ---
+
+# dynatrace_oneagent_default_version (Resource)
+
+!> This resource API endpoint has been deprecated.


### PR DESCRIPTION
#### **Why** this PR?
Currently, this resource is listed in the wrong place in our documentation in the Terraform registry. By adding a deprecation notice (which is anyway missing), we hope the change forces a move to the "Deprecated" section.

#### **What** has changed and **how** does it do it?
Added a deprecation notice to the `dynatrace_oneagent_default_version` documentation template.

#### How is it **tested**?
NA

#### How does it affect **users**?
Let's see: hopefully, the documentation for this deprecated resource will be moved to the deprecated section.

**Issue:** NA
