### PR TITLE
fix: Classic OAuth client can be `nil` if not available

### DIFF
--- a/dynatrace/api/app/dynatrace/sitereliabilityguardian/service.go
+++ b/dynatrace/api/app/dynatrace/sitereliabilityguardian/service.go
@@ -46,7 +46,7 @@ type service struct {
 
 func (me *service) Client(ctx context.Context, schemaIDs string) *settings20.Client {
 	tokenClient, _ := rest.CreateClassicClient(me.credentials.URL, me.credentials.Token)
-	oauthClient, _ := rest.CreateClassicOAuthBasedClient(ctx, me.credentials)
+	oauthClient := rest.CreateClassicOAuthBasedClient(ctx, me.credentials)
 	return settings20.NewClient(tokenClient, oauthClient, schemaIDs)
 }
 

--- a/dynatrace/api/app/dynatrace/slackconnection/service.go
+++ b/dynatrace/api/app/dynatrace/slackconnection/service.go
@@ -42,7 +42,7 @@ type service struct {
 
 func (me *service) Client(ctx context.Context, schemaIDs string) *settings20.Client {
 	tokenClient, _ := rest.CreateClassicClient(me.credentials.URL, me.credentials.Token)
-	oauthClient, _ := rest.CreateClassicOAuthBasedClient(ctx, me.credentials)
+	oauthClient := rest.CreateClassicOAuthBasedClient(ctx, me.credentials)
 	return settings20.NewClient(tokenClient, oauthClient, schemaIDs)
 }
 

--- a/dynatrace/api/builtin/davis/anomalydetectors/service.go
+++ b/dynatrace/api/builtin/davis/anomalydetectors/service.go
@@ -42,7 +42,7 @@ type service struct {
 
 func (me *service) Client(ctx context.Context, schemaIDs string) *settings20.Client {
 	tokenClient, _ := rest.CreateClassicClient(me.credentials.URL, me.credentials.Token)
-	oauthClient, _ := rest.CreateClassicOAuthBasedClient(ctx, me.credentials)
+	oauthClient := rest.CreateClassicOAuthBasedClient(ctx, me.credentials)
 	return settings20.NewClient(tokenClient, oauthClient, schemaIDs)
 }
 

--- a/dynatrace/api/builtin/generic/service.go
+++ b/dynatrace/api/builtin/generic/service.go
@@ -43,7 +43,7 @@ type service struct {
 
 func (me *service) Client(ctx context.Context, schemaIDs string) *settings20.Client {
 	tokenClient, _ := rest.CreateClassicClient(me.credentials.URL, me.credentials.Token)
-	oauthClient, _ := rest.CreateClassicOAuthBasedClient(ctx, me.credentials)
+	oauthClient := rest.CreateClassicOAuthBasedClient(ctx, me.credentials)
 	return settings20.NewClient(tokenClient, oauthClient, schemaIDs)
 }
 

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -109,11 +109,15 @@ var classicClientCache = map[string]*rest.Client{}
 
 var classicClientCacheMutex sync.Mutex
 
-func CreateClassicOAuthBasedClient(ctx context.Context, credentials *Credentials) (*rest.Client, error) {
+func CreateClassicOAuthBasedClient(ctx context.Context, credentials *Credentials) *rest.Client {
 	var parsedURL *url.URL
 	parsedURL, err := url.Parse(credentials.URL)
 	if err != nil {
-		return nil, err
+		return nil
+	}
+
+	if credentials.OAuth.ClientID == "" || credentials.OAuth.ClientSecret == "" {
+		return nil
 	}
 
 	logging.InstallRoundTripper()
@@ -131,8 +135,7 @@ func CreateClassicOAuthBasedClient(ctx context.Context, credentials *Credentials
 	)
 
 	oauthClient.SetHeader("User-Agent", version.UserAgent())
-	oauthClient.SetHeader("Authorization", "Api-Token "+credentials.Token)
-	return oauthClient, nil
+	return oauthClient
 }
 
 func CreateClassicClient(classicURL string, apiToken string) (*rest.Client, error) {

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -131,7 +131,7 @@ func CreateClassicOAuthBasedClient(ctx context.Context, credentials *Credentials
 				ClientSecret: credentials.OAuth.ClientSecret,
 				TokenURL:     credentials.OAuth.TokenURL,
 				AuthStyle:    oauth2.AuthStyleInParams}),
-		crest.WithHTTPListener(logging.HTTPListener("classic ")),
+		crest.WithHTTPListener(logging.HTTPListener("platform")),
 	)
 
 	oauthClient.SetHeader("User-Agent", version.UserAgent())
@@ -155,7 +155,7 @@ func CreateClassicClient(classicURL string, apiToken string) (*rest.Client, erro
 	factory = factory.WithUserAgent(version.UserAgent())
 	factory = factory.WithClassicURL(classicURL)
 	factory = factory.WithAccessToken(apiToken)
-	factory = factory.WithHTTPListener(logging.HTTPListener("classic "))
+	factory = factory.WithHTTPListener(logging.HTTPListener("classic"))
 
 	client, err := factory.CreateClassicClient()
 	if err != nil {


### PR DESCRIPTION
#### **Why** this PR?
The implementations of `dynatrace_davis_anomaly_detectors`, `dynatrace_generic_setting`, `dynatrace_site_reliability_guardian`, and `dynatrace_automation_workflow_slack` resources create a settings client that always has an OAuth client regardless of whether credentials are available or not.

This OAuth client doesn't work. For settings resources that must use OAuth, in this case `dynatrace_davis_anomaly_detectors`, this implementation leads to the original error message being discarded and more confusing error mentioning OAuth:

```
module.davis_anomaly_detectors.dynatrace_davis_anomaly_detectors.Potential_log_data_anomaly: Creating...
╷
│ Error: failed to create object: Post "https://....dynatrace.com/api/v2/settings/objects?repairInput=true": oauth2: cannot fetch token: 400 Bad Request
│ Response: {"errorCode":400,"message":"Bad Request","issueId":"..."}
│ 
``` 

Note: the exact error message depends on which operation is being performed (in this instance create).

With the fix in this PR, no OAuth client is created if no credentials are specified, and so the following is returned:

```
module.davis_anomaly_detectors.dynatrace_davis_anomaly_detectors.Potential_log_data_anomaly: Creating...
╷
│ Error: Could not do validation as request was not done using oAuth.
```

#### **What** has changed and **how** does it do it?
- `CreateClassicOAuthBasedClient()` now returns `nil` if no OAuth client ID or secret is available. By returning `nil` in this situation, the function no longer returns a client that has an API token set. This is OK because in all instances where this client is used, an explicit client with API token set is created and used first. The function also no longer returns an error as this was always dropped.
-  Improves error handling in `CreateClassicClient()`. The `classicClientCache` is not read if a URL is not specified. The cache is also not written to if the client could not be created.

#### How is it **tested**?
NA

#### How does it affect **users**?
Users will see the correct error

**Issue:** CA-17061
