### PR TITLE
feat: Follow-up to Terraform resource updates for Dynatrace version 328

### DIFF
--- a/docs/resources/aws_connection.md
+++ b/docs/resources/aws_connection.md
@@ -48,7 +48,7 @@ The full documentation of the export feature is available [here](https://dt-url.
 
 ```terraform
 resource "dynatrace_aws_connection" "test-aws-connection" {
-  name = "#name#"
+  name = "AWS connection name"
   web_identity {
     consumers = ["APP:dynatrace.aws.connector"]
   }
@@ -63,7 +63,7 @@ resource "aws_iam_openid_connect_provider" "dynatrace-oidc-provider" {
 }
 
 resource "aws_iam_role" "example_role" {
-  name = "#name#"
+  name = "AWS-iam-role-name"
   assume_role_policy = jsonencode(
     {
         "Version": "2012-10-17",
@@ -116,7 +116,7 @@ resource "dynatrace_aws_connection_role_arn" "test-aws-connection-arn" {
 
 Optional:
 
-- `consumers` (Set of String) Dynatrace integrations that can use this connection. Possible values: `DA` (Data Acquisition Deprecated)`, `SVC:com.dynatrace.da` (Data Acquisition), `APP:dynatrace.biz.carbon` (Cost & Carbon Optimization) and `NONE`
+- `consumers` (Set of String) Dynatrace integrations that can use this connection. Possible Values: `APP:dynatrace.biz.carbon` (Cost & Carbon Optimization), `DA` (Data Acquisition Deprecated), `SVC:com.dynatrace.bo` (Business Observability), `SVC:com.dynatrace.da` (Data Acquisition), `SVC:com.dynatrace.openpipeline` (OpenPipeline) and `NONE`
 
 
 <a id="nestedblock--web_identity"></a>

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/service.go
@@ -33,7 +33,7 @@ import (
 )
 
 const SchemaID = "builtin:hyperscaler-authentication.connections.aws"
-const SchemaVersion = "0.0.15"
+const SchemaVersion = "0.0.21"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*role_arn.Settings] {
 	return &service{

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/schema.json
@@ -1,327 +1,280 @@
 {
-    "dynatrace": "1",
-    "schemaId": "builtin:hyperscaler-authentication.connections.aws",
-    "displayName": "Connections to AWS environments",
-    "description": "Connections to AWS for Dynatrace integrations",
-    "documentation": "",
-    "version": "0.0.15",
-    "multiObject": true,
-    "ordered": false,
-    "maxObjects": 3000,
-    "allowedScopes": [
-        "environment"
-    ],
-    "enums": {
-        "ConsumersOfAwsRoleBasedAuthentication": {
-            "displayName": "Consumers",
-            "description": "Dynatrace integrations that can use this connection",
-            "documentation": "",
-            "items": [
-                {
-                    "value": "DA",
-                    "displayName": "(Deprecated) Data Acquisition"
-                },
-                {
-                    "value": "SVC:com.dynatrace.da",
-                    "displayName": "Data Acquisition"
-                },
-                {
-                    "value": "APP:dynatrace.biz.carbon",
-                    "displayName": "Cost & Carbon Optimization"
-                },
-                {
-                    "value": "NONE",
-                    "displayName": "None"
-                }
-            ],
-            "type": "enum"
-        },
-        "ConsumersOfAwsWebIdentity": {
-            "displayName": "Consumers",
-            "description": "Dynatrace integrations that can use this connection",
-            "documentation": "",
-            "items": [
-                {
-                    "value": "APP:dynatrace.aws.connector",
-                    "displayName": "AWS Connector"
-                },
-                {
-                    "value": "APP:dynatrace.biz.carbon",
-                    "displayName": "Cost & Carbon Optimization"
-                }
-            ],
-            "type": "enum"
-        },
-        "Type": {
-            "displayName": "Type",
-            "description": "",
-            "documentation": "",
-            "items": [
-                {
-                    "value": "awsRoleBasedAuthentication",
-                    "displayName": "AWS IAM Cross-account Role-based authentication"
-                },
-                {
-                    "value": "awsWebIdentity",
-                    "displayName": "AWS Web Identity"
-                }
-            ],
-            "type": "enum"
-        }
-    },
-    "types": {
-        "AwsRoleBasedAuthenticationConfig": {
-            "version": "0",
-            "versionInfo": "",
-            "displayName": "",
-            "summaryPattern": "",
-            "searchPattern": "",
-            "description": "",
-            "documentation": "",
-            "properties": {
-                "roleArn": {
-                    "displayName": "AWS IAM Role ARN",
-                    "description": "The ARN of the AWS role that should be assumed",
-                    "documentation": "",
-                    "type": "text",
-                    "nullable": false,
-                    "constraints": [
-                        {
-                            "type": "LENGTH",
-                            "maxLength": 2048
-                        },
-                        {
-                            "type": "PATTERN",
-                            "customMessage": "Invalid AWS IAM Role ARN, it does not adhere to pattern ^$|arn:aws:iam::(?:aws|\\\\d+?):role\\\\/.*$",
-                            "pattern": "^$|arn:aws:iam::(?:aws|\\d+?):role\\/.*$"
-                        }
-                    ],
-                    "maxObjects": 1,
-                    "modificationPolicy": "DEFAULT",
-                    "default": ""
-                },
-                "consumers": {
-                    "displayName": "Consumers",
-                    "description": "Dynatrace integrations that can use this connection",
-                    "documentation": "",
-                    "type": "list",
-                    "items": {
-                        "displayName": "",
-                        "description": "",
-                        "documentation": "",
-                        "type": {
-                            "$ref": "#/enums/ConsumersOfAwsRoleBasedAuthentication"
-                        }
-                    },
-                    "nullable": false,
-                    "minObjects": 0,
-                    "maxObjects": 1,
-                    "modificationPolicy": "DEFAULT",
-                    "default": [
-                        "SVC:com.dynatrace.da"
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "AwsWebIdentity": {
-            "version": "0",
-            "versionInfo": "",
-            "displayName": "",
-            "summaryPattern": "",
-            "searchPattern": "",
-            "description": "",
-            "documentation": "",
-            "properties": {
-                "roleArn": {
-                    "displayName": "AWS IAM Role ARN",
-                    "description": "The ARN of the AWS role that should be assumed",
-                    "documentation": "",
-                    "type": "text",
-                    "nullable": false,
-                    "constraints": [
-                        {
-                            "type": "LENGTH",
-                            "maxLength": 2048
-                        },
-                        {
-                            "type": "PATTERN",
-                            "customMessage": "Role must be valid with given pattern ^$|arn:(?:aws|aws-cn|aws-us-gov):iam::(?:aws|\\d+?):role\\/.*$",
-                            "pattern": "^$|arn:(?:aws|aws-cn|aws-us-gov):iam::(?:aws|\\d+?):role\\/.*$"
-                        }
-                    ],
-                    "maxObjects": 1,
-                    "modificationPolicy": "DEFAULT",
-                    "default": ""
-                },
-                "consumers": {
-                    "displayName": "Consumers",
-                    "description": "Dynatrace integrations that can use this connection",
-                    "documentation": "",
-                    "type": "list",
-                    "items": {
-                        "displayName": "",
-                        "description": "",
-                        "documentation": "",
-                        "type": {
-                            "$ref": "#/enums/ConsumersOfAwsWebIdentity"
-                        }
-                    },
-                    "nullable": false,
-                    "minObjects": 0,
-                    "maxObjects": 1,
-                    "modificationPolicy": "DEFAULT",
-                    "default": [
-                        "APP:dynatrace.aws.connector"
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "MetaData": {
-            "version": "0",
-            "versionInfo": "",
-            "displayName": "",
-            "summaryPattern": "",
-            "searchPattern": "",
-            "description": "",
-            "documentation": "",
-            "properties": {
-                "type": {
-                    "displayName": "Type",
-                    "description": "Type",
-                    "documentation": "",
-                    "type": "text",
-                    "nullable": false,
-                    "constraints": [
-                        {
-                            "type": "LENGTH",
-                            "maxLength": 500,
-                            "minLength": 1
-                        }
-                    ],
-                    "maxObjects": 1,
-                    "modificationPolicy": "NEVER",
-                    "default": "connections"
-                },
-                "subType": {
-                    "displayName": "Type",
-                    "description": "Type",
-                    "documentation": "",
-                    "type": "list",
-                    "items": {
-                        "displayName": "",
-                        "description": "",
-                        "documentation": "",
-                        "type": "text",
-                        "constraints": [
-                            {
-                                "type": "LENGTH",
-                                "maxLength": 500,
-                                "minLength": 1
-                            }
-                        ]
-                    },
-                    "nullable": false,
-                    "minObjects": 0,
-                    "maxObjects": 100,
-                    "modificationPolicy": "NEVER",
-                    "default": [
-                        "ingest",
-                        "automation"
-                    ]
-                }
-            },
-            "type": "object"
-        }
-    },
-    "properties": {
-        "name": {
-            "displayName": "Name",
-            "description": "The name of the connection",
-            "documentation": "",
-            "type": "text",
-            "nullable": false,
-            "constraints": [
-                {
-                    "type": "LENGTH",
-                    "maxLength": 100,
-                    "minLength": 3
-                },
-                {
-                    "type": "PATTERN",
-                    "customMessage": "The symbol : is not allowed the name",
-                    "pattern": "^[^:]+$"
-                }
-            ],
-            "maxObjects": 1,
-            "modificationPolicy": "NEVER",
-            "default": ""
-        },
-        "type": {
-            "displayName": "Connection Type",
-            "description": "AWS Authentication mechanism to be used by the connection",
-            "documentation": "",
-            "type": {
-                "$ref": "#/enums/Type"
-            },
-            "nullable": false,
-            "maxObjects": 1,
-            "modificationPolicy": "NEVER",
-            "default": "awsRoleBasedAuthentication"
-        },
-        "awsRoleBasedAuthentication": {
-            "displayName": "",
-            "description": "",
-            "documentation": "",
-            "type": {
-                "$ref": "#/types/AwsRoleBasedAuthenticationConfig"
-            },
-            "nullable": false,
-            "precondition": {
-                "type": "EQUALS",
-                "property": "type",
-                "expectedValue": "awsRoleBasedAuthentication"
-            },
-            "maxObjects": 1,
-            "modificationPolicy": "DEFAULT"
-        },
-        "awsWebIdentity": {
-            "displayName": "",
-            "description": "",
-            "documentation": "",
-            "type": {
-                "$ref": "#/types/AwsWebIdentity"
-            },
-            "nullable": false,
-            "precondition": {
-                "type": "EQUALS",
-                "property": "type",
-                "expectedValue": "awsWebIdentity"
-            },
-            "maxObjects": 1,
-            "modificationPolicy": "DEFAULT"
-        }
-    },
-    "constraints": [
-        {
-            "type": "CUSTOM_VALIDATOR_REF",
-            "customValidatorId": "hyperscaler-authentication.hyperscaler-authentication:8080/internal/settings-validation/v0.1/validate-container/awsConfiguration",
-            "skipAsyncValidation": true
-        }
-    ],
-    "schemaConstraints": [
-        {
-            "type": "UNIQUE",
-            "customMessage": "There is another connection defined under this name.",
-            "uniqueProperties": [
-                "name"
-            ],
-            "flattenCollections": false
-        }
-    ],
-    "metadata": {
-        "$ref": "#/types/Metadata"
-    },
-    "ownerBasedAccessControl": true
+	"allowedScopes": [
+		"environment"
+	],
+	"constraints": [
+		{
+			"customValidatorId": "hyperscaler-authentication.hyperscaler-authentication:8080/internal/settings-validation/v0.1/validate-container/awsConfiguration",
+			"skipAsyncValidation": true,
+			"type": "CUSTOM_VALIDATOR_REF"
+		}
+	],
+	"description": "Connections to AWS for Dynatrace integrations",
+	"displayName": "Connections to AWS environments",
+	"documentation": "",
+	"dynatrace": "1",
+	"enums": {
+		"ConsumersOfAwsRoleBasedAuthentication": {
+			"description": "Dynatrace integrations that can use this connection",
+			"displayName": "Consumers",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "(Deprecated) Data Acquisition",
+					"value": "DA"
+				},
+				{
+					"displayName": "Data Acquisition",
+					"value": "SVC:com.dynatrace.da"
+				},
+				{
+					"displayName": "Cost \u0026 Carbon Optimization",
+					"value": "APP:dynatrace.biz.carbon"
+				},
+				{
+					"displayName": "Business Observability",
+					"value": "SVC:com.dynatrace.bo"
+				},
+				{
+					"displayName": "OpenPipeline",
+					"value": "SVC:com.dynatrace.openpipeline"
+				},
+				{
+					"displayName": "None",
+					"value": "NONE"
+				}
+			],
+			"type": "enum"
+		},
+		"ConsumersOfAwsWebIdentity": {
+			"description": "Dynatrace integrations that can use this connection",
+			"displayName": "Consumers",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "AWS Connector",
+					"value": "APP:dynatrace.aws.connector"
+				},
+				{
+					"displayName": "Cost \u0026 Carbon Optimization",
+					"value": "APP:dynatrace.biz.carbon"
+				}
+			],
+			"type": "enum"
+		},
+		"Type": {
+			"description": "",
+			"displayName": "Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "AWS IAM Cross-account Role-based authentication",
+					"value": "awsRoleBasedAuthentication"
+				},
+				{
+					"displayName": "AWS Web Identity",
+					"value": "awsWebIdentity"
+				}
+			],
+			"type": "enum"
+		}
+	},
+	"maturity": "EARLY_ADOPTER",
+	"maxObjects": 500,
+	"metadata": {
+		"$ref": "#/types/Metadata"
+	},
+	"multiObject": true,
+	"ordered": false,
+	"ownerBasedAccessControl": true,
+	"properties": {
+		"awsRoleBasedAuthentication": {
+			"description": "",
+			"displayName": "",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "awsRoleBasedAuthentication",
+				"property": "type",
+				"type": "EQUALS"
+			},
+			"type": {
+				"$ref": "#/types/AwsRoleBasedAuthenticationConfig"
+			}
+		},
+		"awsWebIdentity": {
+			"description": "",
+			"displayName": "",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "awsWebIdentity",
+				"property": "type",
+				"type": "EQUALS"
+			},
+			"type": {
+				"$ref": "#/types/AwsWebIdentity"
+			}
+		},
+		"name": {
+			"constraints": [
+				{
+					"maxLength": 100,
+					"minLength": 3,
+					"type": "LENGTH"
+				},
+				{
+					"customMessage": "The symbol : is not allowed the name",
+					"pattern": "^[^:]+$",
+					"type": "PATTERN"
+				}
+			],
+			"default": "",
+			"description": "The name of the connection",
+			"displayName": "Name",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": false,
+			"type": "text"
+		},
+		"type": {
+			"default": "awsRoleBasedAuthentication",
+			"description": "AWS Authentication mechanism to be used by the connection",
+			"displayName": "Connection Type",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/Type"
+			}
+		}
+	},
+	"schemaConstraints": [
+		{
+			"customMessage": "There is another connection defined under this name.",
+			"flattenCollections": false,
+			"type": "UNIQUE",
+			"uniqueProperties": [
+				"name"
+			]
+		}
+	],
+	"schemaId": "builtin:hyperscaler-authentication.connections.aws",
+	"types": {
+		"AwsRoleBasedAuthenticationConfig": {
+			"description": "",
+			"displayName": "",
+			"documentation": "",
+			"properties": {
+				"consumers": {
+					"default": [
+						"SVC:com.dynatrace.da"
+					],
+					"description": "Dynatrace integrations that can use this connection",
+					"displayName": "Consumers",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/enums/ConsumersOfAwsRoleBasedAuthentication"
+						}
+					},
+					"maxObjects": 1,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"roleArn": {
+					"constraints": [
+						{
+							"maxLength": 2048,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Invalid AWS IAM Role ARN, it does not adhere to pattern ^$|arn:aws:iam::(?:aws|\\\\d+?):role\\\\/.*$",
+							"pattern": "^$|arn:aws:iam::(?:aws|\\d+?):role\\/.*$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "",
+					"description": "The ARN of the AWS role that should be assumed",
+					"displayName": "AWS IAM Role ARN",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"searchPattern": "",
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"AwsWebIdentity": {
+			"description": "",
+			"displayName": "",
+			"documentation": "",
+			"properties": {
+				"consumers": {
+					"default": [
+						"APP:dynatrace.aws.connector"
+					],
+					"description": "Dynatrace integrations that can use this connection",
+					"displayName": "Consumers",
+					"documentation": "",
+					"items": {
+						"description": "",
+						"displayName": "",
+						"documentation": "",
+						"type": {
+							"$ref": "#/enums/ConsumersOfAwsWebIdentity"
+						}
+					},
+					"maxObjects": 1,
+					"minObjects": 0,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "list"
+				},
+				"roleArn": {
+					"constraints": [
+						{
+							"maxLength": 2048,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Role must be valid with given pattern ^$|arn:(?:aws|aws-cn|aws-us-gov):iam::(?:aws|\\d+?):role\\/.*$",
+							"pattern": "^$|arn:(?:aws|aws-cn|aws-us-gov):iam::(?:aws|\\d+?):role\\/.*$",
+							"type": "PATTERN"
+						}
+					],
+					"default": "",
+					"description": "The ARN of the AWS role that should be assumed",
+					"displayName": "AWS IAM Role ARN",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "text"
+				}
+			},
+			"searchPattern": "",
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		}
+	},
+	"version": "0.0.21"
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import (
 )
 
 const SchemaID = "builtin:hyperscaler-authentication.connections.aws"
-const SchemaVersion = "0.0.15"
+const SchemaVersion = "0.0.21"
 
 // An update should only happen when the role ARN is added. Otherwise, all attributes and subresources
 // are flagged as "forceNew", meaning instead of an update, the resource is destroyed and created from scratch

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/aws_role_based_authentication_config.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/aws_role_based_authentication_config.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 
 type AwsRoleBasedAuthenticationConfig struct {
 	RoleARN   string                                  `json:"roleArn"`   // The ARN of the AWS role that should be assumed
-	Consumers []ConsumersOfAwsRoleBasedAuthentication `json:"consumers"` // Deafult "SVC:com.dynatrace.da" Dynatrace integrations that can use this connection "type": "list", "minObjects": 0, v"maxObjects": 1,
+	Consumers []ConsumersOfAwsRoleBasedAuthentication `json:"consumers"` // Default "SVC:com.dynatrace.da" Dynatrace integrations that can use this connection. Possible Values: `APP:dynatrace.biz.carbon`, `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.openpipeline`
 }
 
 func (me *AwsRoleBasedAuthenticationConfig) Schema() map[string]*schema.Schema {
@@ -37,7 +37,7 @@ func (me *AwsRoleBasedAuthenticationConfig) Schema() map[string]*schema.Schema {
 		// },
 		"consumers": {
 			Type:        schema.TypeSet,
-			Description: "Dynatrace integrations that can use this connection. Possible values: `DA` (Data Acquisition Deprecated)`, `SVC:com.dynatrace.da` (Data Acquisition), `APP:dynatrace.biz.carbon` (Cost & Carbon Optimization) and `NONE`",
+			Description: "Dynatrace integrations that can use this connection. Possible Values: `APP:dynatrace.biz.carbon` (Cost & Carbon Optimization), `DA` (Data Acquisition Deprecated), `SVC:com.dynatrace.bo` (Business Observability), `SVC:com.dynatrace.da` (Data Acquisition), `SVC:com.dynatrace.openpipeline` (OpenPipeline) and `NONE`",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/aws_web_identity.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/aws_web_identity.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 
 type AWSWebIdentity struct {
 	RoleARN   string                      `json:"roleArn"`   // The ARN of the AWS role that should be assumed
-	Consumers []ConsumersOfAwsWebIdentity `json:"consumers"` // Dynatrace integrations that can use this connection
+	Consumers []ConsumersOfAwsWebIdentity `json:"consumers"` // Dynatrace integrations that can use this connection. Possible Values: `APP:dynatrace.aws.connector`, `APP:dynatrace.biz.carbon`
 }
 
 func (me *AWSWebIdentity) Schema() map[string]*schema.Schema {

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/enums.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/enums.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,11 +33,15 @@ var ConsumersOfAwsRoleBasedAuthentications = struct {
 	DataAcquisitionDeprecated ConsumersOfAwsRoleBasedAuthentication
 	DataAcquisition           ConsumersOfAwsRoleBasedAuthentication
 	CostAndCarbonOptimization ConsumersOfAwsRoleBasedAuthentication
+	BusinessObservability     ConsumersOfAwsRoleBasedAuthentication
+	OpenPipeline              ConsumersOfAwsRoleBasedAuthentication
 	None                      ConsumersOfAwsRoleBasedAuthentication
 }{
 	"DA",
 	"SVC:com.dynatrace.da",
 	"APP:dynatrace.biz.carbon",
+	"SVC:com.dynatrace.bo",
+	"SVC:com.dynatrace.openpipeline",
 	"NONE",
 }
 

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/settings.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/securitycontext/schema.json
+++ b/dynatrace/api/builtin/securitycontext/schema.json
@@ -2,11 +2,20 @@
 	"allowedScopes": [
 		"environment"
 	],
-	"description": "Determines whether security context or management zones rules have priority when assigning actual management zones. If true(default), security context information will be prioritized, otherwise management zone rules will be used to assign management zones. Learn more by visiting [our documentation](https://dt-url.net/vc034se)",
+	"constraints": [
+		{
+			"customMessage": "This setting is deprecated.",
+			"customValidatorId": "security-context-enablement-validator",
+			"skipAsyncValidation": false,
+			"type": "CUSTOM_VALIDATOR_REF"
+		}
+	],
+	"description": "Determines whether security context or management zones rules have priority when assigning actual management zones. If enabled, security context information will be prioritized, otherwise management zone rules will be used to assign management zones. Learn more by visiting [our documentation](https://dt-url.net/vc034se)",
 	"displayName": "Security context settings",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -27,5 +36,5 @@
 	],
 	"schemaId": "builtin:security-context",
 	"types": {},
-	"version": "1.0.3"
+	"version": "1.0.5"
 }

--- a/dynatrace/api/builtin/securitycontext/service.go
+++ b/dynatrace/api/builtin/securitycontext/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.3"
+const SchemaVersion = "1.0.5"
 const SchemaID = "builtin:security-context"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*securitycontext.Settings] {

--- a/dynatrace/api/builtin/securitycontext/settings/settings.go
+++ b/dynatrace/api/builtin/securitycontext/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
#### **Why** this PR?
I missed two resources in #915 so this is a follow-up PR for updating the Terraform resources for Dynatrace version 328.

#### **What** has changed?
Updates to:
 - `dynatrace_aws_connection`: Additional values available for `consumers` when using web identity
 - `dynatrace_aws_connection_role_arn`: Version bump
 - `dynatrace_security_context`: Version bump

#### How is it **tested**?
Existing tests still pass

#### How does it affect **users**?
Mostly documentation updates for additional values for `consumers`

**Issue:**
NOISSUE
