### PR TITLE
doc(azure-connection): Add resource documentation

### DIFF
--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/azure_connector_client_secret.tf
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/azure_connector_client_secret.tf
@@ -29,7 +29,7 @@ resource "azuread_application_password" "example" {
 
 # Create Azure connection
 resource "dynatrace_azure_connection" "example" {
-  name = "Example Azure Connector - Secret"
+  name = "#name#"
   type = "clientSecret"
   client_secret {
     client_secret  = azuread_application_password.example.value

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/azure_connector_federated_identity_credential.tf
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/azure_connector_federated_identity_credential.tf
@@ -36,7 +36,7 @@ resource "azuread_application_registration" "example" {
 
 # Create basic Azure connection
 resource "dynatrace_azure_connection" "example" {
-  name = "Example Azure Connector"
+  name = "#name#"
   type = "federatedIdentityCredential"
   federated_identity_credential {
     consumers = [

--- a/templates/resources/azure_connection.md.tmpl
+++ b/templates/resources/azure_connection.md.tmpl
@@ -1,0 +1,53 @@
+---
+layout: ""
+page_title: "dynatrace_azure_connection Resource - terraform-provider-dynatrace"
+subcategory: "Connections"
+description: |-
+  The resource `dynatrace_azure_connection` covers configuration for Azure connections
+---
+
+# dynatrace_azure_connection (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Requirements
+This resource can be used to create connections using an Azure client secret or federated identity credential. For the latter case, this resource must be used together with a `dynatrace_azure_connection_authentication` resource.
+Ensure you configure both resources together for a valid Azure connection.
+An example of how to set up a connection using a client secret or a federated identiy credential can be found in the [Resource Example Usage](#resource-example-usage) section below.
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- Settings API - https://www.dynatrace.com/support/help/dynatrace-api/environment-api/settings (schemaId: `builtin:hyperscaler-authentication.connections.azure`)
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_azure_connection` downloads all existing Azure connections.
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+### Azure connection with client secret authentication
+{{ tffile "dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/azure_connector_client_secret.tf" }}
+
+### Azure connection with federated identity credential authentication
+{{ tffile "dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/azure_connector_federated_identity_credential.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/azure_connection_authentication.md.tmpl
+++ b/templates/resources/azure_connection_authentication.md.tmpl
@@ -1,0 +1,56 @@
+---
+layout: ""
+page_title: "dynatrace_azure_connection_authentication Resource - terraform-provider-dynatrace"
+subcategory: "Connections"
+description: |-
+  The resource `dynatrace_azure_connection_authentication` configures federated identity credentials for Azure connections
+---
+
+# dynatrace_azure_connection_authentication (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Requirements
+This resource must be used in combination with the `dynatrace_azure_connection` resource to manage a connection using federated identity credential.
+An example of how to set up both resources can be found in the [Resource Example Usage](#resource-example-usage) section below.
+
+## Limitations
+If you are creating the `dynatrace_azure_connection_authentication` and the `azuread_application_federated_identity_credential` it is referencing in the same invocation of `terraform apply`, be aware that due to eventual consistency in Azure, the creation of the federated identity credential might not be fully propagated when the `dynatrace_azure_connection_authentication` resource is being created. To mitigate this, we retry the creation of the `dynatrace_azure_connection_authentication` resource with a default timeout of 2 minutes.
+If you desire a different timeout, you can adjust it using the `timeouts` block in the `dynatrace_azure_connection_authentication` resource as shown in the example below.
+    
+The following is an example of the error you might encounter due to this limitation:
+```
+Error: AADSTS00000: The client '01233456-0123-0123-0123-012345678901'(Application) has no configured federated identity credentials. Trace ID: 01233456-0123-0123-0123-012345678901 Correlation ID: 01233456-0123-0123-0123-012345678901 Timestamp: 2025-12-04 15:34:59Z
+```
+
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- Settings API - https://www.dynatrace.com/support/help/dynatrace-api/environment-api/settings (schemaId: `builtin:hyperscaler-authentication.connections.azure`)
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_azure_connection_authentication` downloads all existing Azure connections.
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/azure_connector_federated_identity_credential.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
#### **Why** this PR?
The PR adds the documentation templates for the `dynatrace_azure_connection` and `dynatrace_azure_connection_authentication` resources.

#### **What** has changed and **how** does it do it?
Documentation templates that include references to the updated example Terraform files.

#### How is it **tested**?
N/A

#### How does it affect **users**?
Documentation is now available for these resources

**Issue:** CA-17189