### PR TITLE
chore(openpipeline-v2): update all resources to version 1.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ terraform-provider-dynatrace.log
 .terraform/
 .terraform.lock.hcl
 __providers__.tf
+terraform.tfstate*
 download.cmd
 build/*
 playground/*

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.bizevents.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.bizevents.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -6,19 +6,10 @@ resource "dynatrace_openpipeline_v2_bizevents_ingestsources" "ingest-source" {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_bizevents_pipelines.pipeline.id
   }
-  processing {
-  }
+  source_type = "http"
 }
 
 resource "dynatrace_openpipeline_v2_bizevents_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_bizevents_ingestsources" "maximal-source" {
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_bizevents_ingestsources" "minimal-source" {
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.bizevents.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.bizevents.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/testdata/terraform/maximal-example.tf
@@ -181,12 +181,6 @@ resource "dynatrace_openpipeline_v2_bizevents_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -201,5 +195,4 @@ resource "dynatrace_openpipeline_v2_bizevents_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_bizevents_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.bizevents.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.bizevents.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_bizevents_routing" "routing" {
 resource "dynatrace_openpipeline_v2_bizevents_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.davis.events.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.davis.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "ingest-source" 
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_davis_events_pipelines.pipeline.id
@@ -13,12 +14,4 @@ resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "ingest-source" 
 resource "dynatrace_openpipeline_v2_davis_events_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "maximal-source"
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "minimal-source"
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.davis.events.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.davis.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.davis.events.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.davis.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.davis.problems.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.davis.problems.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_davis_problems_ingestsources" "ingest-source
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_davis_problems_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_davis_problems_ingestsources" "maximal-sourc
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_davis_problems_ingestsources" "minimal-sourc
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.davis.problems.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.davis.problems.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/testdata/terraform/maximal-example.tf
@@ -66,12 +66,6 @@ resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "max-pipeline" {
       }
     }
   }
-  davis {
-    # davis is not supported for davis.problems pipelines
-  }
-  metric_extraction {
-    # metric_extraction is not supported for davis.problems pipelines
-  }
   security_context {
     processors {
       processor {
@@ -104,12 +98,6 @@ resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -124,5 +112,4 @@ resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.davis.problems.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.davis.problems.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.events.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_events_ingestsources" "ingest-source" {
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_events_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_events_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_events_ingestsources" "maximal-source" {
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_events_ingestsources" "minimal-source" {
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.events.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/testdata/terraform/maximal-example.tf
@@ -181,12 +181,6 @@ resource "dynatrace_openpipeline_v2_events_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -201,5 +195,4 @@ resource "dynatrace_openpipeline_v2_events_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_events_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.events.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_events_routing" "routing" {
 resource "dynatrace_openpipeline_v2_events_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.events.sdlc.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.sdlc.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_events_sdlc_ingestsources" "ingest-source" {
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_events_sdlc_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_events_sdlc_ingestsources" "maximal-source" 
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_events_sdlc_ingestsources" "minimal-source" 
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.events.sdlc.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.sdlc.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/testdata/terraform/maximal-example.tf
@@ -181,12 +181,6 @@ resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -201,5 +195,4 @@ resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.events.sdlc.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.sdlc.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_events_sdlc_routing" "routing" {
 resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.events.security.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.security.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_events_security_ingestsources" "ingest-sourc
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_events_security_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_events_security_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_events_security_ingestsources" "maximal-sour
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_events_security_ingestsources" "minimal-sour
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.events.security.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.security.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/testdata/terraform/maximal-example.tf
@@ -181,12 +181,6 @@ resource "dynatrace_openpipeline_v2_events_security_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -201,5 +195,4 @@ resource "dynatrace_openpipeline_v2_events_security_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_events_security_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.events.security.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.events.security.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_events_security_routing" "routing" {
 resource "dynatrace_openpipeline_v2_events_security_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.logs.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.logs.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_logs_ingestsources" "ingest-source" {
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_logs_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_logs_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_logs_ingestsources" "maximal-source" {
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_logs_ingestsources" "minimal-source" {
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.logs.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.logs.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/testdata/terraform/maximal-example.tf
@@ -181,12 +181,6 @@ resource "dynatrace_openpipeline_v2_logs_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -201,5 +195,36 @@ resource "dynatrace_openpipeline_v2_logs_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
+  data_extraction {
+    processors {
+      processor {
+        description = "SDLC Event Processor"
+        enabled     = true
+        id          = "std_processor_Software_Lifecycle_Event_Processor"
+        type        = "sdlcEvent"
+        matcher     = "true"
+        sdlc_event {
+          event_category {
+            type = "constant"
+            constant = "my-category"
+          }
+          event_provider {
+            type = "constant"
+            constant = "my-provider"
+          }
+          event_status {
+            type = "constant"
+            constant = "my-status"
+          }
+          event_type {
+            type = "constant"
+            constant = "my-type"
+          }
+          field_extraction {
+            type = "includeAll"
+          }
+        }
+      }
+    }
+  }
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_logs_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.logs.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.logs.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_logs_routing" "routing" {
 resource "dynatrace_openpipeline_v2_logs_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.metrics.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.metrics.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_metrics_ingestsources" "ingest-source" {
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_metrics_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_metrics_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_metrics_ingestsources" "maximal-source" {
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_metrics_ingestsources" "minimal-source" {
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.metrics.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.metrics.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/testdata/terraform/maximal-example.tf
@@ -66,12 +66,6 @@ resource "dynatrace_openpipeline_v2_metrics_pipelines" "max-pipeline" {
       }
     }
   }
-  davis {
-    # davis is not supported for metrics pipelines
-  }
-  metric_extraction {
-    # metric_extraction is not supported for metrics pipelines
-  }
   security_context {
     processors {
       processor {
@@ -104,14 +98,4 @@ resource "dynatrace_openpipeline_v2_metrics_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
-  storage {
-    # storage is not supported for metrics pipelines
-  }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_metrics_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.metrics.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.metrics.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_metrics_routing" "routing" {
 resource "dynatrace_openpipeline_v2_metrics_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.security.events.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.security.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_security_events_ingestsources" "ingest-sourc
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_security_events_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_security_events_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_security_events_ingestsources" "maximal-sour
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_security_events_ingestsources" "minimal-sour
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.security.events.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.security.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/testdata/terraform/maximal-example.tf
@@ -181,12 +181,6 @@ resource "dynatrace_openpipeline_v2_security_events_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -201,5 +195,4 @@ resource "dynatrace_openpipeline_v2_security_events_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_security_events_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.security.events.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.security.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_security_events_routing" "routing" {
 resource "dynatrace_openpipeline_v2_security_events_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.spans.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.spans.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_spans_ingestsources" "ingest-source" {
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_spans_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_spans_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_spans_ingestsources" "maximal-source" {
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_spans_ingestsources" "minimal-source" {
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.spans.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.spans.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/testdata/terraform/maximal-example.tf
@@ -181,12 +181,6 @@ resource "dynatrace_openpipeline_v2_spans_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -201,5 +195,4 @@ resource "dynatrace_openpipeline_v2_spans_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_spans_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.spans.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.spans.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_spans_routing" "routing" {
 resource "dynatrace_openpipeline_v2_spans_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.system.events.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.system.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,11 +2,10 @@ resource "dynatrace_openpipeline_v2_system_events_ingestsources" "ingest-source"
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_system_events_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_system_events_ingestsources" "maximal-source
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_system_events_ingestsources" "minimal-source
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.system.events.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.system.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/testdata/terraform/maximal-example.tf
@@ -1,9 +1,6 @@
 resource "dynatrace_openpipeline_v2_system_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
-  processing {
-    # processing is not available for system_events pipelines
-  }
   davis {
     processors {
       processor {
@@ -87,17 +84,4 @@ resource "dynatrace_openpipeline_v2_system_events_pipelines" "max-pipeline" {
       }
     }
   }
-  security_context {
-    # security_context is not available for system_events pipelines
-  }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
-  storage {
-    # storage is not supported for system_events pipelines
-  }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_system_events_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.system.events.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.system.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_system_events_routing" "routing" {
 resource "dynatrace_openpipeline_v2_system_events_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.user.events.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.user.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_user_events_ingestsources" "ingest-source" {
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_user_events_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_user_events_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_user_events_ingestsources" "maximal-source" 
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_user_events_ingestsources" "minimal-source" 
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.user.events.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.user.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/testdata/terraform/maximal-example.tf
@@ -1,12 +1,6 @@
 resource "dynatrace_openpipeline_v2_user_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
-  processing {
-    # processing is not available for system_events pipelines
-  }
-  davis {
-    # davis is not available for user_events pipelines
-  }
   metric_extraction {
     processors {
       processor {
@@ -95,14 +89,4 @@ resource "dynatrace_openpipeline_v2_user_events_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
-  storage {
-    # storage is not available for user_events pipelines
-  }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_user_events_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.user.events.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.user.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_user_events_routing" "routing" {
 resource "dynatrace_openpipeline_v2_user_events_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
@@ -70,6 +70,22 @@
 			],
 			"type": "enum"
 		},
+		"IngestSourceType": {
+			"description": "",
+			"displayName": "Ingest Source Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "HTTP based ingest source",
+					"value": "http"
+				},
+				{
+					"displayName": "Extension based ingest source",
+					"value": "extension"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -164,12 +180,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -186,6 +210,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -278,6 +310,11 @@
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
+			"precondition": {
+				"expectedValue": "http",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
 			"type": "text"
 		},
 		"processing": {
@@ -286,9 +323,51 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"source": {
+			"constraints": [
+				{
+					"type": "NOT_EMPTY"
+				},
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-'), dots ('.') and colons (':')",
+					"pattern": "^[:.A-Za-z0-9_\\-]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "extension",
+			"description": "",
+			"displayName": "Source",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "extension",
+				"property": "sourceType",
+				"type": "EQUALS"
+			},
+			"type": "text"
+		},
+		"sourceType": {
+			"default": "http",
+			"description": "",
+			"displayName": "Source Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/IngestSourceType"
 			}
 		},
 		"staticRouting": {
@@ -308,13 +387,18 @@
 			"flattenCollections": false,
 			"type": "UNIQUE",
 			"uniqueProperties": [
-				"pathSegment"
+				"pathSegment",
+				"source",
+				"sourceType"
 			]
 		},
 		{
 			"byteLimit": 31457280,
 			"type": "BYTE_SIZE_LIMIT"
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.ingest-sources"
 	],
 	"schemaId": "builtin:openpipeline.usersessions.ingest-sources",
 	"types": {
@@ -1054,6 +1138,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1457,6 +1557,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1471,6 +1587,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1503,6 +1635,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1667,9 +1831,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1697,6 +1861,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1724,7 +1896,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1738,12 +1909,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1814,6 +1994,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1854,6 +2263,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2166,5 +3022,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.usersessions.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type IngestSourceType string
+
+var IngestSourceTypes = struct {
+	Extension IngestSourceType
+	Http      IngestSourceType
+}{
+	"extension",
+	"http",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -74,26 +84,30 @@ var PipelineTypes = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -110,9 +124,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -18,31 +18,34 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`.
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`.
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`.
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"dimensions": {
 			Type:        schema.TypeList,
@@ -55,11 +58,11 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		"field": {
 			Type:        schema.TypeString,
 			Description: "Field with metric value",
-			Optional:    true, // nullable
+			Optional:    true, // precondition
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`.",
+			Description: "Possible Values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -69,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}
@@ -85,6 +88,16 @@ func (me *SamplingAwareValueMetricAttributes) MarshalHCL(properties hcl.Properti
 		"metric_key":    me.MetricKey,
 		"sampling":      me.Sampling,
 	})
+}
+
+func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
 }
 
 func (me *SamplingAwareValueMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/settings.go
@@ -74,7 +74,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"source_type": {
 			Type:        schema.TypeString,
 			Description: "Source Type. Possible Values: `extension`, `http`",
-			Required:    true,
+			Optional:    true,
+			Default:     "http",
 		},
 		"static_routing": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/custom-static-routing-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/custom-static-routing-example.tf
@@ -2,23 +2,14 @@ resource "dynatrace_openpipeline_v2_usersessions_ingestsources" "ingest-source" 
   enabled = true
   display_name = "ingest-source"
   path_segment = "ingestsource.path.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "custom"
     pipeline_id = dynatrace_openpipeline_v2_usersessions_pipelines.pipeline.id
-  }
-  processing {
   }
 }
 
 resource "dynatrace_openpipeline_v2_usersessions_pipelines" "pipeline" {
   display_name = "Pipeline"
   custom_id = "pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/maximal-example.tf
@@ -2,6 +2,7 @@ resource "dynatrace_openpipeline_v2_usersessions_ingestsources" "maximal-source"
   enabled = true
   display_name = "max-ingestsource"
   path_segment = "processor.ingestsource.path.max.tf.#name#"
+  source_type = "http"
   static_routing {
     pipeline_type = "builtin"
     builtin_pipeline_id = "default"

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/minimal-example.tf
@@ -2,5 +2,4 @@ resource "dynatrace_openpipeline_v2_usersessions_ingestsources" "minimal-source"
   display_name = "min-ingest-source"
   enabled = true
   path_segment = "processor.ingestsource.path.tf.min.#name#"
-  processing {}
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
@@ -158,12 +158,20 @@
 					"value": "samplingAwareValueMetric"
 				},
 				{
+					"displayName": "samplingAwareHistogramMetric",
+					"value": "samplingAwareHistogramMetric"
+				},
+				{
 					"displayName": "davis",
 					"value": "davis"
 				},
 				{
 					"displayName": "bizevent",
 					"value": "bizevent"
+				},
+				{
+					"displayName": "sdlcEvent",
+					"value": "sdlcEvent"
 				},
 				{
 					"displayName": "azureLogForwarding",
@@ -180,6 +188,14 @@
 				{
 					"displayName": "productAllocation",
 					"value": "productAllocation"
+				},
+				{
+					"displayName": "smartscapeNode",
+					"value": "smartscapeNode"
+				},
+				{
+					"displayName": "smartscapeEdge",
+					"value": "smartscapeEdge"
 				}
 			],
 			"type": "enum"
@@ -212,7 +228,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -248,7 +264,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -259,7 +275,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -290,7 +306,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -301,7 +317,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -312,7 +328,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -323,7 +339,29 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeEdgeExtraction": {
+			"description": "",
+			"displayName": "Smartscape edge extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/Stage"
+			}
+		},
+		"smartscapeNodeExtraction": {
+			"description": "",
+			"displayName": "Smartscape node extraction stage",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -334,7 +372,7 @@
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
-			"nullable": false,
+			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
 			}
@@ -353,6 +391,9 @@
 				"customId"
 			]
 		}
+	],
+	"schemaGroups": [
+		"group:openpipeline.all.pipelines"
 	],
 	"schemaId": "builtin:openpipeline.usersessions.pipelines",
 	"types": {
@@ -1092,6 +1133,22 @@
 			"displayName": "HistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				},
 				"dimensions": {
 					"description": "",
 					"displayName": "List of dimensions",
@@ -1495,6 +1552,22 @@
 						"$ref": "#/types/SamplingAwareCounterMetricAttributes"
 					}
 				},
+				"samplingAwareHistogramMetric": {
+					"description": "",
+					"displayName": "Sampling aware histogram metric processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "samplingAwareHistogramMetric",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SamplingAwareHistogramMetricAttributes"
+					}
+				},
 				"samplingAwareValueMetric": {
 					"description": "",
 					"displayName": "Sampling aware value metric processor attributes",
@@ -1509,6 +1582,22 @@
 					},
 					"type": {
 						"$ref": "#/types/SamplingAwareValueMetricAttributes"
+					}
+				},
+				"sdlcEvent": {
+					"description": "",
+					"displayName": "SdlcEvent extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "sdlcEvent",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SdlcEventAttributes"
 					}
 				},
 				"securityContext": {
@@ -1541,6 +1630,38 @@
 					},
 					"type": {
 						"$ref": "#/types/SecurityEventAttributes"
+					}
+				},
+				"smartscapeEdge": {
+					"description": "",
+					"displayName": "Smartscape edge extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeEdge",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeEdgeAttributes"
+					}
+				},
+				"smartscapeNode": {
+					"description": "",
+					"displayName": "Smartscape node extraction processor attributes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "smartscapeNode",
+						"property": "type",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/SmartscapeNodeAttributes"
 					}
 				},
 				"technology": {
@@ -1705,9 +1826,9 @@
 			"version": "0",
 			"versionInfo": ""
 		},
-		"SamplingAwareValueMetricAttributes": {
+		"SamplingAwareHistogramMetricAttributes": {
 			"description": "",
-			"displayName": "SamplingAwareValueMetricAttributes",
+			"displayName": "SamplingAwareHistogramMetricAttributes",
 			"documentation": "",
 			"properties": {
 				"aggregation": {
@@ -1735,6 +1856,14 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"dimensions": {
@@ -1762,7 +1891,6 @@
 						},
 						{
 							"maxLength": 100,
-							"minLength": 1,
 							"type": "LENGTH"
 						},
 						{
@@ -1776,12 +1904,21 @@
 							"type": "PATTERN"
 						}
 					],
+					"default": "fieldName",
 					"description": "",
 					"displayName": "Field with metric value",
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
 					"type": "text"
 				},
 				"measurement": {
@@ -1852,6 +1989,235 @@
 			"version": "0",
 			"versionInfo": ""
 		},
+		"SamplingAwareValueMetricAttributes": {
+			"description": "",
+			"displayName": "SamplingAwareValueMetricAttributes",
+			"documentation": "",
+			"properties": {
+				"aggregation": {
+					"description": "",
+					"displayName": "Aggregation",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Aggregation"
+					}
+				},
+				"defaultValue": {
+					"constraints": [
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Default value with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"dimensions": {
+					"description": "",
+					"displayName": "List of dimensions",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/FieldExtractionEntry"
+						}
+					},
+					"maxObjects": 50,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "set"
+				},
+				"field": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 100,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'span_id'",
+							"pattern": "^(?!span_id$).+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'trace_id'",
+							"pattern": "^(?!trace_id$).+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "fieldName",
+					"description": "",
+					"displayName": "Field with metric value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"precondition": {
+							"expectedValue": "duration",
+							"property": "measurement",
+							"type": "EQUALS"
+						},
+						"type": "NOT"
+					},
+					"type": "text"
+				},
+				"measurement": {
+					"default": "field",
+					"description": "",
+					"displayName": "Measurement",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/Measurement"
+					}
+				},
+				"metricKey": {
+					"constraints": [
+						{
+							"type": "NOT_EMPTY"
+						},
+						{
+							"maxLength": 250,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not start with 'dt.'",
+							"pattern": "^(?i)(?!dt\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain at least two, non-empty sections separated by a dot",
+							"pattern": "^[^.]+(\\.[^.]+?)+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must contain only basic-latin characters, numbers, underscores ('_'), hyphens ('-') and dots ('.')",
+							"pattern": "^[.A-Za-z0-9_\\-]+$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Section must not start with a hyphen",
+							"pattern": "^((?!\\.-).)+$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "events.",
+					"description": "",
+					"displayName": "Metric key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sampling": {
+					"description": "",
+					"displayName": "Sampling",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/enums/Sampling"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SdlcEventAttributes": {
+			"description": "",
+			"displayName": "SdlcEventAttributes",
+			"documentation": "",
+			"properties": {
+				"eventCategory": {
+					"description": "",
+					"displayName": "Event category",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventProvider": {
+					"description": "",
+					"displayName": "Event provider",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventStatus": {
+					"description": "",
+					"displayName": "Event status",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"eventType": {
+					"description": "",
+					"displayName": "Event type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"fieldExtraction": {
+					"description": "",
+					"displayName": "Field extraction",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/FieldExtraction"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"SecurityContextAttributes": {
 			"description": "",
 			"displayName": "SecurityContextAttributes",
@@ -1892,6 +2258,453 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeEdgeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeEdgeAttributes",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"sourceType": {
+					"constraints": [
+						{
+							"customMessage": "Source type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Source type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeFieldExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeFieldExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"fieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 32,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{fieldName} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeIdComponentsEntry": {
+			"description": "",
+			"displayName": "SmartscapeIdComponentsEntry",
+			"documentation": "",
+			"properties": {
+				"idComponent": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "ID component",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"referencedFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Referenced field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{idComponent} - {referencedFieldName}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeNodeAttributes": {
+			"description": "",
+			"displayName": "SmartscapeNodeAttributes",
+			"documentation": "",
+			"properties": {
+				"extractNode": {
+					"default": false,
+					"description": "",
+					"displayName": "Extract node",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"fieldsToExtract": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"fieldName",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "Fields to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeFieldExtractionEntry"
+						}
+					},
+					"maxObjects": 32,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				},
+				"idComponents": {
+					"constraints": [
+						{
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"idComponent",
+								"referencedFieldName"
+							]
+						}
+					],
+					"description": "",
+					"displayName": "ID components",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeIdComponentsEntry"
+						}
+					},
+					"maxObjects": 10,
+					"minObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"nodeIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"nodeName": {
+					"description": "",
+					"displayName": "Node name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/types/GenericValueAssignment"
+					}
+				},
+				"nodeType": {
+					"constraints": [
+						{
+							"customMessage": "Node type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Node type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"staticEdgesToExtract": {
+					"description": "",
+					"displayName": "Static edges to extract",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/types/SmartscapeStaticEdgeExtractionEntry"
+						}
+					},
+					"maxObjects": 16,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "extractNode",
+						"type": "EQUALS"
+					},
+					"type": "list"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SmartscapeStaticEdgeExtractionEntry": {
+			"description": "",
+			"displayName": "SmartscapeStaticEdgeExtractionEntry",
+			"documentation": "",
+			"properties": {
+				"edgeType": {
+					"constraints": [
+						{
+							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
+							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Edge type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetIdFieldName": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 264,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target ID field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"targetType": {
+					"constraints": [
+						{
+							"customMessage": "Target type must match the pattern [A-Z][A-Z0-9_]{0,249}",
+							"pattern": "^[A-Z][A-Z0-9_]{0,249}$",
+							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Target type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{edgeType} - {targetType} - {targetIdFieldName}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2143,5 +2956,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.usersessions.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/enums.go
@@ -64,26 +64,30 @@ var Measurements = struct {
 type ProcessorType string
 
 var ProcessorTypes = struct {
-	Azurelogforwarding         ProcessorType
-	Bizevent                   ProcessorType
-	Bucketassignment           ProcessorType
-	Costallocation             ProcessorType
-	Countermetric              ProcessorType
-	Davis                      ProcessorType
-	Dql                        ProcessorType
-	Drop                       ProcessorType
-	Fieldsadd                  ProcessorType
-	Fieldsremove               ProcessorType
-	Fieldsrename               ProcessorType
-	Histogrammetric            ProcessorType
-	Nostorage                  ProcessorType
-	Productallocation          ProcessorType
-	Samplingawarecountermetric ProcessorType
-	Samplingawarevaluemetric   ProcessorType
-	Securitycontext            ProcessorType
-	Securityevent              ProcessorType
-	Technology                 ProcessorType
-	Valuemetric                ProcessorType
+	Azurelogforwarding           ProcessorType
+	Bizevent                     ProcessorType
+	Bucketassignment             ProcessorType
+	Costallocation               ProcessorType
+	Countermetric                ProcessorType
+	Davis                        ProcessorType
+	Dql                          ProcessorType
+	Drop                         ProcessorType
+	Fieldsadd                    ProcessorType
+	Fieldsremove                 ProcessorType
+	Fieldsrename                 ProcessorType
+	Histogrammetric              ProcessorType
+	Nostorage                    ProcessorType
+	Productallocation            ProcessorType
+	Samplingawarecountermetric   ProcessorType
+	Samplingawarehistogrammetric ProcessorType
+	Samplingawarevaluemetric     ProcessorType
+	Sdlcevent                    ProcessorType
+	Securitycontext              ProcessorType
+	Securityevent                ProcessorType
+	Smartscapeedge               ProcessorType
+	Smartscapenode               ProcessorType
+	Technology                   ProcessorType
+	Valuemetric                  ProcessorType
 }{
 	"azureLogForwarding",
 	"bizevent",
@@ -100,9 +104,13 @@ var ProcessorTypes = struct {
 	"noStorage",
 	"productAllocation",
 	"samplingAwareCounterMetric",
+	"samplingAwareHistogramMetric",
 	"samplingAwareValueMetric",
+	"sdlcEvent",
 	"securityContext",
 	"securityEvent",
+	"smartscapeEdge",
+	"smartscapeNode",
 	"technology",
 	"valueMetric",
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`.",
+			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`.",
+			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/histogram_metric_attributes.go
@@ -23,13 +23,19 @@ import (
 )
 
 type HistogramMetricAttributes struct {
-	Dimensions FieldExtractionEntries `json:"dimensions,omitempty"` // List of dimensions
-	Field      string                 `json:"field"`                // Field with metric value
-	MetricKey  string                 `json:"metricKey"`            // Metric key
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        string                 `json:"field"`                  // Field with metric value
+	MetricKey    string                 `json:"metricKey"`              // Metric key
 }
 
 func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable
+		},
 		"dimensions": {
 			Type:        schema.TypeList,
 			Description: "List of dimensions",
@@ -53,16 +59,18 @@ func (me *HistogramMetricAttributes) Schema() map[string]*schema.Schema {
 
 func (me *HistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"dimensions": me.Dimensions,
-		"field":      me.Field,
-		"metric_key": me.MetricKey,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"metric_key":    me.MetricKey,
 	})
 }
 
 func (me *HistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"dimensions": &me.Dimensions,
-		"field":      &me.Field,
-		"metric_key": &me.MetricKey,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"metric_key":    &me.MetricKey,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/processor.go
@@ -49,30 +49,34 @@ func (me *Processors) UnmarshalHCL(decoder hcl.Decoder) error {
 
 // Processor. Processor definition
 type Processor struct {
-	AzureLogForwarding         *AzureLogForwardingAttributes         `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
-	Bizevent                   *BizeventAttributes                   `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
-	BucketAssignment           *BucketAssignmentAttributes           `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
-	CostAllocation             *CostAllocationAttributes             `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
-	CounterMetric              *CounterMetricAttributes              `json:"counterMetric,omitempty"`      // Counter metric processor attributes
-	Davis                      *DavisAttributes                      `json:"davis,omitempty"`              // Davis event extraction processor attributes
-	Description                string                                `json:"description"`
-	Dql                        *DqlAttributes                        `json:"dql,omitempty"`                        // DQL processor attributes
-	Enabled                    bool                                  `json:"enabled"`                              // This setting is enabled (`true`) or disabled (`false`)
-	FieldsAdd                  *FieldsAddAttributes                  `json:"fieldsAdd,omitempty"`                  // Fields add processor attributes
-	FieldsRemove               *FieldsRemoveAttributes               `json:"fieldsRemove,omitempty"`               // Fields remove processor attributes
-	FieldsRename               *FieldsRenameAttributes               `json:"fieldsRename,omitempty"`               // Fields rename processor attributes
-	HistogramMetric            *HistogramMetricAttributes            `json:"histogramMetric,omitempty"`            // Histogram metric processor attributes
-	ID                         string                                `json:"id"`                                   // Processor identifier
-	Matcher                    *string                               `json:"matcher,omitempty"`                    // [See our documentation](https://dt-url.net/bp234rv)
-	ProductAllocation          *ProductAllocationAttributes          `json:"productAllocation,omitempty"`          // Product allocation processor attributes
-	SampleData                 *string                               `json:"sampleData,omitempty"`                 // Sample data
-	SamplingAwareCounterMetric *SamplingAwareCounterMetricAttributes `json:"samplingAwareCounterMetric,omitempty"` // Sampling-aware counter metric processor attributes
-	SamplingAwareValueMetric   *SamplingAwareValueMetricAttributes   `json:"samplingAwareValueMetric,omitempty"`   // Sampling aware value metric processor attributes
-	SecurityContext            *SecurityContextAttributes            `json:"securityContext,omitempty"`            // Security context processor attributes
-	SecurityEvent              *SecurityEventAttributes              `json:"securityEvent,omitempty"`              // Security event extraction processor attributes
-	Technology                 *TechnologyAttributes                 `json:"technology,omitempty"`                 // Technology processor attributes
-	Type                       ProcessorType                         `json:"type"`                                 // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.
-	ValueMetric                *ValueMetricAttributes                `json:"valueMetric,omitempty"`                // Value metric processor attributes
+	AzureLogForwarding           *AzureLogForwardingAttributes           `json:"azureLogForwarding,omitempty"` // Azure log forwarding processor attributes
+	Bizevent                     *BizeventAttributes                     `json:"bizevent,omitempty"`           // Bizevent extraction processor attributes
+	BucketAssignment             *BucketAssignmentAttributes             `json:"bucketAssignment,omitempty"`   // Bucket assignment processor attributes
+	CostAllocation               *CostAllocationAttributes               `json:"costAllocation,omitempty"`     // Cost allocation processor attributes
+	CounterMetric                *CounterMetricAttributes                `json:"counterMetric,omitempty"`      // Counter metric processor attributes
+	Davis                        *DavisAttributes                        `json:"davis,omitempty"`              // Davis event extraction processor attributes
+	Description                  string                                  `json:"description"`
+	Dql                          *DqlAttributes                          `json:"dql,omitempty"`                          // DQL processor attributes
+	Enabled                      bool                                    `json:"enabled"`                                // This setting is enabled (`true`) or disabled (`false`)
+	FieldsAdd                    *FieldsAddAttributes                    `json:"fieldsAdd,omitempty"`                    // Fields add processor attributes
+	FieldsRemove                 *FieldsRemoveAttributes                 `json:"fieldsRemove,omitempty"`                 // Fields remove processor attributes
+	FieldsRename                 *FieldsRenameAttributes                 `json:"fieldsRename,omitempty"`                 // Fields rename processor attributes
+	HistogramMetric              *HistogramMetricAttributes              `json:"histogramMetric,omitempty"`              // Histogram metric processor attributes
+	ID                           string                                  `json:"id"`                                     // Processor identifier
+	Matcher                      *string                                 `json:"matcher,omitempty"`                      // [See our documentation](https://dt-url.net/bp234rv)
+	ProductAllocation            *ProductAllocationAttributes            `json:"productAllocation,omitempty"`            // Product allocation processor attributes
+	SampleData                   *string                                 `json:"sampleData,omitempty"`                   // Sample data
+	SamplingAwareCounterMetric   *SamplingAwareCounterMetricAttributes   `json:"samplingAwareCounterMetric,omitempty"`   // Sampling-aware counter metric processor attributes
+	SamplingAwareHistogramMetric *SamplingAwareHistogramMetricAttributes `json:"samplingAwareHistogramMetric,omitempty"` // Sampling aware histogram metric processor attributes
+	SamplingAwareValueMetric     *SamplingAwareValueMetricAttributes     `json:"samplingAwareValueMetric,omitempty"`     // Sampling aware value metric processor attributes
+	SdlcEvent                    *SdlcEventAttributes                    `json:"sdlcEvent,omitempty"`                    // SdlcEvent extraction processor attributes
+	SecurityContext              *SecurityContextAttributes              `json:"securityContext,omitempty"`              // Security context processor attributes
+	SecurityEvent                *SecurityEventAttributes                `json:"securityEvent,omitempty"`                // Security event extraction processor attributes
+	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
+	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
+	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
 func (me *Processor) Schema() map[string]*schema.Schema {
@@ -206,11 +210,27 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"sampling_aware_histogram_metric": {
+			Type:        schema.TypeList,
+			Description: "Sampling aware histogram metric processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SamplingAwareHistogramMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"sampling_aware_value_metric": {
 			Type:        schema.TypeList,
 			Description: "Sampling aware value metric processor attributes",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SamplingAwareValueMetricAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"sdlc_event": {
+			Type:        schema.TypeList,
+			Description: "SdlcEvent extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SdlcEventAttributes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -230,6 +250,22 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"smartscape_edge": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeEdgeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction processor attributes",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(SmartscapeNodeAttributes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"technology": {
 			Type:        schema.TypeList,
 			Description: "Technology processor attributes",
@@ -240,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareValueMetric`, `securityContext`, `securityEvent`, `technology`, `valueMetric`.",
+			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {
@@ -256,30 +292,34 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 
 func (me *Processor) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"azure_log_forwarding":          me.AzureLogForwarding,
-		"bizevent":                      me.Bizevent,
-		"bucket_assignment":             me.BucketAssignment,
-		"cost_allocation":               me.CostAllocation,
-		"counter_metric":                me.CounterMetric,
-		"davis":                         me.Davis,
-		"description":                   me.Description,
-		"dql":                           me.Dql,
-		"enabled":                       me.Enabled,
-		"fields_add":                    me.FieldsAdd,
-		"fields_remove":                 me.FieldsRemove,
-		"fields_rename":                 me.FieldsRename,
-		"histogram_metric":              me.HistogramMetric,
-		"id":                            me.ID,
-		"matcher":                       me.Matcher,
-		"product_allocation":            me.ProductAllocation,
-		"sample_data":                   me.SampleData,
-		"sampling_aware_counter_metric": me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   me.SamplingAwareValueMetric,
-		"security_context":              me.SecurityContext,
-		"security_event":                me.SecurityEvent,
-		"technology":                    me.Technology,
-		"type":                          me.Type,
-		"value_metric":                  me.ValueMetric,
+		"azure_log_forwarding":            me.AzureLogForwarding,
+		"bizevent":                        me.Bizevent,
+		"bucket_assignment":               me.BucketAssignment,
+		"cost_allocation":                 me.CostAllocation,
+		"counter_metric":                  me.CounterMetric,
+		"davis":                           me.Davis,
+		"description":                     me.Description,
+		"dql":                             me.Dql,
+		"enabled":                         me.Enabled,
+		"fields_add":                      me.FieldsAdd,
+		"fields_remove":                   me.FieldsRemove,
+		"fields_rename":                   me.FieldsRename,
+		"histogram_metric":                me.HistogramMetric,
+		"id":                              me.ID,
+		"matcher":                         me.Matcher,
+		"product_allocation":              me.ProductAllocation,
+		"sample_data":                     me.SampleData,
+		"sampling_aware_counter_metric":   me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     me.SamplingAwareValueMetric,
+		"sdlc_event":                      me.SdlcEvent,
+		"security_context":                me.SecurityContext,
+		"security_event":                  me.SecurityEvent,
+		"smartscape_edge":                 me.SmartscapeEdge,
+		"smartscape_node":                 me.SmartscapeNode,
+		"technology":                      me.Technology,
+		"type":                            me.Type,
+		"value_metric":                    me.ValueMetric,
 	})
 }
 
@@ -365,11 +405,23 @@ func (me *Processor) HandlePreconditions() error {
 	if (me.SamplingAwareCounterMetric != nil) && (string(me.Type) != "samplingAwareCounterMetric") {
 		return fmt.Errorf("'sampling_aware_counter_metric' must not be specified if 'type' is set to '%v'", me.Type)
 	}
+	if (me.SamplingAwareHistogramMetric == nil) && (string(me.Type) == "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SamplingAwareHistogramMetric != nil) && (string(me.Type) != "samplingAwareHistogramMetric") {
+		return fmt.Errorf("'sampling_aware_histogram_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
 	if (me.SamplingAwareValueMetric == nil) && (string(me.Type) == "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SamplingAwareValueMetric != nil) && (string(me.Type) != "samplingAwareValueMetric") {
 		return fmt.Errorf("'sampling_aware_value_metric' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent == nil) && (string(me.Type) == "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SdlcEvent != nil) && (string(me.Type) != "sdlcEvent") {
+		return fmt.Errorf("'sdlc_event' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.SecurityContext == nil) && (string(me.Type) == "securityContext") {
 		return fmt.Errorf("'security_context' must be specified if 'type' is set to '%v'", me.Type)
@@ -382,6 +434,18 @@ func (me *Processor) HandlePreconditions() error {
 	}
 	if (me.SecurityEvent != nil) && (string(me.Type) != "securityEvent") {
 		return fmt.Errorf("'security_event' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge == nil) && (string(me.Type) == "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeEdge != nil) && (string(me.Type) != "smartscapeEdge") {
+		return fmt.Errorf("'smartscape_edge' must not be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode == nil) && (string(me.Type) == "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.SmartscapeNode != nil) && (string(me.Type) != "smartscapeNode") {
+		return fmt.Errorf("'smartscape_node' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	if (me.Technology == nil) && (string(me.Type) == "technology") {
 		return fmt.Errorf("'technology' must be specified if 'type' is set to '%v'", me.Type)
@@ -400,29 +464,33 @@ func (me *Processor) HandlePreconditions() error {
 
 func (me *Processor) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"azure_log_forwarding":          &me.AzureLogForwarding,
-		"bizevent":                      &me.Bizevent,
-		"bucket_assignment":             &me.BucketAssignment,
-		"cost_allocation":               &me.CostAllocation,
-		"counter_metric":                &me.CounterMetric,
-		"davis":                         &me.Davis,
-		"description":                   &me.Description,
-		"dql":                           &me.Dql,
-		"enabled":                       &me.Enabled,
-		"fields_add":                    &me.FieldsAdd,
-		"fields_remove":                 &me.FieldsRemove,
-		"fields_rename":                 &me.FieldsRename,
-		"histogram_metric":              &me.HistogramMetric,
-		"id":                            &me.ID,
-		"matcher":                       &me.Matcher,
-		"product_allocation":            &me.ProductAllocation,
-		"sample_data":                   &me.SampleData,
-		"sampling_aware_counter_metric": &me.SamplingAwareCounterMetric,
-		"sampling_aware_value_metric":   &me.SamplingAwareValueMetric,
-		"security_context":              &me.SecurityContext,
-		"security_event":                &me.SecurityEvent,
-		"technology":                    &me.Technology,
-		"type":                          &me.Type,
-		"value_metric":                  &me.ValueMetric,
+		"azure_log_forwarding":            &me.AzureLogForwarding,
+		"bizevent":                        &me.Bizevent,
+		"bucket_assignment":               &me.BucketAssignment,
+		"cost_allocation":                 &me.CostAllocation,
+		"counter_metric":                  &me.CounterMetric,
+		"davis":                           &me.Davis,
+		"description":                     &me.Description,
+		"dql":                             &me.Dql,
+		"enabled":                         &me.Enabled,
+		"fields_add":                      &me.FieldsAdd,
+		"fields_remove":                   &me.FieldsRemove,
+		"fields_rename":                   &me.FieldsRename,
+		"histogram_metric":                &me.HistogramMetric,
+		"id":                              &me.ID,
+		"matcher":                         &me.Matcher,
+		"product_allocation":              &me.ProductAllocation,
+		"sample_data":                     &me.SampleData,
+		"sampling_aware_counter_metric":   &me.SamplingAwareCounterMetric,
+		"sampling_aware_histogram_metric": &me.SamplingAwareHistogramMetric,
+		"sampling_aware_value_metric":     &me.SamplingAwareValueMetric,
+		"sdlc_event":                      &me.SdlcEvent,
+		"security_context":                &me.SecurityContext,
+		"security_event":                  &me.SecurityEvent,
+		"smartscape_edge":                 &me.SmartscapeEdge,
+		"smartscape_node":                 &me.SmartscapeNode,
+		"technology":                      &me.Technology,
+		"type":                            &me.Type,
+		"value_metric":                    &me.ValueMetric,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`.
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`.
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`.",
+			Description: "Possible Values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SamplingAwareHistogramMetricAttributes struct {
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
+	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
+	Field        *string                `json:"field,omitempty"`        // Field with metric value
+	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	MetricKey    string                 `json:"metricKey"`              // Metric key
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregation": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+		"default_value": {
+			Type:        schema.TypeString,
+			Description: "Default value with metric value",
+			Optional:    true, // nullable & precondition
+		},
+		"dimensions": {
+			Type:        schema.TypeList,
+			Description: "List of dimensions",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(FieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field": {
+			Type:        schema.TypeString,
+			Description: "Field with metric value",
+			Optional:    true, // precondition
+		},
+		"measurement": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `duration`, `field`",
+			Required:    true,
+		},
+		"metric_key": {
+			Type:        schema.TypeString,
+			Description: "Metric key",
+			Required:    true,
+		},
+		"sampling": {
+			Type:        schema.TypeString,
+			Description: "Possible Values: `disabled`, `enabled`",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"aggregation":   me.Aggregation,
+		"default_value": me.DefaultValue,
+		"dimensions":    me.Dimensions,
+		"field":         me.Field,
+		"measurement":   me.Measurement,
+		"metric_key":    me.MetricKey,
+		"sampling":      me.Sampling,
+	})
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
+	if (me.Field == nil) && (string(me.Measurement) != "duration") {
+		me.Field = opt.NewString("")
+	}
+	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
+		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	}
+	return nil
+}
+
+func (me *SamplingAwareHistogramMetricAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"aggregation":   &me.Aggregation,
+		"default_value": &me.DefaultValue,
+		"dimensions":    &me.Dimensions,
+		"field":         &me.Field,
+		"measurement":   &me.Measurement,
+		"metric_key":    &me.MetricKey,
+		"sampling":      &me.Sampling,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sdlc_event_attributes.go
@@ -1,0 +1,96 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SdlcEventAttributes struct {
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
+	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+}
+
+func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"event_category": {
+			Type:        schema.TypeList,
+			Description: "Event category",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_provider": {
+			Type:        schema.TypeList,
+			Description: "Event provider",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_status": {
+			Type:        schema.TypeList,
+			Description: "Event status",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"event_type": {
+			Type:        schema.TypeList,
+			Description: "Event type",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"field_extraction": {
+			Type:        schema.TypeList,
+			Description: "Field extraction",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(FieldExtraction).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SdlcEventAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"event_category":   me.EventCategory,
+		"event_provider":   me.EventProvider,
+		"event_status":     me.EventStatus,
+		"event_type":       me.EventType,
+		"field_extraction": me.FieldExtraction,
+	})
+}
+
+func (me *SdlcEventAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"event_category":   &me.EventCategory,
+		"event_provider":   &me.EventProvider,
+		"event_status":     &me.EventStatus,
+		"event_type":       &me.EventType,
+		"field_extraction": &me.FieldExtraction,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
@@ -23,16 +23,18 @@ import (
 )
 
 type Settings struct {
-	CostAllocation    *Stage `json:"costAllocation"`    // Cost allocation stage
-	CustomID          string `json:"customId"`          // Custom pipeline id
-	DataExtraction    *Stage `json:"dataExtraction"`    // Data extraction stage
-	Davis             *Stage `json:"davis"`             // Davis event extraction stage
-	DisplayName       string `json:"displayName"`       // Display name
-	MetricExtraction  *Stage `json:"metricExtraction"`  // Metrics extraction stage
-	Processing        *Stage `json:"processing"`        // Processing stage
-	ProductAllocation *Stage `json:"productAllocation"` // Product allocation stage
-	SecurityContext   *Stage `json:"securityContext"`   // Security context stage
-	Storage           *Stage `json:"storage"`           // Storage stage
+	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string `json:"displayName"`                        // Display name
+	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -40,7 +42,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"cost_allocation": {
 			Type:        schema.TypeList,
 			Description: "Cost allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -53,7 +55,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"data_extraction": {
 			Type:        schema.TypeList,
 			Description: "Data extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -61,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"davis": {
 			Type:        schema.TypeList,
 			Description: "Davis event extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -74,7 +76,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metric_extraction": {
 			Type:        schema.TypeList,
 			Description: "Metrics extraction stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -82,7 +84,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"processing": {
 			Type:        schema.TypeList,
 			Description: "Processing stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -90,7 +92,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"product_allocation": {
 			Type:        schema.TypeList,
 			Description: "Product allocation stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -98,7 +100,23 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"security_context": {
 			Type:        schema.TypeList,
 			Description: "Security context stage",
-			Required:    true,
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_edge_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape edge extraction stage",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"smartscape_node_extraction": {
+			Type:        schema.TypeList,
+			Description: "Smartscape node extraction stage",
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -106,7 +124,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"storage": {
 			Type:        schema.TypeList,
 			Description: "Storage stage",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -116,30 +134,34 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"cost_allocation":    me.CostAllocation,
-		"custom_id":          me.CustomID,
-		"data_extraction":    me.DataExtraction,
-		"davis":              me.Davis,
-		"display_name":       me.DisplayName,
-		"metric_extraction":  me.MetricExtraction,
-		"processing":         me.Processing,
-		"product_allocation": me.ProductAllocation,
-		"security_context":   me.SecurityContext,
-		"storage":            me.Storage,
+		"cost_allocation":            me.CostAllocation,
+		"custom_id":                  me.CustomID,
+		"data_extraction":            me.DataExtraction,
+		"davis":                      me.Davis,
+		"display_name":               me.DisplayName,
+		"metric_extraction":          me.MetricExtraction,
+		"processing":                 me.Processing,
+		"product_allocation":         me.ProductAllocation,
+		"security_context":           me.SecurityContext,
+		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
+		"storage":                    me.Storage,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"cost_allocation":    &me.CostAllocation,
-		"custom_id":          &me.CustomID,
-		"data_extraction":    &me.DataExtraction,
-		"davis":              &me.Davis,
-		"display_name":       &me.DisplayName,
-		"metric_extraction":  &me.MetricExtraction,
-		"processing":         &me.Processing,
-		"product_allocation": &me.ProductAllocation,
-		"security_context":   &me.SecurityContext,
-		"storage":            &me.Storage,
+		"cost_allocation":            &me.CostAllocation,
+		"custom_id":                  &me.CustomID,
+		"data_extraction":            &me.DataExtraction,
+		"davis":                      &me.Davis,
+		"display_name":               &me.DisplayName,
+		"metric_extraction":          &me.MetricExtraction,
+		"processing":                 &me.Processing,
+		"product_allocation":         &me.ProductAllocation,
+		"security_context":           &me.SecurityContext,
+		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
+		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,
+		"storage":                    &me.Storage,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_edge_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_edge_attributes.go
@@ -1,0 +1,81 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeEdgeAttributes struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	SourceIdFieldName string `json:"sourceIdFieldName"` // Source ID field name
+	SourceType        string `json:"sourceType"`        // Source type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeEdgeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"source_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Source ID field name",
+			Required:    true,
+		},
+		"source_type": {
+			Type:        schema.TypeString,
+			Description: "Source type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeEdgeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"source_id_field_name": me.SourceIdFieldName,
+		"source_type":          me.SourceType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeEdgeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"source_id_field_name": &me.SourceIdFieldName,
+		"source_type":          &me.SourceType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_field_extraction_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeFieldExtractionEntries []*SmartscapeFieldExtractionEntry
+
+func (me *SmartscapeFieldExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_field_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeFieldExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_field_extraction_entry", me)
+}
+
+func (me *SmartscapeFieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_field_extraction_entry", me)
+}
+
+type SmartscapeFieldExtractionEntry struct {
+	FieldName           string `json:"fieldName"`           // Field name
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeFieldExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"field_name": {
+			Type:        schema.TypeString,
+			Description: "Field name",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeFieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"field_name":            me.FieldName,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeFieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"field_name":            &me.FieldName,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_id_components_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_id_components_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeIdComponentsEntries []*SmartscapeIdComponentsEntry
+
+func (me *SmartscapeIdComponentsEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeIdComponentsEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("id_component", me)
+}
+
+func (me *SmartscapeIdComponentsEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("id_component", me)
+}
+
+type SmartscapeIdComponentsEntry struct {
+	IdComponent         string `json:"idComponent"`         // ID component
+	ReferencedFieldName string `json:"referencedFieldName"` // Referenced field name
+}
+
+func (me *SmartscapeIdComponentsEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id_component": {
+			Type:        schema.TypeString,
+			Description: "ID component",
+			Required:    true,
+		},
+		"referenced_field_name": {
+			Type:        schema.TypeString,
+			Description: "Referenced field name",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeIdComponentsEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"id_component":          me.IdComponent,
+		"referenced_field_name": me.ReferencedFieldName,
+	})
+}
+
+func (me *SmartscapeIdComponentsEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"id_component":          &me.IdComponent,
+		"referenced_field_name": &me.ReferencedFieldName,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_node_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_node_attributes.go
@@ -1,0 +1,123 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeNodeAttributes struct {
+	ExtractNode          bool                                  `json:"extractNode"`                    // Extract node
+	FieldsToExtract      SmartscapeFieldExtractionEntries      `json:"fieldsToExtract,omitempty"`      // Fields to extract
+	IdComponents         SmartscapeIdComponentsEntries         `json:"idComponents"`                   // ID components
+	NodeIdFieldName      string                                `json:"nodeIdFieldName"`                // Node ID field name
+	NodeName             *GenericValueAssignment               `json:"nodeName,omitempty"`             // Node name
+	NodeType             string                                `json:"nodeType"`                       // Node type
+	StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries `json:"staticEdgesToExtract,omitempty"` // Static edges to extract
+}
+
+func (me *SmartscapeNodeAttributes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"extract_node": {
+			Type:        schema.TypeBool,
+			Description: "Extract node",
+			Required:    true,
+		},
+		"fields_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Fields to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeFieldExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"id_components": {
+			Type:        schema.TypeList,
+			Description: "ID components",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SmartscapeIdComponentsEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Node ID field name",
+			Required:    true,
+		},
+		"node_name": {
+			Type:        schema.TypeList,
+			Description: "Node name",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"node_type": {
+			Type:        schema.TypeString,
+			Description: "Node type",
+			Required:    true,
+		},
+		"static_edges_to_extract": {
+			Type:        schema.TypeList,
+			Description: "Static edges to extract",
+			Optional:    true, // precondition & minobjects == 0
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *SmartscapeNodeAttributes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"extract_node":            me.ExtractNode,
+		"fields_to_extract":       me.FieldsToExtract,
+		"id_components":           me.IdComponents,
+		"node_id_field_name":      me.NodeIdFieldName,
+		"node_name":               me.NodeName,
+		"node_type":               me.NodeType,
+		"static_edges_to_extract": me.StaticEdgesToExtract,
+	})
+}
+
+func (me *SmartscapeNodeAttributes) HandlePreconditions() error {
+	if (me.NodeName == nil) && (me.ExtractNode) {
+		return fmt.Errorf("'node_name' must be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	if (me.NodeName != nil) && (!me.ExtractNode) {
+		return fmt.Errorf("'node_name' must not be specified if 'extract_node' is set to '%v'", me.ExtractNode)
+	}
+	// ---- FieldsToExtract SmartscapeFieldExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	// ---- StaticEdgesToExtract SmartscapeStaticEdgeExtractionEntries -> {"expectedValue":true,"property":"extractNode","type":"EQUALS"}
+	return nil
+}
+
+func (me *SmartscapeNodeAttributes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"extract_node":            &me.ExtractNode,
+		"fields_to_extract":       &me.FieldsToExtract,
+		"id_components":           &me.IdComponents,
+		"node_id_field_name":      &me.NodeIdFieldName,
+		"node_name":               &me.NodeName,
+		"node_type":               &me.NodeType,
+		"static_edges_to_extract": &me.StaticEdgesToExtract,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_static_edge_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/smartscape_static_edge_extraction_entry.go
@@ -1,0 +1,87 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type SmartscapeStaticEdgeExtractionEntries []*SmartscapeStaticEdgeExtractionEntry
+
+func (me *SmartscapeStaticEdgeExtractionEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"smartscape_static_edge_extraction_entry": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(SmartscapeStaticEdgeExtractionEntry).Schema()},
+		},
+	}
+}
+
+func (me SmartscapeStaticEdgeExtractionEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("smartscape_static_edge_extraction_entry", me)
+}
+
+type SmartscapeStaticEdgeExtractionEntry struct {
+	EdgeType          string `json:"edgeType"`          // Edge type
+	TargetIdFieldName string `json:"targetIdFieldName"` // Target ID field name
+	TargetType        string `json:"targetType"`        // Target type
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"edge_type": {
+			Type:        schema.TypeString,
+			Description: "Edge type",
+			Required:    true,
+		},
+		"target_id_field_name": {
+			Type:        schema.TypeString,
+			Description: "Target ID field name",
+			Required:    true,
+		},
+		"target_type": {
+			Type:        schema.TypeString,
+			Description: "Target type",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"edge_type":            me.EdgeType,
+		"target_id_field_name": me.TargetIdFieldName,
+		"target_type":          me.TargetType,
+	})
+}
+
+func (me *SmartscapeStaticEdgeExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"edge_type":            &me.EdgeType,
+		"target_id_field_name": &me.TargetIdFieldName,
+		"target_type":          &me.TargetType,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/testdata/terraform/maximal-example.tf
@@ -181,12 +181,6 @@ resource "dynatrace_openpipeline_v2_usersessions_pipelines" "max-pipeline" {
       }
     }
   }
-  cost_allocation {
-
-  }
-  product_allocation {
-
-  }
   storage {
     processors {
       processor {
@@ -201,5 +195,4 @@ resource "dynatrace_openpipeline_v2_usersessions_pipelines" "max-pipeline" {
       }
     }
   }
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/testdata/terraform/minimal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/testdata/terraform/minimal-example.tf
@@ -1,12 +1,4 @@
 resource "dynatrace_openpipeline_v2_usersessions_pipelines" "min-pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
@@ -61,6 +61,9 @@
 			"type": "list"
 		}
 	},
+	"schemaGroups": [
+		"group:openpipeline.all.routing"
+	],
 	"schemaId": "builtin:openpipeline.usersessions.routing",
 	"types": {
 		"RoutingEntry": {
@@ -178,5 +181,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.6"
+	"version": "1.21"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.6"
+const SchemaVersion = "1.21"
 const SchemaID = "builtin:openpipeline.usersessions.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`.
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`.",
+			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/testdata/terraform/custom-pipeline-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/testdata/terraform/custom-pipeline-example.tf
@@ -13,12 +13,4 @@ resource "dynatrace_openpipeline_v2_usersessions_routing" "routing" {
 resource "dynatrace_openpipeline_v2_usersessions_pipelines" "pipeline" {
   display_name = "Minimal pipeline"
   custom_id = "pipeline_Minimal_pipeline_1234_tf_#name#"
-  processing {}
-  davis {}
-  metric_extraction {}
-  security_context {}
-  cost_allocation {}
-  product_allocation {}
-  storage {}
-  data_extraction {}
 }


### PR DESCRIPTION
#### **Why** this PR?
The OpenPipeline resuorces are outdated and need to be updated to reflect the latest changes to the schema.

#### **What** has changed?
Several types have been added. Also new property types but most of them aren't supported as it seems.
A new required property `source_type` has been added to the ingest-source resources. 

#### **How** does it do it?
By updating all the resources based on the schema

#### How is it **tested**?
Current tests still succeed and the SDLC processor was added to the log pipeline example.

#### How does it affect **users**?
They are now able to use the SDLC processor for log pipelines.

## Open for discussion
We want to set the new required `source_type` as optional with a default, right?


**Issue:** CA-16919
