### PR TITLE
test: make `dynatrace_business_events_metrics` test unique

### DIFF
--- a/dynatrace/api/builtin/bizevents/processing/metrics/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/bizevents/processing/metrics/testdata/terraform/example_a.tf
@@ -1,6 +1,6 @@
 resource "dynatrace_business_events_metrics" "#name#" {
   enabled           = true
-  key               = "bizevents.easyTrade.TradingVolume"
+  key               = "bizevents.easyTrade.#name#"
   matcher           = "matchesValue(event.type, \"com.easytrade.buy-assets\")"
   measure           = "ATTRIBUTE"
   measure_attribute = "trading_volume"


### PR DESCRIPTION
#### **Why** this PR?
The test for `dynatrace_business_events_metrics` runs into conflicts if run in parallel.

#### **What** has changed?
The `dynatrace_business_events_metrics` test now doesn't run into conflicts anymore

#### **How** does it do it?
By adding a unique identifier to the `dynatrace_business_events_metrics` test.

#### How is it **tested**?
Current test still works.

#### How does it affect **users**?
Doesn't affect users
