### PR TITLE
ci(sonar): Add Sonar Qube with coverage and linting report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,8 @@
 name: Tests
 
 # This workflow
-#  - runs the unit tests
+#  - runs the unit tests and create coverage report
+#  - runs static code analysis (linting)
 #  - runs integration tests in parallel chunks
 #  - reports the code coverage and linting errors to Sonar
 
@@ -50,12 +51,6 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
         with:
           go-version-file: go.mod
-
-      - name: ✍️ Check format
-        run: make lint
-
-      - name: 🕵️ Go vet
-        run: make vet
 
       - name: 🔎 golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,10 @@
 name: Tests
+
+# This workflow
+#  - runs the unit tests
+#  - runs integration tests in parallel chunks
+#  - reports the code coverage and linting errors to Sonar
+
 on:
   push:
     branches:
@@ -16,10 +22,53 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # 4.3.0
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@3f7ff0ec4aeb6f95f5d67c998b71f272aa8a8b41 #v1.12.1
+
       - name: Run Unit Tests
         env:
           GOPROXY: "https://proxy.golang.org"
-        run: go test -tags=unit -v ./...
+        run: gotestsum --format testdox --format-icons hivis -- -coverprofile=cov.out -tags=unit -v ./...
+
+      - name: ⬆️ Archive code coverage results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: code-coverage-report
+          path: cov.out
+
+  lint:
+    name: Run Static Code Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: 🛠️ Set up Go 1.x
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: ✍️ Check format
+        run: make lint
+
+      - name: 🕵️ Go vet
+        run: make vet
+
+      - name: 🔎 golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
+        with:
+          install-mode: 'goinstall' # install mode goinstall in order to use hashes for the version
+          version: eabc2638a66daf5bb6c6fb052a32fa3ef7b6600d #v2.1.6
+          args: '--output.checkstyle.path=lint-report.xml --issues-exit-code=0' # if issues are found, don't exit with "1". Sonar decides if it fails or not
+
+      - name: ⬆️ Archive lint results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: lint-report
+          path: lint-report.xml
 
   integration-tests:
     name: Integration Tests - ${{ matrix.config.name }}
@@ -76,3 +125,41 @@ jobs:
           DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
         run: go test -tags=integration -v -p 1 ${{ matrix.config.path }}
+
+  sonar_scan:
+    name: Report lint and test coverage
+    if: ${{ always() }} # always runs after lint and test have completed, regardless of whether they were successful
+    needs: [ unit-tests, lint ]
+    permissions:
+      contents: read
+      checks: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        with:
+          # Disabling shallow clones is recommended for improving the relevancy of reporting
+          fetch-depth: 0
+
+      - name: ⬇️ Download coverage artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: code-coverage-report
+
+      - name: ⬇️ Download lint artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: lint-report
+
+      - name: 🏷️ Get latest tag
+        id: get_latest_tag
+        run: |
+          echo "GIT_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+      - name: 🔍 SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@1a6d90ebcb0e6a6b1d87e37ba693fe453195ae25 # nosemgrep false detection of commit v5.3.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: |
+            -Dsonar.projectVersion=${{steps.get_latest_tag.outputs.GIT_TAG}}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=dynatrace-oss_terraform-provider-dynatrace
+sonar.organization=dynatrace-oss
+
+sonar.projectName=terraform-provider-dynatrace
+# sonar.projectVersion=<set by CI>
+
+sonar.language=go
+sonar.sources=.
+sonar.exclusions=**/*_test.go,  **/test_clientset.go, **/terraform.tfstate, **/*schema.json,
+
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.go.coverage.reportPaths=cov.out
+sonar.go.golangci-lint.reportPaths=lint-report.xml


### PR DESCRIPTION
### Why this PR?
Introduce CI support for SonarCloud code quality analysis by ensuring Go code coverage is generated and published.

### What has changed?
Added installation of gotestsum in unit test workflow.
Modified unit test step to produce cov.out with atomic coverage.
Uploaded coverage artifact for downstream use (e.g. SonarCloud scan).
Ensured sonar-project.properties references the generated coverage report.

### How does it do it?
Uses gotestsum to wrap go test with coverage flags (-covermode=atomic -coverprofile=cov.out) and publishes cov.out via actions/upload-artifact. Sonar config consumes cov.out in subsequent analysis.

### How is it tested?
Validated through CI workflow execution:
Unit tests run with coverage.
Artifact cov.out is generated and uploaded. (Existing test suite remains unchanged.)

### How does it affect users?
No provider behavior changes. Improves code quality feedback by enabling coverage reporting in SonarCloud. No action required by end users.