### PR TITLE
test: make `dynatrace_attribute_block_list` and `dynatrace_process_group_simple_detection` unique

### DIFF
--- a/dynatrace/api/builtin/attribute/blocklist/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/attribute/blocklist/testdata/terraform/example_a.tf
@@ -1,4 +1,4 @@
 resource "dynatrace_attribute_block_list" "#name#" {
   enabled = true
-  key = "attribute.example"
+  key = "attribute.#name#"
 }

--- a/dynatrace/api/builtin/processgroup/simpledetectionrule/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/processgroup/simpledetectionrule/testdata/terraform/example_a.tf
@@ -1,7 +1,7 @@
 resource "dynatrace_process_group_simple_detection" "#name#" {
   enabled             = false
   group_identifier    = "GroupIdentifierExample"
-  instance_identifier = "InstanceIdentifierExample"
+  instance_identifier = "InstanceIdentifierExample_#name#"
   process_type        = "PROCESS_TYPE_GO"
   rule_type           = "prop"
 }

--- a/dynatrace/api/builtin/processgroup/simpledetectionrule/testdata/terraform/example_insert_after.tf
+++ b/dynatrace/api/builtin/processgroup/simpledetectionrule/testdata/terraform/example_insert_after.tf
@@ -1,7 +1,7 @@
 resource "dynatrace_process_group_simple_detection" "first-instance" {
   enabled             = false
   group_identifier    = "GroupIdentifierExample"
-  instance_identifier = "InstanceIdentifierExample"
+  instance_identifier = "InstanceIdentifierExample_#name#"
   process_type        = "PROCESS_TYPE_GO"
   rule_type           = "prop"
 }
@@ -9,7 +9,7 @@ resource "dynatrace_process_group_simple_detection" "first-instance" {
 resource "dynatrace_process_group_simple_detection" "second-instance" {
   enabled             = false
   group_identifier    = "GroupIdentifierExample2"
-  instance_identifier = "InstanceIdentifierExample"
+  instance_identifier = "InstanceIdentifierExample_#name#"
   process_type        = "PROCESS_TYPE_GO"
   rule_type           = "prop"
   insert_after        = dynatrace_process_group_simple_detection.first-instance.id


### PR DESCRIPTION
#### **Why** this PR?
Some E2E ran into conflicts

#### **What** has changed?
The E2E for `dynatrace_attribute_block_list` and `dynatrace_process_group_simple_detection` won't run into conflicts anymore.

#### **How** does it do it?
By adding `#name#` (our unique replacement strategy) to the affected resources.

#### How is it **tested**?
Current tests still work.

#### How does it affect **users**?
Doesn't affect users (just a small change in the docs).
