### PR TITLE
feat: Update resources for Dynatrace version 1.328

### DIFF
--- a/docs/resources/business_events_oneagent.md
+++ b/docs/resources/business_events_oneagent.md
@@ -129,7 +129,7 @@ Optional:
 
 Required:
 
-- `source_type` (String) Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `source_type` (String) Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 
@@ -142,7 +142,7 @@ Optional:
 
 Required:
 
-- `source_type` (String) Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `source_type` (String) Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 
@@ -155,7 +155,7 @@ Optional:
 
 Required:
 
-- `source_type` (String) Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `source_type` (String) Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 
@@ -183,7 +183,7 @@ Required:
 
 Required:
 
-- `source_type` (String) Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `source_type` (String) Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 
@@ -207,7 +207,7 @@ Required:
 Required:
 
 - `source` (Block List, Min: 1, Max: 1) no documentation available (see [below for nested schema](#nestedblock--triggers--trigger--source))
-- `type` (String) Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`
+- `type` (String) Operator. Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`
 
 Optional:
 
@@ -219,7 +219,7 @@ Optional:
 
 Required:
 
-- `data_source` (String) Possible Values: `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `data_source` (String) Data source. Possible Values: `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 

--- a/docs/resources/business_events_oneagent_outgoing.md
+++ b/docs/resources/business_events_oneagent_outgoing.md
@@ -73,7 +73,7 @@ resource "dynatrace_business_events_oneagent_outgoing" "#name#" {
 - `enabled` (Boolean) This setting is enabled (`true`) or disabled (`false`)
 - `event` (Block List, Min: 1, Max: 1) Event meta data (see [below for nested schema](#nestedblock--event))
 - `rule_name` (String) Rule name
-- `triggers` (Block List, Min: 1, Max: 1) Define conditions to trigger business events from incoming web requests. Triggers are connected by AND logic per capture rule. If you set multiple trigger rules, all of them need to be fulfilled to capture a business event. (see [below for nested schema](#nestedblock--triggers))
+- `triggers` (Block List, Min: 1, Max: 1) Define conditions to trigger business events from outgoing web requests. Triggers are connected by AND logic per capture rule. If you set multiple trigger rules, all of them need to be fulfilled to capture a business event. (see [below for nested schema](#nestedblock--triggers))
 
 ### Optional
 
@@ -102,7 +102,7 @@ Optional:
 
 Required:
 
-- `source_type` (String) Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `source_type` (String) Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 
@@ -115,7 +115,7 @@ Optional:
 
 Required:
 
-- `source_type` (String) Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `source_type` (String) Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 
@@ -128,7 +128,7 @@ Optional:
 
 Required:
 
-- `source_type` (String) Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `source_type` (String) Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 
@@ -156,7 +156,7 @@ Required:
 
 Required:
 
-- `source_type` (String) Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `source_type` (String) Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 
@@ -180,7 +180,7 @@ Required:
 Required:
 
 - `source` (Block List, Min: 1, Max: 1) no documentation available (see [below for nested schema](#nestedblock--triggers--trigger--source))
-- `type` (String) Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`
+- `type` (String) Operator. Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`
 
 Optional:
 
@@ -192,7 +192,7 @@ Optional:
 
 Required:
 
-- `data_source` (String) Possible Values: `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+- `data_source` (String) Data source. Possible Values: `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 
 Optional:
 

--- a/docs/resources/hub_extension_config.md
+++ b/docs/resources/hub_extension_config.md
@@ -54,8 +54,11 @@ The full documentation of the export feature is available [here](https://dt-url.
 ```terraform
 resource "dynatrace_hub_extension_config" "com_dynatrace_extension_jmx-weblogic-cp" {
   name = "com.dynatrace.extension.jmx-weblogic-cp"
+  scope = "environment"
     value = jsonencode(
     {
+      "activationContext": "LOCAL",
+      "activationTags": [],
       "enabled" : true,
       "description" : "jj",
       "version" : "2.0.4",
@@ -83,6 +86,7 @@ resource "dynatrace_hub_extension_config" "com_dynatrace_extension_jmx-weblogic-
 - `host` (String) The ID of the host this monitoring configuration will be defined for
 - `host_group` (String) The ID of the host group this monitoring configuration will be defined for
 - `management_zone` (String) The name of the Management Zone this monitoring configuration will be defined for
+- `scope` (String) The scope this monitoring configuration will be defined for
 
 ### Read-Only
 

--- a/docs/resources/log_timestamp.md
+++ b/docs/resources/log_timestamp.md
@@ -56,6 +56,7 @@ resource "dynatrace_log_timestamp" "#name#" {
 - `date_search_limit` (Number) Defines the number of characters in every log line (starting from the first character in the line) where the timestamp is searched.
 - `entry_boundary` (Block List, Max: 1) Optional field. Enter a fragment of the line text that starts the entry. No support for wildcards - the text is treated literally. (see [below for nested schema](#nestedblock--entry_boundary))
 - `insert_after` (String) Because this resource allows for ordering you may specify the ID of the resource instance that comes before this instance regarding order. If not specified when creating the setting will be added to the end of the list. If not specified during update the order will remain untouched
+- `json_configuration` (Block List, Max: 1) Detect JSON format (see [below for nested schema](#nestedblock--json_configuration))
 - `matchers` (Block List, Max: 1) no documentation available (see [below for nested schema](#nestedblock--matchers))
 - `scope` (String) The scope of this setting (HOST, KUBERNETES_CLUSTER, HOST_GROUP). Omit this property if you want to cover the whole environment.
 - `skip_indented_lines` (Boolean) Don't parse timestamps in lines starting with white character
@@ -72,6 +73,14 @@ Optional:
 - `pattern` (String) no documentation available
 
 
+<a id="nestedblock--json_configuration"></a>
+### Nested Schema for `json_configuration`
+
+Optional:
+
+- `format_detection` (Boolean) no documentation available
+
+
 <a id="nestedblock--matchers"></a>
 ### Nested Schema for `matchers`
 
@@ -84,7 +93,7 @@ Required:
 
 Required:
 
-- `attribute` (String) Possible Values: `Container_name`, `Dt_entity_container_group`, `Dt_entity_process_group`, `Host_tag`, `K8s_container_name`, `K8s_deployment_name`, `K8s_namespace_name`, `K8s_pod_annotation`, `K8s_pod_label`, `K8s_workload_kind`, `K8s_workload_name`, `Log_source`, `Log_source_origin`, `Process_technology`
+- `attribute` (String) Possible Values: `container.name`, `dt.entity.container_group`, `dt.entity.process_group`, `host.tag`, `k8s.container.name`, `k8s.deployment.name`, `k8s.namespace.name`, `k8s.pod.annotation`, `k8s.pod.label`, `k8s.workload.kind`, `k8s.workload.name`, `log.source`, `log.source.origin`, `process.technology`
 - `operator` (String) Possible Values: `MATCHES`
 - `values` (Set of String) no documentation available
  

--- a/docs/resources/openpipeline_v2_bizevents_ingestsources.md
+++ b/docs/resources/openpipeline_v2_bizevents_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_bizevents_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_bizevents_ingestsources" "maximal-source" {
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_bizevents_ingestsources" "maximal-source" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_bizevents_pipelines.md
+++ b/docs/resources/openpipeline_v2_bizevents_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_bizevents_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -253,6 +259,7 @@ resource "dynatrace_openpipeline_v2_bizevents_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -3037,6 +3044,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_davis_events_ingestsources.md
+++ b/docs/resources/openpipeline_v2_davis_events_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "maximal-source"
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "maximal-source"
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "maximal-source"
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_davis_events_pipelines.md
+++ b/docs/resources/openpipeline_v2_davis_events_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_davis_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -183,6 +189,7 @@ resource "dynatrace_openpipeline_v2_davis_events_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -2967,6 +2974,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_davis_problems_ingestsources.md
+++ b/docs/resources/openpipeline_v2_davis_problems_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_davis_problems_ingestsources" "maximal-sourc
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_davis_problems_ingestsources" "maximal-sourc
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_davis_problems_ingestsources" "maximal-sourc
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_davis_problems_pipelines.md
+++ b/docs/resources/openpipeline_v2_davis_problems_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -170,6 +176,7 @@ resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -2954,6 +2961,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_events_ingestsources.md
+++ b/docs/resources/openpipeline_v2_events_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_events_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_events_ingestsources" "maximal-source" {
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_events_ingestsources" "maximal-source" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_events_pipelines.md
+++ b/docs/resources/openpipeline_v2_events_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -253,6 +259,7 @@ resource "dynatrace_openpipeline_v2_events_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -3037,6 +3044,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_events_sdlc_ingestsources.md
+++ b/docs/resources/openpipeline_v2_events_sdlc_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_events_sdlc_ingestsources" "maximal-source" 
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_events_sdlc_ingestsources" "maximal-source" 
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_events_sdlc_ingestsources" "maximal-source" 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_events_sdlc_pipelines.md
+++ b/docs/resources/openpipeline_v2_events_sdlc_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -253,6 +259,7 @@ resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -3037,6 +3044,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_events_security_ingestsources.md
+++ b/docs/resources/openpipeline_v2_events_security_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_events_security_ingestsources" "maximal-sour
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_events_security_ingestsources" "maximal-sour
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_events_security_ingestsources" "maximal-sour
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_events_security_pipelines.md
+++ b/docs/resources/openpipeline_v2_events_security_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_events_security_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -253,6 +259,7 @@ resource "dynatrace_openpipeline_v2_events_security_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -3037,6 +3044,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_logs_ingestsources.md
+++ b/docs/resources/openpipeline_v2_logs_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_logs_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_logs_ingestsources" "maximal-source" {
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_logs_ingestsources" "maximal-source" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_logs_pipelines.md
+++ b/docs/resources/openpipeline_v2_logs_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_logs_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -285,6 +291,7 @@ resource "dynatrace_openpipeline_v2_logs_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -3069,6 +3076,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_metrics_ingestsources.md
+++ b/docs/resources/openpipeline_v2_metrics_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_metrics_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_metrics_ingestsources" "maximal-source" {
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_metrics_ingestsources" "maximal-source" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_metrics_pipelines.md
+++ b/docs/resources/openpipeline_v2_metrics_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_metrics_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -156,6 +162,7 @@ resource "dynatrace_openpipeline_v2_metrics_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -2940,6 +2947,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_security_events_ingestsources.md
+++ b/docs/resources/openpipeline_v2_security_events_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_security_events_ingestsources" "maximal-sour
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_security_events_ingestsources" "maximal-sour
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_security_events_ingestsources" "maximal-sour
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_security_events_pipelines.md
+++ b/docs/resources/openpipeline_v2_security_events_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_security_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -253,6 +259,7 @@ resource "dynatrace_openpipeline_v2_security_events_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -3037,6 +3044,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_spans_ingestsources.md
+++ b/docs/resources/openpipeline_v2_spans_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_spans_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_spans_ingestsources" "maximal-source" {
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_spans_ingestsources" "maximal-source" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_spans_pipelines.md
+++ b/docs/resources/openpipeline_v2_spans_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_spans_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -253,6 +259,7 @@ resource "dynatrace_openpipeline_v2_spans_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -3037,6 +3044,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_system_events_ingestsources.md
+++ b/docs/resources/openpipeline_v2_system_events_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_system_events_ingestsources" "maximal-source
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_system_events_ingestsources" "maximal-source
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_system_events_ingestsources" "maximal-source
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_system_events_pipelines.md
+++ b/docs/resources/openpipeline_v2_system_events_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_system_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   davis {
     processors {
       processor {
@@ -142,6 +148,7 @@ resource "dynatrace_openpipeline_v2_system_events_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -2926,6 +2933,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_user_events_ingestsources.md
+++ b/docs/resources/openpipeline_v2_user_events_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_user_events_ingestsources" "maximal-source" 
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_user_events_ingestsources" "maximal-source" 
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_user_events_ingestsources" "maximal-source" 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_user_events_pipelines.md
+++ b/docs/resources/openpipeline_v2_user_events_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_user_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   metric_extraction {
     processors {
       processor {
@@ -147,6 +153,7 @@ resource "dynatrace_openpipeline_v2_user_events_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -2931,6 +2938,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/docs/resources/openpipeline_v2_usersessions_ingestsources.md
+++ b/docs/resources/openpipeline_v2_usersessions_ingestsources.md
@@ -50,6 +50,12 @@ resource "dynatrace_openpipeline_v2_usersessions_ingestsources" "maximal-source"
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -129,6 +135,7 @@ resource "dynatrace_openpipeline_v2_usersessions_ingestsources" "maximal-source"
 ### Optional
 
 - `default_bucket` (String) Default Bucket
+- `metadata_list` (Block List, Max: 1) Ingest source metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `path_segment` (String) Endpoint segment
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `source` (String) Source
@@ -138,6 +145,26 @@ resource "dynatrace_openpipeline_v2_usersessions_ingestsources" "maximal-source"
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
+
+
 
 <a id="nestedblock--processing"></a>
 ### Nested Schema for `processing`

--- a/docs/resources/openpipeline_v2_usersessions_pipelines.md
+++ b/docs/resources/openpipeline_v2_usersessions_pipelines.md
@@ -43,6 +43,12 @@ The full documentation of the export feature is available [here](https://dt-url.
 resource "dynatrace_openpipeline_v2_usersessions_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {
@@ -253,6 +259,7 @@ resource "dynatrace_openpipeline_v2_usersessions_pipelines" "max-pipeline" {
 - `cost_allocation` (Block List, Max: 1) Cost allocation stage (see [below for nested schema](#nestedblock--cost_allocation))
 - `data_extraction` (Block List, Max: 1) Data extraction stage (see [below for nested schema](#nestedblock--data_extraction))
 - `davis` (Block List, Max: 1) Davis event extraction stage (see [below for nested schema](#nestedblock--davis))
+- `metadata_list` (Block List, Max: 1) Pipeline metadata list (see [below for nested schema](#nestedblock--metadata_list))
 - `metric_extraction` (Block List, Max: 1) Metrics extraction stage (see [below for nested schema](#nestedblock--metric_extraction))
 - `processing` (Block List, Max: 1) Processing stage (see [below for nested schema](#nestedblock--processing))
 - `product_allocation` (Block List, Max: 1) Product allocation stage (see [below for nested schema](#nestedblock--product_allocation))
@@ -3037,6 +3044,26 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--metadata_list"></a>
+### Nested Schema for `metadata_list`
+
+Required:
+
+- `metadata` (Block List, Min: 1) (see [below for nested schema](#nestedblock--metadata_list--metadata))
+
+<a id="nestedblock--metadata_list--metadata"></a>
+### Nested Schema for `metadata_list.metadata`
+
+Required:
+
+- `entry_key` (String) Metadata entry key
+
+Optional:
+
+- `entry_value` (String) Metadata entry value
 
 
 

--- a/dynatrace/api/builtin/bizevents/http/incoming/schema.json
+++ b/dynatrace/api/builtin/bizevents/http/incoming/schema.json
@@ -150,6 +150,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"metadata": {
 		"addItemButton": "Add new capture rule",
@@ -472,6 +473,15 @@
 					}
 				},
 				"data": {
+					"constraints": [
+						{
+							"customMessage": "Event data field name must be unique.",
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"name"
+							]
+						}
+					],
 					"description": "Additional attributes for the business event.",
 					"displayName": "Event data",
 					"documentation": "",
@@ -727,5 +737,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.0.3"
+	"version": "1.0.4"
 }

--- a/dynatrace/api/builtin/bizevents/http/incoming/service.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.3"
+const SchemaVersion = "1.0.4"
 const SchemaID = "builtin:bizevents.http.incoming"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*incoming.Settings] {

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/data_source_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/data_source_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@ package incoming
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/slices"
 )
 
 type DataSourceComplex struct {
-	DataSource DataSourceEnum `json:"dataSource"`     // Possible Values: `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+	DataSource DataSourceEnum `json:"dataSource"`     // Data source. Possible Values: `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 	Path       *string        `json:"path,omitempty"` // [See our documentation](https://dt-url.net/ei034bx)
 }
 
@@ -34,7 +34,7 @@ func (me *DataSourceComplex) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"data_source": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`",
+			Description: "Data source. Possible Values: `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`",
 			Required:    true,
 		},
 		"path": {
@@ -53,8 +53,11 @@ func (me *DataSourceComplex) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *DataSourceComplex) HandlePreconditions() error {
-	if me.Path == nil && slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.DataSource)) {
+	if (me.Path == nil) && (slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.DataSource))) {
 		return fmt.Errorf("'path' must be specified if 'data_source' is set to '%v'", me.DataSource)
+	}
+	if (me.Path != nil) && (!slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.DataSource))) {
+		return fmt.Errorf("'path' must not be specified if 'data_source' is set to '%v'", me.DataSource)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/enums.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/enums.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/event_attribute_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/event_attribute_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@ package incoming
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/slices"
 )
 
 type EventAttributeComplex struct {
 	Path       *string                        `json:"path,omitempty"`   // [See our documentation](https://dt-url.net/ei034bx)
 	Source     *string                        `json:"source,omitempty"` // Fixed value
-	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 }
 
 func (me *EventAttributeComplex) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *EventAttributeComplex) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`",
+			Description: "Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`",
 			Required:    true,
 		},
 	}
@@ -60,11 +60,17 @@ func (me *EventAttributeComplex) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *EventAttributeComplex) HandlePreconditions() error {
-	if me.Path == nil && slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType)) {
+	if (me.Path == nil) && (slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
 		return fmt.Errorf("'path' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
-	if me.Source == nil && slices.Contains([]string{"constant.string"}, string(me.SourceType)) {
+	if (me.Path != nil) && (!slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
+		return fmt.Errorf("'path' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Source == nil) && (slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Source != nil) && (!slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/event_category_attribute_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/event_category_attribute_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,17 +19,17 @@ package incoming
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/slices"
 )
 
 type EventCategoryAttributeComplex struct {
 	Path       *string                        `json:"path,omitempty"`   // [See our documentation](https://dt-url.net/ei034bx)
 	Source     *string                        `json:"source,omitempty"` // Fixed value
-	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 }
 
 func (me *EventCategoryAttributeComplex) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *EventCategoryAttributeComplex) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`",
+			Description: "Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`",
 			Required:    true,
 		},
 	}
@@ -61,11 +61,14 @@ func (me *EventCategoryAttributeComplex) MarshalHCL(properties hcl.Properties) e
 }
 
 func (me *EventCategoryAttributeComplex) HandlePreconditions() error {
-	if me.Source == nil && slices.Contains([]string{"constant.string"}, string(me.SourceType)) {
+	if (me.Source == nil) && (slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
 		me.Source = opt.NewString("")
 	}
-	if me.Path == nil && slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType)) {
+	if (me.Path == nil) && (slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
 		return fmt.Errorf("'path' must be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Path != nil) && (!slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
+		return fmt.Errorf("'path' must not be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/event_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/event_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/event_data_attribute_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/event_data_attribute_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@ package incoming
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/slices"
 )
 
 type EventDataAttributeComplex struct {
 	Path       *string                        `json:"path,omitempty"`   // [See our documentation](https://dt-url.net/ei034bx)
 	Source     *string                        `json:"source,omitempty"` // Fixed value
-	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 }
 
 func (me *EventDataAttributeComplex) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *EventDataAttributeComplex) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`",
+			Description: "Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`",
 			Required:    true,
 		},
 	}
@@ -60,11 +60,17 @@ func (me *EventDataAttributeComplex) MarshalHCL(properties hcl.Properties) error
 }
 
 func (me *EventDataAttributeComplex) HandlePreconditions() error {
-	if me.Path == nil && slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType)) {
+	if (me.Path == nil) && (slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
 		return fmt.Errorf("'path' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
-	if me.Source == nil && slices.Contains([]string{"constant.string"}, string(me.SourceType)) {
+	if (me.Path != nil) && (!slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
+		return fmt.Errorf("'path' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Source == nil) && (slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Source != nil) && (!slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/event_data_field_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/event_data_field_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/matcher_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/matcher_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ package incoming
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/slices"
 )
 
 type MatcherComplexes []*MatcherComplex
@@ -66,7 +66,7 @@ func (me *MatcherComplexes) UnmarshalHCL(decoder hcl.Decoder) error {
 type MatcherComplex struct {
 	CaseSensitive *bool              `json:"caseSensitive,omitempty"` // Case sensitive
 	Source        *DataSourceComplex `json:"source"`
-	Type          ComparisonEnum     `json:"type"` // Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`
+	Type          ComparisonEnum     `json:"type"` // Operator. Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`
 	Value         *string            `json:"value,omitempty"`
 }
 
@@ -87,7 +87,7 @@ func (me *MatcherComplex) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`",
+			Description: "Operator. Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`",
 			Required:    true,
 		},
 		"value": {
@@ -108,10 +108,10 @@ func (me *MatcherComplex) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *MatcherComplex) HandlePreconditions() error {
-	if me.CaseSensitive == nil && !slices.Contains([]string{"EXISTS", "N_EXISTS"}, string(me.Type)) {
+	if (me.CaseSensitive == nil) && (!slices.Contains([]string{"EXISTS", "N_EXISTS"}, string(me.Type))) {
 		me.CaseSensitive = opt.NewBool(false)
 	}
-	if len(me.Type) > 0 && me.Value == nil && !slices.Contains([]string{"EXISTS", "N_EXISTS"}, string(me.Type)) {
+	if len(me.Type) > 0 && me.Value == nil && (!slices.Contains([]string{"EXISTS", "N_EXISTS"}, string(me.Type))) {
 		return fmt.Errorf("'value' must be specified if 'type' is set to '%v'", me.Type)
 	}
 	return nil

--- a/dynatrace/api/builtin/bizevents/http/incoming/settings/settings.go
+++ b/dynatrace/api/builtin/bizevents/http/incoming/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/bizevents/http/outgoing/schema.json
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/schema.json
@@ -150,6 +150,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"metadata": {
 		"addItemButton": "Add new capture rule",
@@ -472,6 +473,15 @@
 					}
 				},
 				"data": {
+					"constraints": [
+						{
+							"customMessage": "Event data field name must be unique.",
+							"type": "UNIQUE",
+							"uniqueProperties": [
+								"name"
+							]
+						}
+					],
 					"description": "Additional attributes for the business event.",
 					"displayName": "Event data",
 					"documentation": "",
@@ -727,5 +737,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.0.3"
+	"version": "1.0.4"
 }

--- a/dynatrace/api/builtin/bizevents/http/outgoing/service.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.3"
+const SchemaVersion = "1.0.4"
 const SchemaID = "builtin:bizevents.http.outgoing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*outgoing.Settings] {

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/data_source_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/data_source_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import (
 )
 
 type DataSourceComplex struct {
-	DataSource DataSourceEnum `json:"dataSource"`     // Possible Values: `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+	DataSource DataSourceEnum `json:"dataSource"`     // Data source. Possible Values: `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 	Path       *string        `json:"path,omitempty"` // [See our documentation](https://dt-url.net/ei034bx)
 }
 
@@ -34,7 +34,7 @@ func (me *DataSourceComplex) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"data_source": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`",
+			Description: "Data source. Possible Values: `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`",
 			Required:    true,
 		},
 		"path": {
@@ -55,6 +55,9 @@ func (me *DataSourceComplex) MarshalHCL(properties hcl.Properties) error {
 func (me *DataSourceComplex) HandlePreconditions() error {
 	if (me.Path == nil) && (slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.DataSource))) {
 		return fmt.Errorf("'path' must be specified if 'data_source' is set to '%v'", me.DataSource)
+	}
+	if (me.Path != nil) && (!slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.DataSource))) {
+		return fmt.Errorf("'path' must not be specified if 'data_source' is set to '%v'", me.DataSource)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/enums.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/enums.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_attribute_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_attribute_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import (
 type EventAttributeComplex struct {
 	Path       *string                        `json:"path,omitempty"`   // [See our documentation](https://dt-url.net/ei034bx)
 	Source     *string                        `json:"source,omitempty"` // Fixed value
-	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 }
 
 func (me *EventAttributeComplex) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *EventAttributeComplex) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`",
+			Description: "Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`",
 			Required:    true,
 		},
 	}
@@ -63,8 +63,14 @@ func (me *EventAttributeComplex) HandlePreconditions() error {
 	if (me.Path == nil) && (slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
 		return fmt.Errorf("'path' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Path != nil) && (!slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
+		return fmt.Errorf("'path' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	if (me.Source == nil) && (slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Source != nil) && (!slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_category_attribute_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_category_attribute_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import (
 type EventCategoryAttributeComplex struct {
 	Path       *string                        `json:"path,omitempty"`   // [See our documentation](https://dt-url.net/ei034bx)
 	Source     *string                        `json:"source,omitempty"` // Fixed value
-	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 }
 
 func (me *EventCategoryAttributeComplex) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *EventCategoryAttributeComplex) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`",
+			Description: "Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`",
 			Required:    true,
 		},
 	}
@@ -66,6 +66,9 @@ func (me *EventCategoryAttributeComplex) HandlePreconditions() error {
 	}
 	if (me.Path == nil) && (slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
 		return fmt.Errorf("'path' must be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Path != nil) && (!slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
+		return fmt.Errorf("'path' must not be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_data_attribute_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_data_attribute_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import (
 type EventDataAttributeComplex struct {
 	Path       *string                        `json:"path,omitempty"`   // [See our documentation](https://dt-url.net/ei034bx)
 	Source     *string                        `json:"source,omitempty"` // Fixed value
-	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`
+	SourceType DataSourceWithStaticStringEnum `json:"sourceType"`       // Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`
 }
 
 func (me *EventDataAttributeComplex) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *EventDataAttributeComplex) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Constant_string`, `Request_body`, `Request_headers`, `Request_method`, `Request_parameters`, `Request_path`, `Request_url`, `Response_body`, `Response_headers`, `Response_statusCode`",
+			Description: "Data source. Possible Values: `constant.string`, `request.body`, `request.headers`, `request.method`, `request.parameters`, `request.path`, `request.url`, `response.body`, `response.headers`, `response.statusCode`",
 			Required:    true,
 		},
 	}
@@ -63,8 +63,14 @@ func (me *EventDataAttributeComplex) HandlePreconditions() error {
 	if (me.Path == nil) && (slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
 		return fmt.Errorf("'path' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Path != nil) && (!slices.Contains([]string{"request.body", "request.headers", "request.parameters", "response.body", "response.headers"}, string(me.SourceType))) {
+		return fmt.Errorf("'path' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	if (me.Source == nil) && (slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Source != nil) && (!slices.Contains([]string{"constant.string"}, string(me.SourceType))) {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_data_field_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/event_data_field_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/matcher_complex.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/matcher_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ func (me *MatcherComplexes) UnmarshalHCL(decoder hcl.Decoder) error {
 type MatcherComplex struct {
 	CaseSensitive *bool              `json:"caseSensitive,omitempty"` // Case sensitive
 	Source        *DataSourceComplex `json:"source"`
-	Type          ComparisonEnum     `json:"type"` // Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`
+	Type          ComparisonEnum     `json:"type"` // Operator. Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`
 	Value         *string            `json:"value,omitempty"`
 }
 
@@ -73,7 +73,7 @@ func (me *MatcherComplex) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`",
+			Description: "Operator. Possible Values: `CONTAINS`, `ENDS_WITH`, `EQUALS`, `EXISTS`, `N_CONTAINS`, `N_ENDS_WITH`, `N_EQUALS`, `N_EXISTS`, `N_STARTS_WITH`, `STARTS_WITH`",
 			Required:    true,
 		},
 		"value": {
@@ -99,6 +99,9 @@ func (me *MatcherComplex) HandlePreconditions() error {
 	}
 	if (me.Value == nil) && (!slices.Contains([]string{"EXISTS", "N_EXISTS"}, string(me.Type))) {
 		return fmt.Errorf("'value' must be specified if 'type' is set to '%v'", me.Type)
+	}
+	if (me.Value != nil) && (slices.Contains([]string{"EXISTS", "N_EXISTS"}, string(me.Type))) {
+		return fmt.Errorf("'value' must not be specified if 'type' is set to '%v'", me.Type)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/bizevents/http/outgoing/settings/settings.go
+++ b/dynatrace/api/builtin/bizevents/http/outgoing/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ type Settings struct {
 	Event       *EventComplex    `json:"event"`           // Event meta data
 	RuleName    string           `json:"ruleName"`        // Rule name
 	Scope       *string          `json:"-" scope:"scope"` // The scope of this setting (HOST, HOST_GROUP). Omit this property if you want to cover the whole environment.
-	Triggers    MatcherComplexes `json:"triggers"`        // Define conditions to trigger business events from incoming web requests. Triggers are connected by AND logic per capture rule. If you set multiple trigger rules, all of them need to be fulfilled to capture a business event.
+	Triggers    MatcherComplexes `json:"triggers"`        // Define conditions to trigger business events from outgoing web requests. Triggers are connected by AND logic per capture rule. If you set multiple trigger rules, all of them need to be fulfilled to capture a business event.
 	InsertAfter string           `json:"-"`
 }
 
@@ -63,7 +63,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"triggers": {
 			Type:        schema.TypeList,
-			Description: "Define conditions to trigger business events from incoming web requests. Triggers are connected by AND logic per capture rule. If you set multiple trigger rules, all of them need to be fulfilled to capture a business event.",
+			Description: "Define conditions to trigger business events from outgoing web requests. Triggers are connected by AND logic per capture rule. If you set multiple trigger rules, all of them need to be fulfilled to capture a business event.",
 			Required:    true,
 			Elem:        &schema.Resource{Schema: new(MatcherComplexes).Schema()},
 			MinItems:    1,

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/schema.json
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/schema.json
@@ -109,6 +109,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"metadata": {
 		"addItemButton": "Add rule",
@@ -212,6 +213,17 @@
 				"$ref": "#/types/EntryBoundary"
 			}
 		},
+		"json-configuration": {
+			"description": "",
+			"displayName": "Detect JSON format",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/JSONConfiguration"
+			}
+		},
 		"matchers": {
 			"description": "",
 			"displayName": "",
@@ -306,6 +318,26 @@
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
 					"type": "text"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"JSONConfiguration": {
+			"description": "",
+			"displayName": "JSONConfiguration",
+			"documentation": "",
+			"properties": {
+				"formatDetection": {
+					"description": "",
+					"displayName": "",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "boolean"
 				}
 			},
 			"summaryPattern": "",
@@ -429,6 +461,11 @@
 					"displayName": "Entry boundary",
 					"id": "entryBoundary",
 					"propertyRef": "entry-boundary/pattern"
+				},
+				{
+					"displayName": "JSON Configuration",
+					"id": "jsonConf",
+					"propertyRef": "json-configuration/formatDetection"
 				}
 			],
 			"emptyState": {
@@ -436,5 +473,5 @@
 			}
 		}
 	},
-	"version": "1.0.17"
+	"version": "1.0.18"
 }

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/service.go
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.17"
+const SchemaVersion = "1.0.18"
 const SchemaID = "builtin:logmonitoring.timestamp-configuration"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*timestampconfiguration.Settings] {

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings/enums.go
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings/enums.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings/jsonconfiguration.go
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings/jsonconfiguration.go
@@ -22,28 +22,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-type EntryBoundary struct {
-	Pattern *string `json:"pattern,omitempty"`
+type JSONConfiguration struct {
+	FormatDetection *bool `json:"formatDetection,omitempty"`
 }
 
-func (me *EntryBoundary) Schema() map[string]*schema.Schema {
+func (me *JSONConfiguration) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"pattern": {
-			Type:        schema.TypeString,
+		"format_detection": {
+			Type:        schema.TypeBool,
 			Description: "no documentation available",
 			Optional:    true, // nullable
 		},
 	}
 }
 
-func (me *EntryBoundary) MarshalHCL(properties hcl.Properties) error {
+func (me *JSONConfiguration) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"pattern": me.Pattern,
+		"format_detection": me.FormatDetection,
 	})
 }
 
-func (me *EntryBoundary) UnmarshalHCL(decoder hcl.Decoder) error {
+func (me *JSONConfiguration) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"pattern": &me.Pattern,
+		"format_detection": &me.FormatDetection,
 	})
 }

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings/matcher.go
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings/matcher.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ func (me *Matchers) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type Matcher struct {
-	Attribute MatcherType `json:"attribute"` // Possible Values: `Container_name`, `Dt_entity_container_group`, `Dt_entity_process_group`, `Host_tag`, `K8s_container_name`, `K8s_deployment_name`, `K8s_namespace_name`, `K8s_pod_annotation`, `K8s_pod_label`, `K8s_workload_kind`, `K8s_workload_name`, `Log_source`, `Log_source_origin`, `Process_technology`
+	Attribute MatcherType `json:"attribute"` // Possible Values: `container.name`, `dt.entity.container_group`, `dt.entity.process_group`, `host.tag`, `k8s.container.name`, `k8s.deployment.name`, `k8s.namespace.name`, `k8s.pod.annotation`, `k8s.pod.label`, `k8s.workload.kind`, `k8s.workload.name`, `log.source`, `log.source.origin`, `process.technology`
 	Operator  Operator    `json:"operator"`  // Possible Values: `MATCHES`
 	Values    []string    `json:"values"`
 }
@@ -54,7 +54,7 @@ func (me *Matcher) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"attribute": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Container_name`, `Dt_entity_container_group`, `Dt_entity_process_group`, `Host_tag`, `K8s_container_name`, `K8s_deployment_name`, `K8s_namespace_name`, `K8s_pod_annotation`, `K8s_pod_label`, `K8s_workload_kind`, `K8s_workload_name`, `Log_source`, `Log_source_origin`, `Process_technology`",
+			Description: "Possible Values: `container.name`, `dt.entity.container_group`, `dt.entity.process_group`, `host.tag`, `k8s.container.name`, `k8s.deployment.name`, `k8s.namespace.name`, `k8s.pod.annotation`, `k8s.pod.label`, `k8s.workload.kind`, `k8s.workload.name`, `log.source`, `log.source.origin`, `process.technology`",
 			Required:    true,
 		},
 		"operator": {
@@ -66,8 +66,7 @@ func (me *Matcher) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeSet,
 			Description: "no documentation available",
 			Required:    true,
-
-			Elem: &schema.Schema{Type: schema.TypeString},
+			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 	}
 }

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings/settings.go
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,16 +23,17 @@ import (
 )
 
 type Settings struct {
-	Config_item_title   string         `json:"config-item-title"`           // Name
-	Date_search_limit   *int           `json:"date-search-limit,omitempty"` // Defines the number of characters in every log line (starting from the first character in the line) where the timestamp is searched.
-	Date_time_pattern   string         `json:"date-time-pattern"`           // Date-time pattern
-	Enabled             bool           `json:"enabled"`                     // This setting is enabled (`true`) or disabled (`false`)
-	Entry_boundary      *EntryBoundary `json:"entry-boundary,omitempty"`    // Optional field. Enter a fragment of the line text that starts the entry. No support for wildcards - the text is treated literally.
-	Matchers            Matchers       `json:"matchers,omitempty"`
-	Scope               *string        `json:"-" scope:"scope"`               // The scope of this setting (HOST, KUBERNETES_CLUSTER, HOST_GROUP). Omit this property if you want to cover the whole environment.
-	Skip_indented_lines *bool          `json:"skip-indented-lines,omitempty"` // Don't parse timestamps in lines starting with white character
-	Timezone            string         `json:"timezone"`                      // Timezone
-	InsertAfter         string         `json:"-"`
+	Config_item_title   string             `json:"config-item-title"`            // Name
+	Date_search_limit   *int               `json:"date-search-limit,omitempty"`  // Defines the number of characters in every log line (starting from the first character in the line) where the timestamp is searched.
+	Date_time_pattern   string             `json:"date-time-pattern"`            // Date-time pattern
+	Enabled             bool               `json:"enabled"`                      // This setting is enabled (`true`) or disabled (`false`)
+	Entry_boundary      *EntryBoundary     `json:"entry-boundary,omitempty"`     // Optional field. Enter a fragment of the line text that starts the entry. No support for wildcards - the text is treated literally.
+	Json_configuration  *JSONConfiguration `json:"json-configuration,omitempty"` // Detect JSON format
+	Matchers            Matchers           `json:"matchers,omitempty"`
+	Scope               *string            `json:"-" scope:"scope"`               // The scope of this setting (HOST, KUBERNETES_CLUSTER, HOST_GROUP). Omit this property if you want to cover the whole environment.
+	Skip_indented_lines *bool              `json:"skip-indented-lines,omitempty"` // Don't parse timestamps in lines starting with white character
+	Timezone            string             `json:"timezone"`                      // Timezone
+	InsertAfter         string             `json:"-"`
 }
 
 func (me *Settings) Name() string {
@@ -66,6 +67,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Optional field. Enter a fragment of the line text that starts the entry. No support for wildcards - the text is treated literally.",
 			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(EntryBoundary).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"json_configuration": {
+			Type:        schema.TypeList,
+			Description: "Detect JSON format",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(JSONConfiguration).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -109,6 +118,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"date_time_pattern":   me.Date_time_pattern,
 		"enabled":             me.Enabled,
 		"entry_boundary":      me.Entry_boundary,
+		"json_configuration":  me.Json_configuration,
 		"matchers":            me.Matchers,
 		"scope":               me.Scope,
 		"skip_indented_lines": me.Skip_indented_lines,
@@ -124,6 +134,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"date_time_pattern":   &me.Date_time_pattern,
 		"enabled":             &me.Enabled,
 		"entry_boundary":      &me.Entry_boundary,
+		"json_configuration":  &me.Json_configuration,
 		"matchers":            &me.Matchers,
 		"scope":               &me.Scope,
 		"skip_indented_lines": &me.Skip_indented_lines,

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/testdata/terraform/example_b.tf
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/testdata/terraform/example_b.tf
@@ -1,0 +1,17 @@
+resource "dynatrace_log_timestamp" "#name#" {
+  enabled               = false
+  config_item_title = "#name#"
+  date_time_pattern = "%m/%d/%Y %I:%M:%S %p"
+  scope                 = "environment"
+  timezone              = "America/Detroit"
+  matchers {
+    matcher {
+      attribute = "container.name"
+      operator  = "MATCHES"
+      values    = [ "terraform" ]
+    }
+  }
+  json_configuration {
+    format_detection = true
+  }
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.bizevents.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_bizevents_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
@@ -6,14 +6,15 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"deletionConstraints": [
 		{
 			"schemaIds": [
-				"builtin:openpipeline.bizevents.compositions",
 				"builtin:openpipeline.bizevents.routing",
+				"builtin:openpipeline.bizevents.pipeline-groups",
 				"builtin:openpipeline.bizevents.ingest-sources"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.bizevents.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_bizevents_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.bizevents.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.davis.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_davis_events_ingestsources" "maximal-source"
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
@@ -6,13 +6,14 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"deletionConstraints": [
 		{
 			"schemaIds": [
-				"builtin:openpipeline.davis.events.compositions",
+				"builtin:openpipeline.davis.events.pipeline-groups",
 				"builtin:openpipeline.davis.events.routing",
 				"builtin:openpipeline.davis.events.ingest-sources"
 			],
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.davis.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_davis_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.davis.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.davis.problems.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_davis_problems_ingestsources" "maximal-sourc
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -14,7 +15,7 @@
 			"schemaIds": [
 				"builtin:openpipeline.davis.problems.routing",
 				"builtin:openpipeline.davis.problems.ingest-sources",
-				"builtin:openpipeline.davis.problems.compositions"
+				"builtin:openpipeline.davis.problems.pipeline-groups"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
 		}
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.davis.problems.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.davis.problems.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_events_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/schema.json
@@ -6,15 +6,16 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"deletionConstraints": [
 		{
 			"schemaIds": [
+				"builtin:openpipeline.events.pipeline-groups",
 				"builtin:openpipeline.events.routing",
-				"builtin:openpipeline.events.ingest-sources",
-				"builtin:openpipeline.events.compositions"
+				"builtin:openpipeline.events.ingest-sources"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
 		}
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.sdlc.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_events_sdlc_ingestsources" "maximal-source" 
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/schema.json
@@ -6,13 +6,14 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"deletionConstraints": [
 		{
 			"schemaIds": [
-				"builtin:openpipeline.events.sdlc.compositions",
+				"builtin:openpipeline.events.sdlc.pipeline-groups",
 				"builtin:openpipeline.events.sdlc.routing",
 				"builtin:openpipeline.events.sdlc.ingest-sources"
 			],
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.sdlc.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.sdlc.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.security.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_events_security_ingestsources" "maximal-sour
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
@@ -6,15 +6,16 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"deletionConstraints": [
 		{
 			"schemaIds": [
-				"builtin:openpipeline.events.security.compositions",
 				"builtin:openpipeline.events.security.ingest-sources",
-				"builtin:openpipeline.events.security.routing"
+				"builtin:openpipeline.events.security.routing",
+				"builtin:openpipeline.events.security.pipeline-groups"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
 		}
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.security.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_events_security_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.events.security.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.logs.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_logs_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -14,7 +15,7 @@
 			"schemaIds": [
 				"builtin:openpipeline.logs.ingest-sources",
 				"builtin:openpipeline.logs.routing",
-				"builtin:openpipeline.logs.compositions"
+				"builtin:openpipeline.logs.pipeline-groups"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
 		}
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.logs.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_logs_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.logs.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.metrics.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_metrics_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -13,8 +14,8 @@
 		{
 			"schemaIds": [
 				"builtin:openpipeline.metrics.routing",
-				"builtin:openpipeline.metrics.ingest-sources",
-				"builtin:openpipeline.metrics.compositions"
+				"builtin:openpipeline.metrics.pipeline-groups",
+				"builtin:openpipeline.metrics.ingest-sources"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
 		}
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.metrics.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_metrics_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.metrics.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.security.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_security_events_ingestsources" "maximal-sour
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -14,7 +15,7 @@
 			"schemaIds": [
 				"builtin:openpipeline.security.events.routing",
 				"builtin:openpipeline.security.events.ingest-sources",
-				"builtin:openpipeline.security.events.compositions"
+				"builtin:openpipeline.security.events.pipeline-groups"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
 		}
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.security.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_security_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.security.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.spans.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_spans_ingestsources" "maximal-source" {
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -13,8 +14,8 @@
 		{
 			"schemaIds": [
 				"builtin:openpipeline.spans.routing",
-				"builtin:openpipeline.spans.ingest-sources",
-				"builtin:openpipeline.spans.compositions"
+				"builtin:openpipeline.spans.pipeline-groups",
+				"builtin:openpipeline.spans.ingest-sources"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
 		}
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.spans.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_spans_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.spans.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.system.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_system_events_ingestsources" "maximal-source
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
@@ -6,13 +6,14 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"deletionConstraints": [
 		{
 			"schemaIds": [
-				"builtin:openpipeline.system.events.compositions",
+				"builtin:openpipeline.system.events.pipeline-groups",
 				"builtin:openpipeline.system.events.routing",
 				"builtin:openpipeline.system.events.ingest-sources"
 			],
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.system.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_system_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   davis {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.system.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.user.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_user_events_ingestsources" "maximal-source" 
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -13,7 +14,7 @@
 		{
 			"schemaIds": [
 				"builtin:openpipeline.user.events.routing",
-				"builtin:openpipeline.user.events.compositions",
+				"builtin:openpipeline.user.events.pipeline-groups",
 				"builtin:openpipeline.user.events.ingest-sources"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.user.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_user_events_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   metric_extraction {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.user.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
@@ -6,6 +6,7 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -239,6 +240,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -288,6 +290,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "boolean"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Ingest source metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"pathSegment": {
 			"constraints": [
@@ -1242,6 +1270,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3022,5 +3097,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.usersessions.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package ingestsources
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/settings.go
@@ -29,6 +29,7 @@ type Settings struct {
 	DefaultBucket *string          `json:"defaultBucket,omitempty"` // Default Bucket
 	DisplayName   string           `json:"displayName"`             // Endpoint display name
 	Enabled       bool             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
+	MetadataList  MetadataEntries  `json:"metadataList,omitempty"`  // Ingest source metadata list
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
@@ -52,6 +53,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Ingest source metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"path_segment": {
 			Type:        schema.TypeString,
@@ -93,6 +102,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"default_bucket": me.DefaultBucket,
 		"display_name":   me.DisplayName,
 		"enabled":        me.Enabled,
+		"metadata_list":  me.MetadataList,
 		"path_segment":   me.PathSegment,
 		"processing":     me.Processing,
 		"source":         me.Source,
@@ -108,6 +118,9 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.Source == nil) && (string(me.SourceType) == "extension") {
 		return fmt.Errorf("'source' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}
+	if (me.Source != nil) && (string(me.SourceType) != "extension") {
+		return fmt.Errorf("'source' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
 	return nil
 }
 
@@ -116,6 +129,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"default_bucket": &me.DefaultBucket,
 		"display_name":   &me.DisplayName,
 		"enabled":        &me.Enabled,
+		"metadata_list":  &me.MetadataList,
 		"path_segment":   &me.PathSegment,
 		"processing":     &me.Processing,
 		"source":         &me.Source,

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/static_routing.go
@@ -66,6 +66,9 @@ func (me *StaticRouting) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/testdata/terraform/maximal-example.tf
@@ -8,6 +8,12 @@ resource "dynatrace_openpipeline_v2_usersessions_ingestsources" "maximal-source"
     builtin_pipeline_id = "default"
   }
   default_bucket = "default_events"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
@@ -6,15 +6,16 @@
 		{
 			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"deletionConstraints": [
 		{
 			"schemaIds": [
+				"builtin:openpipeline.usersessions.pipeline-groups",
 				"builtin:openpipeline.usersessions.routing",
-				"builtin:openpipeline.usersessions.ingest-sources",
-				"builtin:openpipeline.usersessions.compositions"
+				"builtin:openpipeline.usersessions.ingest-sources"
 			],
 			"type": "REFERENTIAL_INTEGRITY"
 		}
@@ -217,6 +218,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -299,6 +301,32 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"metadataList": {
+			"constraints": [
+				{
+					"type": "UNIQUE",
+					"uniqueProperties": [
+						"entryKey"
+					]
+				}
+			],
+			"description": "",
+			"displayName": "Pipeline metadata list",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/MetadataEntry"
+				}
+			},
+			"maxObjects": 32,
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"metricExtraction": {
 			"description": "",
@@ -1237,6 +1265,53 @@
 				}
 			},
 			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"MetadataEntry": {
+			"description": "",
+			"displayName": "MetadataEntry",
+			"documentation": "",
+			"properties": {
+				"entryKey": {
+					"constraints": [
+						{
+							"type": "NOT_BLANK"
+						},
+						{
+							"maxLength": 256,
+							"minLength": 3,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Metadata entry key",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				},
+				"entryValue": {
+					"constraints": [
+						{
+							"maxLength": 1024,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "",
+					"displayName": "Metadata entry value",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "text"
+				}
+			},
+			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -2956,5 +3031,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.usersessions.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/metadata_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/metadata_entry.go
@@ -1,0 +1,79 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package pipelines
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MetadataEntries []*MetadataEntry
+
+func (me *MetadataEntries) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"metadata": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(MetadataEntry).Schema()},
+		},
+	}
+}
+
+func (me MetadataEntries) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("metadata", me)
+}
+
+func (me *MetadataEntries) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("metadata", me)
+}
+
+type MetadataEntry struct {
+	EntryKey   string  `json:"entryKey"`             // Metadata entry key
+	EntryValue *string `json:"entryValue,omitempty"` // Metadata entry value
+}
+
+func (me *MetadataEntry) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"entry_key": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry key",
+			Required:    true,
+		},
+		"entry_value": {
+			Type:        schema.TypeString,
+			Description: "Metadata entry value",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *MetadataEntry) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"entry_key":   me.EntryKey,
+		"entry_value": me.EntryValue,
+	})
+}
+
+func (me *MetadataEntry) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"entry_key":   &me.EntryKey,
+		"entry_value": &me.EntryValue,
+	})
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareHistogramMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -94,8 +94,8 @@ func (me *SamplingAwareValueMetricAttributes) HandlePreconditions() error {
 	if (me.Field == nil) && (string(me.Measurement) != "duration") {
 		me.Field = opt.NewString("")
 	}
-	if (me.DefaultValue == nil) && (string(me.Measurement) != "duration") {
-		return fmt.Errorf("'default_value' must be specified if 'measurement' is set to '%v'", me.Measurement)
+	if (me.DefaultValue != nil) && (string(me.Measurement) == "duration") {
+		return fmt.Errorf("'default_value' must not be specified if 'measurement' is set to '%v'", me.Measurement)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
@@ -23,18 +23,19 @@ import (
 )
 
 type Settings struct {
-	CostAllocation           *Stage `json:"costAllocation,omitempty"`           // Cost allocation stage
-	CustomID                 string `json:"customId"`                           // Custom pipeline id
-	DataExtraction           *Stage `json:"dataExtraction,omitempty"`           // Data extraction stage
-	Davis                    *Stage `json:"davis,omitempty"`                    // Davis event extraction stage
-	DisplayName              string `json:"displayName"`                        // Display name
-	MetricExtraction         *Stage `json:"metricExtraction,omitempty"`         // Metrics extraction stage
-	Processing               *Stage `json:"processing,omitempty"`               // Processing stage
-	ProductAllocation        *Stage `json:"productAllocation,omitempty"`        // Product allocation stage
-	SecurityContext          *Stage `json:"securityContext,omitempty"`          // Security context stage
-	SmartscapeEdgeExtraction *Stage `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
-	SmartscapeNodeExtraction *Stage `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
-	Storage                  *Stage `json:"storage,omitempty"`                  // Storage stage
+	CostAllocation           *Stage          `json:"costAllocation,omitempty"`           // Cost allocation stage
+	CustomID                 string          `json:"customId"`                           // Custom pipeline id
+	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
+	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
+	DisplayName              string          `json:"displayName"`                        // Display name
+	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
+	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
+	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
+	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
+	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
+	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
+	Storage                  *Stage          `json:"storage,omitempty"`                  // Storage stage
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -72,6 +73,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Display name",
 			Required:    true,
+		},
+		"metadata_list": {
+			Type:        schema.TypeList,
+			Description: "Pipeline metadata list",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(MetadataEntries).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"metric_extraction": {
 			Type:        schema.TypeList,
@@ -139,6 +148,7 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
@@ -156,6 +166,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/testdata/terraform/maximal-example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/testdata/terraform/maximal-example.tf
@@ -1,6 +1,12 @@
 resource "dynatrace_openpipeline_v2_usersessions_pipelines" "max-pipeline" {
   display_name = "Warning pipeline"
   custom_id = "pipeline_Warning_pipeline_2773_tf_#name#"
+  metadata_list {
+    metadata {
+      entry_key = "environment"
+      entry_value = "production"
+    }
+  }
   processing {
     processors {
       processor {

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
@@ -31,6 +31,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -181,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.21"
+	"version": "1.26.1"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.21"
+const SchemaVersion = "1.26.1"
 const SchemaID = "builtin:openpipeline.usersessions.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
@@ -109,6 +109,9 @@ func (me *RoutingEntry) HandlePreconditions() error {
 	if (me.BuiltinPipelineID == nil) && (string(me.PipelineType) == "builtin") {
 		return fmt.Errorf("'builtin_pipeline_id' must be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
 	}
+	if (me.BuiltinPipelineID != nil) && (string(me.PipelineType) != "builtin") {
+		return fmt.Errorf("'builtin_pipeline_id' must not be specified if 'pipeline_type' is set to '%v'", me.PipelineType)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/synthetic/browser/performancethresholds/schema.json
+++ b/dynatrace/api/builtin/synthetic/browser/performancethresholds/schema.json
@@ -14,6 +14,7 @@
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -147,6 +148,12 @@
 						{
 							"minimum": 0,
 							"type": "RANGE"
+						},
+						{
+							"customMessage": "Threshold must be greater than 0.",
+							"customValidatorId": "greater-than-zero-validator",
+							"skipAsyncValidation": false,
+							"type": "CUSTOM_VALIDATOR_REF"
 						}
 					],
 					"default": 10,
@@ -181,5 +188,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.7.4"
+	"version": "1.8.1"
 }

--- a/dynatrace/api/builtin/synthetic/browser/performancethresholds/service.go
+++ b/dynatrace/api/builtin/synthetic/browser/performancethresholds/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.7.4"
+const SchemaVersion = "1.8.1"
 const SchemaID = "builtin:synthetic.browser.performance-thresholds"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*performancethresholds.Settings] {

--- a/dynatrace/api/builtin/synthetic/browser/performancethresholds/settings/settings.go
+++ b/dynatrace/api/builtin/synthetic/browser/performancethresholds/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/synthetic/browser/performancethresholds/settings/threshold_entry.go
+++ b/dynatrace/api/builtin/synthetic/browser/performancethresholds/settings/threshold_entry.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
#### **Why** this PR?
Some APIs have changed with Dynatrace version 1.328. Therefore, the Terraform resources also need updating.

#### **What** has changed?
- For all OpenPipeline V2 resources
  - a `metadata_list` argument was added
  - some precondition handling changed to prevent misconfiguration, but this should not affect users
- For `dynatrace_log_timestamp` 
  - the argument `json_configuration` was added. 
  - some precondition handling changed to prevent misconfiguration, but this should not affect users
  - possible enum values are now documented properly
- For  `dynatrace_business_events_oneagent` and `dynatrace_business_events_oneagent_outgoing`
  - some precondition handling changed to prevent misconfiguration, but this should not affect users
  - possible enum values are now documented properly
- For `dynatrace_browser_monitor_performance`
  - Version bump, date in license header updated, but no substantial changes otherwise.

#### How is it **tested**?
For `dynatrace_log_timestamp` the `json_configuration` argument is added to the test resource.
For all OpenPipeline V2 resources, `metadata_list` has been added to one test file each.

#### How does it affect **users**?
- New arguments added to openpipeline resources and `dynatrace_log_timestamp`
- Fixes to the documentation

**Issue:**
NOISSUE