### PR TITLE
fix(export): list-exclusions cannot be set with other flags anymore

### DIFF
--- a/dynatrace/export.go
+++ b/dynatrace/export.go
@@ -38,6 +38,11 @@ func Export(args []string, cfgGetter config.Getter) bool {
 
 	if len(args) > 2 {
 		if strings.TrimSpace(args[2]) == "-list-exclusions" {
+			if len(args) > 3 {
+				fmt.Println("-list-exclusions cannot be combined with other flags\nUsage: terraform-provider-dynatrace -export -list-exclusions")
+				return true
+			}
+
 			for _, group := range export.GetExcludeListedResourceGroups() {
 				fmt.Println(group.Reason)
 				// Calculate the maximum length of the name field


### PR DESCRIPTION
#### **Why** this PR?
Previously it was allowed to set other flags together with `-list-exclusions`, e.g.,
`terraform-provider-dynatrace -export -list-exclusions -import-state`
This was confusing because actually after the exclusions were listed the command would just return and no actual export was done, making the `-import-state` flag useless. This behavior was not properly documented in our [documentation](https://docs.dynatrace.com/docs/deliver/configuration-as-code/terraform/terraform-cli-commands#options-and-flags). 

#### **What** has changed?
The first necessary change is an improvement of the documentation, which is in the works.

To make it less confusing, I changed the behavior such that you get an error if another flag is listed together with `list-exclusions`, explaining its usage. 

##### Examples

**Command: `-export -list-exclusions`**
-> Exclusion list is printed

**Command: `-export -list-exclusions -import-state`**
-> `-list-exclusions cannot be combined with other flags
Usage: terraform-provider-dynatrace -export -list-exclusions`

**Command: `-export -import-state -list-exclusions`**
-> `-list-exclusions cannot be combined with other flags
Usage: terraform-provider-dynatrace -export -list-exclusions`

#### How does it affect **users**?
Using `-export -list-exclusions <any-other-flag>` now gives an error message which also explains the proper usage.

**Issue:**
CA-17016