### PR TITLE
fix: Improve error message on Read

### DIFF
--- a/dynatrace/api/api_error.go
+++ b/dynatrace/api/api_error.go
@@ -1,0 +1,40 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package api
+
+// APIError wraps lower-level errors with an API domain context.
+type APIError struct {
+	Method string
+	Err    error
+}
+
+func (e APIError) Error() string {
+	if e.Err == nil {
+		return e.Method
+	}
+
+	return "API Error: <" + e.Method + "> " + e.Err.Error()
+}
+
+func (e APIError) Unwrap() error {
+	return e.Err
+}
+
+func NewAPIError(m string, err error) APIError {
+	return APIError{Method: m, Err: err}
+}

--- a/resources/generic.go
+++ b/resources/generic.go
@@ -468,15 +468,7 @@ func (me *Generic) Read(ctx context.Context, d *schema.ResourceData, m any) diag
 			return diag.FromErr(err)
 		}
 	}
-	if err != nil {
-		if restError, ok := err.(rest.Error); ok {
-			if restError.Code == 404 {
-				d.SetId("")
-				return diag.Diagnostics{}
-			}
-		}
-		return diag.FromErr(err)
-	}
+
 	return me.ReadForSettings(ctx, d, m, sttngs)
 }
 

--- a/resources/generic.go
+++ b/resources/generic.go
@@ -458,15 +458,10 @@ func (me *Generic) Read(ctx context.Context, d *schema.ResourceData, m any) diag
 				ctx = context.WithValue(ctx, settings.ContextKeyStateConfig, tfConfig)
 			}
 			err = service.Get(ctx, d.Id(), sttngs)
-		} else {
-			if restError, ok := err.(rest.Error); ok {
-				if restError.Code == 404 {
-					d.SetId("")
-					return diag.Diagnostics{}
-				}
-			}
-			return diag.FromErr(err)
 		}
+
+		d.SetId("")
+		return diag.FromErr(api.NewAPIError("GET", err))
 	}
 
 	return me.ReadForSettings(ctx, d, m, sttngs)


### PR DESCRIPTION
#### **Why** this PR?
This PR is connected to the GitHub issue #868, where an API, after a successful POST request, returns a 404 on the consequent read operation with the objectId.

 As there is a state mismatch, Terraform will fail without an error message.

#### **What** has changed?

1. Removed unused code block
2. Introduced APIError 
3. Using the APIError and removing the silent failing on a 404 error

#### **How** does it do it?

#### How is it **tested**?
Manually tested and covered by tests

#### How does it affect **users**?
The user should be provided with a better error message. Example below.
`│ Error: API Error: <GET> Settings modification only visible for devops`
**Issue:**
