### PR TITLE
feat: Improve default value of `version.Version` for development

### DIFF
--- a/provider/version/version.go
+++ b/provider/version/version.go
@@ -24,7 +24,8 @@ import "fmt"
 var (
 	// Version is a string representing the current version of the Dynatrace Terraform provider.
 	// This should be in `major.minor.patch` format, with prereleases having an optional suffix introduced by a dash, for example, `1.2.0-beta`.
-	Version = "(unknown-version)"
+	// The value ~>1.0 should allow the latest 1.x version during development.
+	Version = "~>1.0"
 
 	// OperatingSystem is a string representing the operating system the provider was built for.
 	OperatingSystem = "(unknown-os)"


### PR DESCRIPTION
#### **Why** this PR?
This PR removes the need to set the version in code every time before running an export when developing the provider.

#### **What** has changed and **How** does it do it?
`version.Version` is set to `~>1.0`, allowing any `1.x` version of the provider.

#### How is it **tested**?
Manual testing indicates that the latest version of the provider will be downloaded with this version string, e.g. during an export.

#### How does it affect **users**?
No effect. `version.Version` is overwritten with the actual version of the provider during the release process.

**Issue:** NA
