### PR TITLE
 feat(aws-connection): Improve UX for dynatrace_aws_connection_role_arn resource

### DIFF
--- a/docs/resources/aws_connection.md
+++ b/docs/resources/aws_connection.md
@@ -88,6 +88,10 @@ resource "aws_iam_role" "example_role" {
 resource "dynatrace_aws_connection_role_arn" "test-aws-connection-arn" {
   aws_connection_id = dynatrace_aws_connection.test-aws-connection.id
   role_arn          = aws_iam_role.example_role.arn
+
+  timeouts {
+    create = "15s"
+  }
 }
 ```
 

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/service_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/service_test.go
@@ -22,22 +22,22 @@ func approx(d1, d2 time.Duration) bool {
 
 func TestComputeRetryContext_NoDeadline(t *testing.T) {
 	ctx := context.Background()
-	retryTimeout, _ := computeRetryTimeout(ctx, time.Minute, 2*time.Minute)
+	retryTimeout, _ := computeRetryTimeout(ctx, 2*time.Minute)
 
 	assert.Equal(t, 2*time.Minute, retryTimeout)
 }
 
 func TestComputeRetryContext_WithDeadline_Plenty(t *testing.T) {
-	// caller provides 5 minutes; timeoutDeadlineBuffer is 1 minute -> retryTimeout should be ~4 minutes
+	// caller provides 5 minutes; retryTimeout should be ~5 minutes
 	parent := context.Background()
 	deadline := time.Now().Add(5 * time.Minute)
 	ctxWithDL, cancelParent := context.WithDeadline(parent, deadline)
 	defer cancelParent()
 
-	retryTimeout, _ := computeRetryTimeout(ctxWithDL, time.Minute, 2*time.Minute)
+	retryTimeout, _ := computeRetryTimeout(ctxWithDL, 2*time.Minute)
 
-	// expect ~4 minutes
-	expected := 4 * time.Minute
+	// expect ~5 minutes
+	expected := 5 * time.Minute
 	assert.True(t, approx(expected, retryTimeout), "expected approximately %v, got %v", expected, retryTimeout)
 }
 
@@ -45,29 +45,27 @@ func TestComputeRetryContext_ExpiredDeadline(t *testing.T) {
 	ctxWithExpiredDL, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
 
-	_, err := computeRetryTimeout(ctxWithExpiredDL, time.Minute, 2*time.Minute)
+	_, err := computeRetryTimeout(ctxWithExpiredDL, 2*time.Minute)
 
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestClassifyRetryError(t *testing.T) {
 	tests := []struct {
-		err            error
-		expectedSubstr string
+		err         error
+		isRetryable bool
 	}{
-		{err: rest.Error{Code: 400, Message: "bad"}, expectedSubstr: "not yet usable (HTTP 400)"},
-		{err: rest.Error{Code: 404, Message: "notfound"}, expectedSubstr: "not yet usable (HTTP 404)"},
-		{err: rest.Error{Code: 401, Message: "unauth"}, expectedSubstr: "unusable (HTTP 401)"},
-		{err: rest.Error{Code: 500, Message: "server"}, expectedSubstr: "not yet usable (HTTP 500)"},
-		{err: errors.New("network failure"), expectedSubstr: "not yet usable"},
+		{err: rest.Error{Code: 400, Message: "bad"}, isRetryable: true},
+		{err: rest.Error{Code: 404, Message: "notfound"}, isRetryable: true},
+		{err: rest.Error{Code: 401, Message: "unauth"}, isRetryable: false},
+		{err: rest.Error{Code: 500, Message: "server"}, isRetryable: true},
+		{err: errors.New("network failure"), isRetryable: false},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.expectedSubstr, func(t *testing.T) {
-			re := classifyRetryError(tc.err)
-			msg := re.Err.Error()
-
-			assert.Contains(t, msg, tc.expectedSubstr)
+		t.Run(tc.err.Error(), func(t *testing.T) {
+			retryError := classifyRetryError(tc.err)
+			assert.Equal(t, tc.isRetryable, retryError.Retryable)
 		})
 	}
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/settings/settings.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/settings/settings.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	DefaultCreateTimeout = 20 * time.Minute
+	DefaultCreateTimeout = 2 * time.Minute
 )
 
 type Settings struct {

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/testdata/terraform/example_webidentity.tf
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/testdata/terraform/example_webidentity.tf
@@ -39,4 +39,8 @@ resource "aws_iam_role" "example_role" {
 resource "dynatrace_aws_connection_role_arn" "test-aws-connection-arn" {
   aws_connection_id = dynatrace_aws_connection.test-aws-connection.id
   role_arn          = aws_iam_role.example_role.arn
+
+  timeouts {
+    create = "15s"
+  }
 }

--- a/templates/resources/aws_connection_role_arn.md.tmpl
+++ b/templates/resources/aws_connection_role_arn.md.tmpl
@@ -18,6 +18,18 @@ Ensure you configure both resources together for a valid AWS connection.
 An example of how to set up both resources can be found in the [Resource Example Usage](#resource-example-usage) section below.
 
 ## Limitations
+If you are creating the `dynatrace_aws_connection_role_arn` and the `aws_iam_role` it is referencing in the same invocation
+of `terraform apply`, be aware that due to eventual consistency in AWS, the creation of the `aws_iam_role` might not be fully propagated
+when the `dynatrace_aws_connection_role_arn` resource is being created. To mitigate this, we retry the creation of the `dynatrace_aws_connection_role_arn` resource
+with a default timeout of 2 minutes.
+This is also the timeout used by [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/blob/546cd5a106a10516fcb8465459f2abd1b37b6036/internal/service/iam/consts.go#L16) when waiting for IAM changes to propagate.
+If you desire a different timeout, you can adjust it using the `timeouts` block in the `dynatrace_aws_connection_role_arn` resource as shown in the example below.
+
+The following is an example of the error you might encounter due to this limitation:
+```
+Unable to assume role with web identity. (AccessDenied) Not authorized to perform sts:AssumeRoleWithWebIdentity (Service: Sts, Status Code: 403, Request ID: 00000000-1111-2222-3333-555555555555) (SDK Attempt Count: 1), RequestId 00000000-1111-2222-3333-555555555555
+```
+
 ~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
 
 An empty owner implies:


### PR DESCRIPTION
#### **Why** this PR?
Currently, we have a default create timeout of 20 minutes for the `dynatrace_aws_connection_role_arn` resource. 
This is a problem, because when the creation of the `dynatrace_aws_connection_role_arn` resource fails, we cannot deduce from the returned error message
 - whether the referenced IAM role has not been created yet, or
 - whether something was misconfigured.

So, worst case scenario, since we retry the creation in case of errors: Something has been misconfigured and we only fail after 20 minutes, when the create timeout is reached.

Also, in the error cases, we made assumptions about the cause of the error. We should not do this, it is most often a wrong assumption.

#### **What** has changed and **How**?

- Default timeout is reduced to 2 minutes, because we cannot distinguish in the error message between a misconfiguration and a problem stemming from eventual consistency on the AWS side. Therefore, instead of forcing users to wait for 20 minutes on misconfigurations, we want to fail earlier. This is also the timeout that the AWS terraform provider uses when [waiting on IAM change propagation](https://github.com/hashicorp/terraform-provider-aws/blob/546cd5a106a10516fcb8465459f2abd1b37b6036/internal/service/iam/consts.go#L16):
- The buffer makes no sense anymore, so I just removed it.
- Instead of assuming what went wrong in `classifyRetryError` we just wrap the error as-is.
- non-HTTP errors are now seen as non-retryable
- Using a dedicated retry context is not needed, therefore I removed it

Also, the example for how to use `dynatrace_aws_connection_role_arn` now features the use of the `timeouts` block to show how it could be used to change the create timeout.

The documentation has also been adapted to explain the situation with eventual consistency of AWS resources and how the `timeouts` block can be used, should the need for a longer timeout arise.

#### How is it **tested**?
E2E test case now features the `timeouts` block.

#### How does it affect **users**?
- For some users, where the default create timeout of 2 minutes is not enough, the creation of `dynatrace_aws_connection_role_arn` might fail with an error message, mentioning that `AssumeRole` was not possible. This case is documented. The creation can be fixed by either waiting and tryin to create the resource again a bit later or by modifying or adding the `timeouts` block. 
- Users that have misconfigured some parts of their setup get feedback much earlier now by default.

**Issue:**
CA-17137
