### PR TITLE
test: add unique identifier for `dynatrace_log_metrics` metric key

### DIFF
--- a/dynatrace/api/builtin/logmonitoring/schemalesslogmetric/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/logmonitoring/schemalesslogmetric/testdata/terraform/example_a.tf
@@ -1,7 +1,7 @@
 resource "dynatrace_log_metrics" "#name#" {
   enabled           = true
   dimensions        = ["dt.os.type", "dt.entity.process_group"]
-  key               = "log.terraformexample3"
+  key               = "log.#name#"
   measure           = "ATTRIBUTE"
   measure_attribute = "dt.entity.host"
   query             = "matchesPhrase(content, \"terratest\")"


### PR DESCRIPTION
#### **Why** this PR?
The test for `dynatrace_log_metrics` can fail if the metric key already exists (race condition or parallel test executions).

#### **What** has changed?
A unique identifier is now added to the `dynatrace_log_metrics` resource example.

#### **How** does it do it?
By adding `#name#` to the metric key.

#### How is it **tested**?
Current tests cover it.

#### How does it affect **users**?
Doesn't affect users. They will just see a slightly different example.

**Issue:**
