### PR TITLE
fix: Code using `settings20.Client` should handle error before using the response

### DIFF
--- a/dynatrace/api/app/dynatrace/sitereliabilityguardian/service.go
+++ b/dynatrace/api/app/dynatrace/sitereliabilityguardian/service.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	sitereliabilityguardian "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/app/dynatrace/sitereliabilityguardian/settings"
@@ -100,10 +99,6 @@ func (me *service) Delete(ctx context.Context, id string) error {
 			return err
 		}
 		err = fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
-	}
-
-	if err != nil && strings.Contains(err.Error(), "Deletion of value(s) is not allowed") {
-		return nil
 	}
 
 	return err

--- a/dynatrace/api/app/dynatrace/slackconnection/service.go
+++ b/dynatrace/api/app/dynatrace/slackconnection/service.go
@@ -47,21 +47,22 @@ func (me *service) Client(ctx context.Context, schemaIDs string) *settings20.Cli
 }
 
 func (me *service) Create(ctx context.Context, v *slackconnection.Settings) (*api.Stub, error) {
-	scope := "environment"
 	data, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
 
+	scope := "environment"
 	response, err := me.Client(ctx, SchemaID).Create(ctx, scope, data)
+	if err != nil {
+		return nil, err
+	}
+
 	if response.StatusCode != 200 {
 		if err := rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
-	}
-	if err != nil {
-		return nil, err
 	}
 
 	stub := &api.Stub{ID: response.ID, Name: response.ID}
@@ -73,7 +74,12 @@ func (me *service) Update(ctx context.Context, id string, v *slackconnection.Set
 	if err != nil {
 		return err
 	}
+
 	response, err := me.Client(ctx, "").Update(ctx, id, data)
+	if err != nil {
+		return err
+	}
+
 	if response.StatusCode != 200 {
 		if err := rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return err
@@ -81,7 +87,7 @@ func (me *service) Update(ctx context.Context, id string, v *slackconnection.Set
 		return fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
 	}
 
-	return err
+	return nil
 }
 
 func (me *service) Validate(v *slackconnection.Settings) error {
@@ -90,14 +96,19 @@ func (me *service) Validate(v *slackconnection.Settings) error {
 
 func (me *service) Delete(ctx context.Context, id string) error {
 	response, err := me.Client(ctx, "").Delete(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	if response.StatusCode != 204 {
 		if err = rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return err
 		}
-		err = fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
+		return fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
+
 	}
 
-	return err
+	return nil
 }
 
 type SettingsObject struct {
@@ -108,20 +119,19 @@ type SettingsObject struct {
 }
 
 func (me *service) Get(ctx context.Context, id string, v *slackconnection.Settings) error {
-	var err error
-	var response settings20.Response
-	var settingsObject SettingsObject
-
-	response, err = me.Client(ctx, "").Get(ctx, id)
+	response, err := me.Client(ctx, "").Get(ctx, id)
 	if err != nil {
 		return err
 	}
+
 	if response.StatusCode != 200 {
 		if err := rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return err
 		}
 		return fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
 	}
+
+	var settingsObject SettingsObject
 	if err := json.Unmarshal(response.Data, &settingsObject); err != nil {
 		return err
 	}
@@ -133,17 +143,19 @@ func (me *service) Get(ctx context.Context, id string, v *slackconnection.Settin
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	var stubs api.Stubs
 	response, err := me.Client(ctx, SchemaID).List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if response.StatusCode != 200 {
 		if err := rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
 	}
-	if err != nil {
-		return nil, err
-	}
+
+	var stubs api.Stubs
 	for _, item := range response.Items {
 		stubs = append(stubs, &api.Stub{ID: item.ID, Name: item.ID})
 

--- a/dynatrace/api/app/dynatrace/slackconnection/service.go
+++ b/dynatrace/api/app/dynatrace/slackconnection/service.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	slackconnection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/app/dynatrace/slackconnection/settings"
@@ -96,10 +95,6 @@ func (me *service) Delete(ctx context.Context, id string) error {
 			return err
 		}
 		err = fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
-	}
-
-	if err != nil && strings.Contains(err.Error(), "Deletion of value(s) is not allowed") {
-		return nil
 	}
 
 	return err

--- a/dynatrace/api/builtin/davis/anomalydetectors/service.go
+++ b/dynatrace/api/builtin/davis/anomalydetectors/service.go
@@ -47,21 +47,22 @@ func (me *service) Client(ctx context.Context, schemaIDs string) *settings20.Cli
 }
 
 func (me *service) Create(ctx context.Context, v *anomalydetectors.Settings) (*api.Stub, error) {
-	scope := "environment"
 	data, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
 
+	scope := "environment"
 	response, err := me.Client(ctx, SchemaID).Create(ctx, scope, data)
+	if err != nil {
+		return nil, err
+	}
+
 	if response.StatusCode != 200 {
 		if err := rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
-	}
-	if err != nil {
-		return nil, err
 	}
 
 	stub := &api.Stub{ID: response.ID, Name: response.ID}
@@ -73,7 +74,12 @@ func (me *service) Update(ctx context.Context, id string, v *anomalydetectors.Se
 	if err != nil {
 		return err
 	}
+
 	response, err := me.Client(ctx, "").Update(ctx, id, data)
+	if err != nil {
+		return err
+	}
+
 	if response.StatusCode != 200 {
 		if err := rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return err
@@ -81,7 +87,7 @@ func (me *service) Update(ctx context.Context, id string, v *anomalydetectors.Se
 		return fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
 	}
 
-	return err
+	return nil
 }
 
 func (me *service) Validate(v *anomalydetectors.Settings) error {
@@ -90,14 +96,18 @@ func (me *service) Validate(v *anomalydetectors.Settings) error {
 
 func (me *service) Delete(ctx context.Context, id string) error {
 	response, err := me.Client(ctx, "").Delete(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	if response.StatusCode != 204 {
 		if err = rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return err
 		}
-		err = fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
+		return fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
 	}
 
-	return err
+	return nil
 }
 
 type SettingsObject struct {
@@ -108,11 +118,7 @@ type SettingsObject struct {
 }
 
 func (me *service) Get(ctx context.Context, id string, v *anomalydetectors.Settings) error {
-	var err error
-	var response settings20.Response
-	var settingsObject SettingsObject
-
-	response, err = me.Client(ctx, "").Get(ctx, id)
+	response, err := me.Client(ctx, "").Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -122,6 +128,8 @@ func (me *service) Get(ctx context.Context, id string, v *anomalydetectors.Setti
 		}
 		return fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
 	}
+
+	var settingsObject SettingsObject
 	if err := json.Unmarshal(response.Data, &settingsObject); err != nil {
 		return err
 	}
@@ -133,17 +141,19 @@ func (me *service) Get(ctx context.Context, id string, v *anomalydetectors.Setti
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	var stubs api.Stubs
 	response, err := me.Client(ctx, SchemaID).List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if response.StatusCode != 200 {
 		if err := rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 200, string(response.Data))
 	}
-	if err != nil {
-		return nil, err
-	}
+
+	var stubs api.Stubs
 	for _, item := range response.Items {
 		stubs = append(stubs, &api.Stub{ID: item.ID, Name: item.ID})
 

--- a/dynatrace/api/builtin/davis/anomalydetectors/service.go
+++ b/dynatrace/api/builtin/davis/anomalydetectors/service.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	anomalydetectors "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/davis/anomalydetectors/settings"
@@ -96,10 +95,6 @@ func (me *service) Delete(ctx context.Context, id string) error {
 			return err
 		}
 		err = fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
-	}
-
-	if err != nil && strings.Contains(err.Error(), "Deletion of value(s) is not allowed") {
-		return nil
 	}
 
 	return err

--- a/dynatrace/api/builtin/generic/service.go
+++ b/dynatrace/api/builtin/generic/service.go
@@ -114,13 +114,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 			return nil, err
 		}
 		for _, item := range response.Items {
-			newItem := new(generic.Settings)
-			newItem.Value = string(item.Value)
-			newItem.Scope = item.Scope
-			newItem.SchemaID = schemaID
-			newItem.Scope = item.Scope
 			stubs = append(stubs, &api.Stub{ID: item.ID, Name: item.ID})
-
 		}
 	}
 	return stubs, nil

--- a/dynatrace/api/builtin/generic/service.go
+++ b/dynatrace/api/builtin/generic/service.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	generic "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/generic/settings"
@@ -173,10 +172,6 @@ func (me *service) Update(ctx context.Context, id string, v *generic.Settings) e
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return me.delete(ctx, id, 0)
-}
-
-func (me *service) delete(ctx context.Context, id string, numRetries int) error {
 	response, err := me.Client(ctx, "").Delete(ctx, id)
 	if response.StatusCode != 204 {
 		if err = rest.Envelope(response.Data, response.Request.URL, response.Request.Method); err != nil {
@@ -185,13 +180,6 @@ func (me *service) delete(ctx context.Context, id string, numRetries int) error 
 		err = fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
 	}
 
-	if err != nil && strings.Contains(err.Error(), "Internal Server Error occurred") {
-		if numRetries == 10 {
-			return err
-		}
-		time.Sleep(6 * time.Second)
-		return me.delete(ctx, id, numRetries+1)
-	}
 	return err
 
 }

--- a/dynatrace/api/builtin/generic/service.go
+++ b/dynatrace/api/builtin/generic/service.go
@@ -191,9 +191,6 @@ func (me *service) delete(ctx context.Context, id string, numRetries int) error 
 		err = fmt.Errorf("status code %d (expected: %d): %s", response.StatusCode, 204, string(response.Data))
 	}
 
-	if err != nil && strings.Contains(err.Error(), "Deletion of value(s) is not allowed") {
-		return nil
-	}
 	if err != nil && strings.Contains(err.Error(), "Internal Server Error occurred") {
 		if numRetries == 10 {
 			return err

--- a/dynatrace/rest/legacy_request.go
+++ b/dynatrace/rest/legacy_request.go
@@ -202,17 +202,18 @@ func Envelope(data []byte, url string, method string) error {
 	if len(data) == 0 {
 		return nil
 	}
-	var err error
+
 	var env errorEnvelope
-	if err = json.Unmarshal(data, &env); err == nil && env.Error != nil {
+	if err := json.Unmarshal(data, &env); err == nil && env.Error != nil {
 		return Error{Code: env.Error.Code, Method: method, URL: url, Message: env.Error.Message, ConstraintViolations: env.Error.ConstraintViolations}
-	} else {
-		var envs []errorEnvelope
-		if err = json.Unmarshal(data, &envs); err == nil && len(envs) > 0 {
-			env = envs[0]
-			return Error{Code: env.Error.Code, Method: method, URL: url, Message: env.Error.Message, ConstraintViolations: env.Error.ConstraintViolations}
-		}
 	}
+
+	var envs []errorEnvelope
+	if err := json.Unmarshal(data, &envs); err == nil && len(envs) > 0 {
+		env = envs[0]
+		return Error{Code: env.Error.Code, Method: method, URL: url, Message: env.Error.Message, ConstraintViolations: env.Error.ConstraintViolations}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### **Why** this PR?
This PR is in response to a user seeing:
```
│ Error: status code 0 (expected: 200): 
```
when applying a `dynatrace_davis_anomaly_detectors` resource. The actual error is not visible and status code 0 is clearly incorrect. It was then found that the response from calls to a `settings20.Client` is used before the error is checked, and that this pattern has been repeated in three other resources.

This PR improves the following resources:
- `dynatrace_davis_anomaly_detectors`
- `dynatrace_generic_setting`
- `dynatrace_site_reliability_guardian`
- `dynatrace_automation_workflow_slack`

#### **What** has changed and **how** does it do it?
First, some refactoring:
- Simplify `rest.Envelope`
- Remove dead code to disregard deletion errors for modification validation constraint violations. This code would never be reached as these errors are returned inside an error envelope, which is caught and returned several lines above.
- Remove dead code from `generic.Service` `List` method. While it might have been intended that `newItem` was assigned to the `api.Stub` `Value` field, it wasn't, so it is removed for now.
- Remove dead code for retry logic for `generic.Service` `Delete` method. Due to the response being examined first, this code was never reached and so can be removed for now.

Then, a change is introduced to check errors first before processing responses. While the current code doesn't panic as an empty Response is returned for errors with `StatusCode` set to `0`,  the actual error is lost. This change fixes that by checking the error first. Overall, this change makes the code more Go idiomatic.

#### How is it **tested**?
Existing tests

#### How does it affect **users**?
Users of these resources will see better error messages

**Issue:**  CA-17019