### PR TITLE
feat(extensions): Adds scope parameter

### DIFF
--- a/dynatrace/api/v2/hub/extension/config/service.go
+++ b/dynatrace/api/v2/hub/extension/config/service.go
@@ -93,6 +93,7 @@ func (me *service) Get(ctx context.Context, id string, v *extension_config.Setti
 
 	injectScope(response.Scope, v)
 	v.Name = name
+	v.Scope = response.Scope
 
 	// Try to replace placeholders only if stateConfig and response.Value are valid
 	if stateConfig != nil && response.Value != nil {
@@ -299,6 +300,9 @@ func injectScope(scope string, v *extension_config.Settings) {
 }
 
 func extractScope(v *extension_config.Settings) string {
+	if v.Scope != "" {
+		return v.Scope
+	}
 	if len(v.ActiveGateGroup) > 0 {
 		return fmt.Sprintf("ag_group-%s", v.ActiveGateGroup)
 	}

--- a/dynatrace/api/v2/hub/extension/config/service_test.go
+++ b/dynatrace/api/v2/hub/extension/config/service_test.go
@@ -23,8 +23,63 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestAccExtensionConfiguration(t *testing.T) {
+	// this also tests "no scope" => "no change after apply & plan"
 	api.TestAcc(t)
+}
+
+func TestAccExtensionsCustomScope(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	const resourceName = "dynatrace_hub_extension_configuration.this"
+	configNoScope, _ := api.ReadTfConfig(t, "testdata/terraform/noscope.tf")
+	configWithScope, _ := api.ReadTfConfig(t, "testdata/terraform/withscope.tf")
+	scope := "environment"
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("No scope to default custom scope yields empty plan", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configNoScope},
+				{
+					Config: configWithScope,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "scope", scope),
+					),
+					PlanOnly: true,
+				},
+			},
+		}
+		resource.Test(t, testCase)
+	})
+
+	t.Run("Removal of default custom scope yields empty plan", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configWithScope},
+				{
+					Config: configNoScope,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "scope", scope),
+					),
+					PlanOnly: true,
+				},
+			},
+		}
+		resource.Test(t, testCase)
+	})
 }

--- a/dynatrace/api/v2/hub/extension/config/settings/settings.go
+++ b/dynatrace/api/v2/hub/extension/config/settings/settings.go
@@ -31,6 +31,7 @@ import (
 
 type Settings struct {
 	Name            string `json:"-"`
+	Scope           string `json:"-"`
 	Value           string `json:"-"`
 	Host            string `json:"-"`
 	HostGroup       string `json:"-"`
@@ -47,6 +48,13 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "The fully qualified name of the extension, such as `com.dynatrace.extension.jmx-liberty-cp`. You can query for these names using the data source `dynatrace_hub_items`",
 			ForceNew:    true,
 			Required:    true,
+		},
+		"scope": {
+			Type:        schema.TypeString,
+			Description: "The scope this monitoring configuration will be defined for",
+			ForceNew:    true,
+			Optional:    true,
+			Computed:    true,
 		},
 		"host": {
 			Type:          schema.TypeString,
@@ -187,6 +195,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
 		"name":              me.Name,
 		"value":             me.Value,
+		"scope":             me.Scope,
 		"host":              me.Host,
 		"host_group":        me.HostGroup,
 		"active_gate_group": me.ActiveGateGroup,
@@ -198,6 +207,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
 		"name":              &me.Name,
 		"value":             &me.Value,
+		"scope":             &me.Scope,
 		"host":              &me.Host,
 		"host_group":        &me.HostGroup,
 		"active_gate_group": &me.ActiveGateGroup,

--- a/dynatrace/api/v2/hub/extension/config/testdata/terraform/noscope.tf
+++ b/dynatrace/api/v2/hub/extension/config/testdata/terraform/noscope.tf
@@ -1,0 +1,17 @@
+resource "dynatrace_hub_extension_config" "com_dynatrace_extension_jmx-weblogic-cp" {
+  name = "com.dynatrace.extension.jmx-weblogic-cp"
+  value = jsonencode(
+    {
+      "activationContext": "LOCAL",
+      "activationTags": [],
+      "enabled" : true,
+      "description" : "jj",
+      "version" : "2.0.4",
+      "featureSets" : [
+        "cache",
+        "connections",
+        "capacity"
+      ]
+    }
+  )
+}

--- a/dynatrace/api/v2/hub/extension/config/testdata/terraform/withscope.tf
+++ b/dynatrace/api/v2/hub/extension/config/testdata/terraform/withscope.tf
@@ -1,5 +1,6 @@
 resource "dynatrace_hub_extension_config" "com_dynatrace_extension_jmx-weblogic-cp" {
   name = "com.dynatrace.extension.jmx-weblogic-cp"
+  scope = "environment"
     value = jsonencode(
     {
       "activationContext": "LOCAL",

--- a/templates/resources/hub_extension_config.md.tmpl
+++ b/templates/resources/hub_extension_config.md.tmpl
@@ -51,7 +51,7 @@ The full documentation of the export feature is available [here](https://dt-url.
 
 ## Resource Example Usage
 
-{{ tffile "dynatrace/api/v2/hub/extension/config/testdata/terraform/example-a.tf" }}
+{{ tffile "dynatrace/api/v2/hub/extension/config/testdata/terraform/withscope.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
  


### PR DESCRIPTION
#### **Why** this PR?
Some monitoring configurations for extensions expect specific scopes to be set. Before this PR, users were not able to set the scope themselves. We tried to deduce it from the other attributes of the `dynatrace_hub_extension_config` resource, but this approach is not sufficient for all potential scopes. To enable Terraform management for additional extensions, this resource is extended.

#### **What** has changed?
This enables to set the `scope` parameter manually in HCL for `dynatrace_hub_extension_config` resources.
If it is set, it is used for the value of `scope`. If it is not set, the previous approach, where we try to deduce the scope from the rest of the attributes of the resource, is taken.

#### **How** does it do it?
The `scope` parameter is added to the HCL schema and it is used in the CRUD service

#### How is it **tested**?
An additional testfile is added where the scope parameter is set.

#### How does it affect **users**?
Users can set the `scope` parameter for `dynatrace_hub_extension_config` resources which require this.

**Issue:**
CA-17125