### PR TITLE
chore: limit most classic-environment calls to apiToken only

### DIFF
--- a/dynatrace/api/builtin/host/monitoring/mode/service.go
+++ b/dynatrace/api/builtin/host/monitoring/mode/service.go
@@ -44,7 +44,7 @@ func Service(credentials *rest.Credentials) settings.CRUDService[*mode.Settings]
 	return &service{
 		service:     settings20.Service[*mode.Settings](credentials, SchemaID, SchemaVersion),
 		credentials: credentials,
-		client:      rest.HybridClient(credentials),
+		client:      rest.APITokenClient(credentials),
 	}
 }
 

--- a/dynatrace/api/builtin/monitoring/slo/service.go
+++ b/dynatrace/api/builtin/monitoring/slo/service.go
@@ -175,7 +175,7 @@ func (me *service) get(ctx context.Context, id string, v *slo.Settings) error {
 
 	slo := new(sloGet)
 
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(legacyId)), 200)
 	if err := req.Finish(slo); err != nil {
 		return err

--- a/dynatrace/api/v1/config/customtags/service.go
+++ b/dynatrace/api/v1/config/customtags/service.go
@@ -46,7 +46,7 @@ type service struct {
 var entityIdSelectorRegexp = regexp.MustCompile("entityId\\((.*)\\)")
 
 func (me *service) Get(ctx context.Context, selector string, v *customtags.Settings) (err error) {
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if err = client.Get(ctx, fmt.Sprintf("/api/v2/tags?entitySelector=%s&from=now-3y&to=now", url.QueryEscape(selector)), 200).Finish(v); err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (me *service) SchemaID() string {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	return list.List(ctx, rest.HybridClient(me.credentials))
+	return list.List(ctx, rest.APITokenClient(me.credentials))
 }
 
 func (me *service) Validate(ctx context.Context, v *customtags.Settings) error {
@@ -90,7 +90,7 @@ func (me *service) Update(ctx context.Context, id string, v *customtags.Settings
 	var err error
 
 	var settingsObj customtags.Settings
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if err = client.Post(ctx, fmt.Sprintf("/api/v2/tags?entitySelector=%s&from=now-3y&to=now", url.QueryEscape(v.EntitySelector)), v, 200).Finish(&settingsObj); err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (me *service) Delete(ctx context.Context, id string) error {
 }
 
 func (me *service) DeleteValue(ctx context.Context, v *customtags.Settings) error {
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	for _, tag := range v.Tags {
 		if tag.Value == nil || len(*tag.Value) == 0 {
 			if err := client.Delete(ctx, fmt.Sprintf("/api/v2/tags?key=%s&entitySelector=%s", url.QueryEscape(tag.Key), url.QueryEscape(v.EntitySelector)), 200).Finish(); err != nil {

--- a/dynatrace/api/v1/config/deployment/lambdaagent/service.go
+++ b/dynatrace/api/v1/config/deployment/lambdaagent/service.go
@@ -30,7 +30,7 @@ const SchemaID = "v1:deployment:lambdaagent"
 const BasePath = "/api/v1/deployment/lambda/agent/latest"
 
 func Service(credentials *rest.Credentials) settings.RService[*lambdaagent.Latest] {
-	return &service{client: rest.HybridClient(credentials)}
+	return &service{client: rest.APITokenClient(credentials)}
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/service.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/service.go
@@ -30,7 +30,7 @@ import (
 const SchemaID = "v1:synthetic:monitors:browser"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*browser.SyntheticMonitor] {
-	return settings.NewHybridService(credentials, SchemaID, &settings.ServiceOptions[*browser.SyntheticMonitor]{
+	return settings.NewAPITokenService(credentials, SchemaID, &settings.ServiceOptions[*browser.SyntheticMonitor]{
 		Get:            settings.Path("/api/v1/synthetic/monitors/%s"),
 		List:           settings.Path("/api/v1/synthetic/monitors?type=BROWSER"),
 		CreateURL:      func(v *browser.SyntheticMonitor) string { return "/api/v1/synthetic/monitors" },

--- a/dynatrace/api/v1/config/synthetic/monitors/http/script/service.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/script/service.go
@@ -33,7 +33,7 @@ const SchemaID = "v1:synthetic:monitors:http:script"
 const BasePath = "/api/v1/synthetic/monitors"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*script.Settings] {
-	return &service{scriptService: settings.NewHybridService(credentials, SchemaID, settings.DefaultServiceOptions[*script.Settings](http.BasePath)), httpService: http.Service(credentials)}
+	return &service{scriptService: settings.NewAPITokenService(credentials, SchemaID, settings.DefaultServiceOptions[*script.Settings](http.BasePath)), httpService: http.Service(credentials)}
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/synthetic/monitors/http/service.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service.go
@@ -33,7 +33,7 @@ const SchemaID = "v1:synthetic:monitors:http"
 const BasePath = "/api/v1/synthetic/monitors"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*http.SyntheticMonitor] {
-	return &service{service: settings.NewHybridService(credentials, SchemaID, &settings.ServiceOptions[*http.SyntheticMonitor]{
+	return &service{service: settings.NewAPITokenService(credentials, SchemaID, &settings.ServiceOptions[*http.SyntheticMonitor]{
 		Get:            settings.Path("/api/v1/synthetic/monitors/%s"),
 		List:           settings.Path("/api/v1/synthetic/monitors?type=HTTP"),
 		CreateURL:      func(v *http.SyntheticMonitor) string { return "/api/v1/synthetic/monitors" },

--- a/dynatrace/api/v1/config/synthetic/nodes/service.go
+++ b/dynatrace/api/v1/config/synthetic/nodes/service.go
@@ -31,7 +31,7 @@ import (
 const SchemaID = "v1:synthetic:nodes:all"
 
 func Service(credentials *rest.Credentials) settings.RService[*nodes.Settings] {
-	return &service{client: rest.HybridClient(credentials)}
+	return &service{client: rest.APITokenClient(credentials)}
 }
 
 type service struct {

--- a/dynatrace/api/v2/activegatetokens/service.go
+++ b/dynatrace/api/v2/activegatetokens/service.go
@@ -50,7 +50,7 @@ type service struct {
 func (me *service) Get(ctx context.Context, id string, v *activegatetokens.Settings) error {
 	var err error
 
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/activeGateTokens/%s", url.PathEscape(id))).Expect(200)
 	if err = req.Finish(v); err != nil {
 		return err
@@ -80,7 +80,7 @@ func (me *service) Create(ctx context.Context, v *activegatetokens.Settings) (*a
 	var err error
 
 	response := TokenCreateResponse{}
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if err = client.Post(ctx, "/api/v2/activeGateTokens", v, 201).Finish(&response); err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (me *service) Update(ctx context.Context, id string, v *activegatetokens.Se
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return rest.HybridClient(me.credentials).Delete(ctx, fmt.Sprintf("/api/v2/activeGateTokens/%s", url.PathEscape(id)), 204).Finish()
+	return rest.APITokenClient(me.credentials).Delete(ctx, fmt.Sprintf("/api/v2/activeGateTokens/%s", url.PathEscape(id)), 204).Finish()
 }
 
 func (me *service) New() *activegatetokens.Settings {

--- a/dynatrace/api/v2/apitokens/service.go
+++ b/dynatrace/api/v2/apitokens/service.go
@@ -41,7 +41,7 @@ type service struct {
 func (me *service) Get(ctx context.Context, id string, v *apitokens.APIToken) error {
 	var err error
 
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id)).Expect(200)
 	if err = req.Finish(v); err != nil {
 		return err
@@ -57,7 +57,7 @@ func (me *service) SchemaID() string {
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	req := client.Get(ctx, "/api/v2/apiTokens?pageSize=10000&fields=%2Bscopes%2C%2BexpirationDate%2C%2BpersonalAccessToken&sort=-creationDate").Expect(200)
 	var tokenlist apitokens.TokenList
 	if err = req.Finish(&tokenlist); err != nil {
@@ -79,7 +79,7 @@ func (me *service) Create(ctx context.Context, v *apitokens.APIToken) (*api.Stub
 	var err error
 
 	resultToken := apitokens.APIToken{}
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if err = client.Post(ctx, "/api/v2/apiTokens", v, 201).Finish(&resultToken); err != nil {
 		return nil, err
 	}
@@ -98,11 +98,11 @@ func (me *service) Create(ctx context.Context, v *apitokens.APIToken) (*api.Stub
 }
 
 func (me *service) Update(ctx context.Context, id string, v *apitokens.APIToken) error {
-	return rest.HybridClient(me.credentials).Put(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id), v, 204).Finish()
+	return rest.APITokenClient(me.credentials).Put(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id), v, 204).Finish()
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return rest.HybridClient(me.credentials).Delete(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id), 204).Finish()
+	return rest.APITokenClient(me.credentials).Delete(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id), 204).Finish()
 }
 
 func (me *service) New() *apitokens.APIToken {

--- a/dynatrace/api/v2/credentials/vault/service.go
+++ b/dynatrace/api/v2/credentials/vault/service.go
@@ -36,7 +36,7 @@ var mu sync.Mutex
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*vault.Credentials] {
 	return &service{
-		service: settings.NewHybridService(
+		service: settings.NewAPITokenService(
 			credentials,
 			SchemaID,
 			settings.DefaultServiceOptions[*vault.Credentials](BasePath).

--- a/dynatrace/api/v2/customdevice/service.go
+++ b/dynatrace/api/v2/customdevice/service.go
@@ -53,7 +53,7 @@ func (me *service) Get(ctx context.Context, id string, v *customdevice.CustomDev
 	stateConfig, stateConfigFound := cfg.(*customdevice.CustomDevice)
 
 	var err error
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	entitySelector := `detectedName("` + id + `"),type("CUSTOM_DEVICE")`
 	var CustomDeviceGetResponse customdevice.CustomDeviceGetResponse
 
@@ -136,7 +136,7 @@ func (me *service) Get(ctx context.Context, id string, v *customdevice.CustomDev
 
 func (me *service) CheckGet(ctx context.Context, id string, v *customdevice.CustomDevice) error {
 	var err error
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	entitySelector := `detectedName("` + id + `"),type("CUSTOM_DEVICE")`
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/entities?from=now-3y&entitySelector=%s&fields=properties", url.QueryEscape(entitySelector))).Expect(200)
 	var CustomDeviceGetResponse customdevice.CustomDeviceGetResponse
@@ -183,7 +183,7 @@ type lresponse struct {
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var err error
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	entitySelector := `type("CUSTOM_DEVICE")`
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/entities?from=now-3y&entitySelector=%s&fields=properties,fromRelationships&pageSize=500", url.QueryEscape(entitySelector))).Expect(200)
 	listResponse := lresponse{}
@@ -231,7 +231,7 @@ func (me *service) Create(ctx context.Context, v *customdevice.CustomDevice) (*a
 	if v.CustomDeviceID == "" {
 		v.CustomDeviceID = uuid.NewString()
 	}
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	uiBasedQuery := ""
 	if v.UIBased != nil && *v.UIBased {
 		uiBasedQuery = "?uiBased=true"
@@ -269,7 +269,7 @@ func (me *service) Update(ctx context.Context, id string, v *customdevice.Custom
 	var err error
 	v.CustomDeviceID = id
 	v.EntityId = ""
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if err = client.Post(ctx, "/api/v2/entities/custom", v, 201, 204).Finish(); err != nil {
 		return err
 	}

--- a/dynatrace/api/v2/entities/service.go
+++ b/dynatrace/api/v2/entities/service.go
@@ -34,7 +34,7 @@ import (
 const SchemaID = "v2:environment:entities"
 
 func Service(entityType string, entityName string, entitySelector string, from string, to string, credentials *rest.Credentials) settings.RService[*entities.Settings] {
-	return &service{entityType: entityType, entityName: entityName, entitySelector: entitySelector, from: from, to: to, client: rest.HybridClient(credentials)}
+	return &service{entityType: entityType, entityName: entityName, entitySelector: entitySelector, from: from, to: to, client: rest.APITokenClient(credentials)}
 }
 
 type service struct {

--- a/dynatrace/api/v2/entity/service.go
+++ b/dynatrace/api/v2/entity/service.go
@@ -35,7 +35,7 @@ import (
 const SchemaID = "v2:environment:entity"
 
 func Service(credentials *rest.Credentials) settings.RService[*entity.Entity] {
-	return &service{client: rest.HybridClient(credentials)}
+	return &service{client: rest.APITokenClient(credentials)}
 }
 
 type service struct {
@@ -55,7 +55,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func DataSourceService(credentials *rest.Credentials) settings.RService[*entity.Entity] {
-	return &dataSourceService{client: rest.HybridClient(credentials)}
+	return &dataSourceService{client: rest.APITokenClient(credentials)}
 }
 
 type dataSourceService struct {

--- a/dynatrace/api/v2/hub/extension/active_version/service.go
+++ b/dynatrace/api/v2/hub/extension/active_version/service.go
@@ -41,7 +41,7 @@ type service struct {
 
 func (me *service) Get(ctx context.Context, id string, v *active_version.Settings) error {
 	var response GetActiveEnvironmentConfigurationResponse
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if err := client.Get(ctx, fmt.Sprintf("/api/v2/extensions/%s/environmentConfiguration", url.PathEscape(id)), 200).Finish(&response); err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (me *service) Create(ctx context.Context, v *active_version.Settings) (*api
 	if err := me.ensureInstalled(ctx, name, version); err != nil {
 		return nil, err
 	}
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	createResponse := SetActiveEnvironmentConfigurationResponse{}
 	retry := 10
 	for retry > 0 {
@@ -91,7 +91,7 @@ func (me *service) Create(ctx context.Context, v *active_version.Settings) (*api
 }
 
 func (me *service) ensureInstalled(ctx context.Context, name string, version string) error {
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	response := struct {
 		Name    string `json:"extensionName"`
 		Version string `json:"extensionVersion"`

--- a/dynatrace/api/v2/hub/extension/config/service.go
+++ b/dynatrace/api/v2/hub/extension/config/service.go
@@ -79,7 +79,7 @@ func (me *service) Get(ctx context.Context, id string, v *extension_config.Setti
 	name, configurationID := splitID(id)
 
 	var response GetMonitoringConfigurationResponse
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 
 	urlPath := fmt.Sprintf(
 		"/api/v2/extensions/%s/monitoringConfigurations/%s",
@@ -125,7 +125,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var stubs api.Stubs
 
 	var extensionsList ExtensionsList
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 
 	nextPageKey := "first"
 	for len(nextPageKey) > 0 {
@@ -173,7 +173,7 @@ func (me *service) Create(ctx context.Context, v *extension_config.Settings) (*a
 	if err := me.ensureInstalled(ctx, name, version); err != nil {
 		return nil, err
 	}
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	createResponse := []CreateMonitoringConfigResponse{}
 	retry := 10
 	for retry > 0 {
@@ -196,7 +196,7 @@ func (me *service) Create(ctx context.Context, v *extension_config.Settings) (*a
 }
 
 func (me *service) ensureInstalled(ctx context.Context, name string, version string) error {
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if strings.HasPrefix(name, "custom:") {
 		request := client.Get(ctx, fmt.Sprintf("/api/v2/extensions/%s/%s", url.PathEscape(name), url.QueryEscape(version)), 200)
 		request.SetHeader("Accept", "application/json; charset=utf-8")
@@ -229,7 +229,7 @@ func (me *service) Update(ctx context.Context, id string, v *extension_config.Se
 	if err := me.ensureInstalled(ctx, name, version); err != nil {
 		return err
 	}
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	createResponse := CreateMonitoringConfigResponse{}
 	payload := MonitoringConfigCreateDto{Value: []byte(v.Value)}
 	if err := client.Put(ctx, fmt.Sprintf("/api/v2/extensions/%s/monitoringConfigurations/%s", url.PathEscape(name), url.PathEscape(configID)), &payload, 200).Finish(&createResponse); err != nil {
@@ -243,7 +243,7 @@ func (me *service) Update(ctx context.Context, id string, v *extension_config.Se
 
 func (me *service) Delete(ctx context.Context, id string) error {
 	name, configID := splitID(id)
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if err := client.Delete(ctx, fmt.Sprintf("/api/v2/extensions/%s/monitoringConfigurations/%s", url.PathEscape(name), url.PathEscape(configID)), 200).Finish(nil); err != nil {
 		// Potential response when the configuration contains
 		//    import {

--- a/dynatrace/api/v2/networkzones/service.go
+++ b/dynatrace/api/v2/networkzones/service.go
@@ -36,7 +36,7 @@ import (
 const SchemaID = "v2:environment:network-zones"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*networkzones.NetworkZone] {
-	return &service{client: rest.HybridClient(credentials), credentials: credentials}
+	return &service{client: rest.APITokenClient(credentials), credentials: credentials}
 }
 
 type service struct {

--- a/dynatrace/api/v2/slo/service.go
+++ b/dynatrace/api/v2/slo/service.go
@@ -56,7 +56,7 @@ func (me *service) Get(ctx context.Context, id string, v *slo.SLO) error {
 func (me *service) get(ctx context.Context, id string, v *slo.SLO) error {
 	var err error
 
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/slo/%s?evaluate=false", url.PathEscape(id)), 200)
 	if err = req.Finish(v); err != nil {
 		return err
@@ -83,7 +83,7 @@ type sloListEntry struct {
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	req := client.Get(ctx, "/api/v2/slo?pageSize=4000&sort=name&timeFrame=CURRENT&pageIdx=1&demo=false&evaluate=false", 200)
 	var slos sloList
 	if err = req.Finish(&slos); err != nil {
@@ -109,7 +109,7 @@ func (me *service) Create(ctx context.Context, v *slo.SLO) (*api.Stub, error) {
 
 	var id string
 
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	req := client.Post(ctx, "/api/v2/slo", v, 201).OnResponse(func(resp *http.Response) {
 		if resp == nil {
 			return
@@ -190,11 +190,11 @@ func (me *service) Create(ctx context.Context, v *slo.SLO) (*api.Stub, error) {
 }
 
 func (me *service) Update(ctx context.Context, id string, v *slo.SLO) error {
-	return rest.HybridClient(me.credentials).Put(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(id)), v, 200).Finish()
+	return rest.APITokenClient(me.credentials).Put(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(id)), v, 200).Finish()
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return rest.HybridClient(me.credentials).Delete(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(id)), 204).Finish()
+	return rest.APITokenClient(me.credentials).Delete(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(id)), 204).Finish()
 }
 
 func (me *service) New() *slo.SLO {

--- a/dynatrace/api/v2/synthetic/monitors/service.go
+++ b/dynatrace/api/v2/synthetic/monitors/service.go
@@ -49,7 +49,7 @@ func (me *service) Create(ctx context.Context, v *monitors.Settings) (*api.Stub,
 	resp := struct {
 		EntityId string `json:"entityId"`
 	}{}
-	client := rest.HybridClient(me.credentials)
+	client := rest.APITokenClient(me.credentials)
 	if err = client.Post(ctx, BasePath, v, 201).Finish(&resp); err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (me *service) Create(ctx context.Context, v *monitors.Settings) (*api.Stub,
 }
 
 func (me *service) Get(ctx context.Context, id string, v *monitors.Settings) error {
-	if err := rest.HybridClient(me.credentials).Get(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), 200).Finish(v); err != nil {
+	if err := rest.APITokenClient(me.credentials).Get(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), 200).Finish(v); err != nil {
 		return err
 	}
 
@@ -113,7 +113,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 	var monitors monitorList
 
-	if err = rest.HybridClient(me.credentials).Get(ctx, BasePath, 200).Finish(&monitors); err != nil {
+	if err = rest.APITokenClient(me.credentials).Get(ctx, BasePath, 200).Finish(&monitors); err != nil {
 		return nil, err
 	}
 	stubs := api.Stubs{}
@@ -128,11 +128,11 @@ func (me *service) Validate(v *monitors.Settings) error {
 }
 
 func (me *service) Update(ctx context.Context, id string, v *monitors.Settings) error {
-	return rest.HybridClient(me.credentials).Put(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), v, 200).Finish()
+	return rest.APITokenClient(me.credentials).Put(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), v, 200).Finish()
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return rest.HybridClient(me.credentials).Delete(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), 204).Finish()
+	return rest.APITokenClient(me.credentials).Delete(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), 204).Finish()
 }
 
 func (me *service) New() *monitors.Settings {

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -19,22 +19,8 @@ import (
 )
 
 var eligiblePlatformRequests = map[string]string{
-	"/api/v2/settings/objects":   "/platform/classic/environment-api/v2/settings/objects",
-	"/api/v2/settings/schemas":   "/platform/classic/environment-api/v2/settings/schemas",
-	"/api/v2/networkZones":       "/platform/classic/environment-api/v2/networkZones",
-	"/api/v2/entities":           "/platform/classic/environment-api/v2/entities",
-	"/api/v2/entityTypes":        "/platform/classic/environment-api/v2/entityTypes",
-	"/api/v2/tags":               "/platform/classic/environment-api/v2/tags",
-	"/api/v2/slo":                "/platform/classic/environment-api/v2/slo",
-	"/api/v2/extensions":         "/platform/classic/environment-api/v2/extensions",
-	"/api/v2/apiTokens":          "/platform/classic/environment-api/v2/apiTokens",
-	"/api/v2/credentials":        "/platform/classic/environment-api/v2/credentials",
-	"/api/v2/synthetic/monitors": "/platform/classic/environment-api/v2/synthetic/monitors",
-	"/api/v2/activeGateTokens":   "/platform/classic/environment-api/v2/activeGateTokens",
-
-	"/api/v1/synthetic/monitors": "/platform/classic/environment-api/v1/synthetic/monitors",
-	"/api/v1/deployment":         "/platform/classic/environment-api/v1/deployment",
-	"/api/v1/synthetic/nodes":    "/platform/classic/environment-api/v1/synthetic/nodes",
+	"/api/v2/settings/objects": "/platform/classic/environment-api/v2/settings/objects",
+	"/api/v2/settings/schemas": "/platform/classic/environment-api/v2/settings/schemas",
 }
 
 type platform_request request


### PR DESCRIPTION
#### **Why** this PR?
The OAuth permission `environment-api:*` is not available anymore. Therefore, it doesn't make sense that some resources that rely on this one make OAuth requests

#### **What** has changed?
Affected classic environment resources are now API token-only instead of API token and OAuth.

#### **How** does it do it?
By replacing HybridClients with ApiTokenClients

#### How is it **tested**?
Current tests are sufficient.

#### How does it affect **users**?
They have to use API tokens instead or in addition to OAuth for the following resources:
- `dynatrace_host_monitoring_mode` (uses OAuth and API tokens)
- `dynatrace_slo`
- `dynatrace_slo_v2` (uses OAuth and API tokens)
- `dynatrace_custom_tags`
- `dynatrace_browser_monitor`
- `dynatrace_http_monitor_script`
- `dynatrace_http_monitor`
- `dynatrace_ag_token`
- `dynatrace_api_token`
- `dynatrace_credentials`
- `dynatrace_custom_device`
- `dynatrace_key_requests` (uses OAuth and API tokens)
- `dynatrace_hub_extension_active_version`
- `dynatrace_hub_extension_config`
- `dynatrace_network_zone`
- `dynatrace_network_monitor`

Regarding `uses OAuth and API tokens`: There are some resources that combine multiple requests. For example, `dynatrace_host_monitoring_mode` calls the entities endpoint and settings `builtin:host.monitoring.mode`. In this case OAuth is preferred for the request if the env `DYNATRACE_HTTP_OAUTH_PREFERENCE` is set to `true`.

and the following data sources:
- `dynatrace_lambda_agent_version`
- `dynatrace_synthetic_nodes`
- `dynatrace_entities`
- `dynatrace_entity`

**Issue:** CA-17080
