### PR TITLE
fix: Forward all environment variables when executing terraform during export

### DIFF
--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -1148,7 +1148,6 @@ func genApplyCmd() *exec.Cmd {
 }
 
 func (me *Environment) executeTF(cmd *exec.Cmd) (err error) {
-
 	var outb, errb bytes.Buffer
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb
@@ -1157,16 +1156,16 @@ func (me *Environment) executeTF(cmd *exec.Cmd) (err error) {
 	if cacheFolder, err = filepath.Abs(cache.GetCacheFolder()); err != nil {
 		return err
 	}
-	cmd.Env = []string{
-		// "TF_LOG_PROVIDER=INFO",
-		"DYNATRACE_ENV_URL=" + me.Credentials.URL,
-		"DYNATRACE_API_TOKEN=" + me.Credentials.Token,
-		"DT_CACHE_FOLDER=" + cacheFolder,
+
+	// pass all existing environment variables but set or overwrite some specifc ones when executing terraform commands
+	cmd.Env = append(os.Environ(),
+		"DT_CACHE_FOLDER="+cacheFolder,
 		"CACHE_OFFLINE_MODE=true",
 		"DT_CACHE_DELETE_ON_LAUNCH=false",
 		"DT_NO_CACHE_CLEANUP=true",
 		"DT_TERRAFORM_IMPORT=true",
-	}
+	)
+
 	cmd.Start()
 	if err := cmd.Wait(); err != nil {
 		fmt.Println("out:", outb.String())


### PR DESCRIPTION
#### **Why** this PR?
Currently importing state as part of an export doesn't work if the export contains resources that need an OAuth or platform token client because the credentials are not forwarded when `terraform` is called

#### **What** has changed?
With this PR, all environment variables are forwarded when executing `terraform`.

#### **How** does it do it?
Similar to how it is done for `terraform init` [here](https://github.com/dynatrace-oss/terraform-provider-dynatrace/blob/95a0c90531aec791e576f3dea8577a2a10ff1bc5/dynatrace/export/environment.go#L1222), environment variables are retrieved and then specific ones are added. Note: According to the documentation of `(exec.Cmd).Env`, these values will overwrite any existing values for these keys if they're already present.

#### How is it **tested**?
NA

#### How does it affect **users**?
The `terraform plan` and `terraform apply` executed as part of an export will now work for resources using OAuth or platform tokens as the credentials will be forwarded. 

**Issue:** CA-17047
