### PR TITLE
fix(web-app-auto-injection): Wrong preconditions fixed

### DIFF
--- a/dynatrace/api/builtin/rum/web/automaticinjection/settings/monitoring_code_source.go
+++ b/dynatrace/api/builtin/rum/web/automaticinjection/settings/monitoring_code_source.go
@@ -52,8 +52,8 @@ func (me *MonitoringCodeSource) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *MonitoringCodeSource) HandlePreconditions() error {
-	if (me.MonitoringCodePath == nil) && (string(me.CodeSource) == "OneAgent") {
-		return fmt.Errorf("'monitoring_code_path' must be specified if 'code_source' is set to '%v'", me.CodeSource)
+	if (me.MonitoringCodePath != nil) && (string(me.CodeSource) != "OneAgent") {
+		return fmt.Errorf("'monitoring_code_path' must not be specified if 'code_source' is set to '%v'", me.CodeSource)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/rum/web/automaticinjection/settings/snippet_format.go
+++ b/dynatrace/api/builtin/rum/web/automaticinjection/settings/snippet_format.go
@@ -66,9 +66,6 @@ func (me *SnippetFormat) HandlePreconditions() error {
 	if (me.CodeSnippetType != nil) && (string(me.SnippetFormat) != "Code Snippet") {
 		return fmt.Errorf("'code_snippet_type' must not be specified if 'snippet_format' is set to '%v'", me.SnippetFormat)
 	}
-	if (me.ScriptExecutionAttribute == nil) && (slices.Contains([]string{"OneAgent JavaScript Tag", "OneAgent JavaScript Tag with SRI"}, string(me.SnippetFormat))) {
-		return fmt.Errorf("'script_execution_attribute' must be specified if 'snippet_format' is set to '%v'", me.SnippetFormat)
-	}
 	if (me.ScriptExecutionAttribute != nil) && (!slices.Contains([]string{"OneAgent JavaScript Tag", "OneAgent JavaScript Tag with SRI"}, string(me.SnippetFormat))) {
 		return fmt.Errorf("'script_execution_attribute' must not be specified if 'snippet_format' is set to '%v'", me.SnippetFormat)
 	}

--- a/dynatrace/api/builtin/rum/web/automaticinjection/testdata/terraform/example_b.tf
+++ b/dynatrace/api/builtin/rum/web/automaticinjection/testdata/terraform/example_b.tf
@@ -1,0 +1,12 @@
+resource "dynatrace_web_app_auto_injection" "#name#" {
+  application_id = "APPLICATION-1234567890000000"
+  cache_control_headers {
+    cache_control_headers = true
+  }
+  monitoring_code_source_section {
+    code_source          = "OneAgent"
+  }
+  snippet_format {
+    snippet_format    = "OneAgent JavaScript Tag"
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
Preconditions were set too strictly for the resource `dynatrace_web_app_auto_injection`.
While the API handles null value just fine for the fields
- `monitoring_code_path` in case `code_source` is set to `OneAgent`, or 
- `script_execution_attribute` in case `snippet_format` is set to `OneAgent JavaScript Tag` or `OneAgent JavaScript Tag with SRI`,

the Terraform provider complains about said null values.
The precondition handling is wrong here.

#### **What** has changed?
It is no longer mandatory to define `monitoring_code_path` if `code_source` is `OneAgent`, but it mustn't be set if `code_source` is set to something else. Also, it is no longer mandatory to define `script_execution_attribute` if `snippet_format` is `OneAgent JavaScript Tag` or `OneAgent JavaScript Tag with SRI`

#### How does it affect **users**?
Users can now set `code_source` to `OneAgent` without needing to define `monitoring_code_path` and `snippet_format` to `OneAgent Javascript Tag` or `OneAgent JavaScript Tag with SRI` without needing to define `script_execution_attribute` for the resource `dynatrace_web_app_auto_injection`.

**Issue:**
https://github.com/dynatrace-oss/terraform-provider-dynatrace/issues/866
CA-17036