### PR TITLE
fix(azure-connection): Resources using client secret must be updated following export

### DIFF
--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/settings.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/settings.go
@@ -106,3 +106,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"type":                          &me.Type,
 	})
 }
+
+func (me *Settings) FillDemoValues() []string {
+	// connections using client secret authentication must be modified before use
+	if me.Type == Types.Clientsecret && me.ClientSecret != nil {
+		me.ClientSecret.ClientSecret = "#######"
+		return []string{"Please fill in the client secret"}
+	}
+	return []string{}
+}


### PR DESCRIPTION
#### **Why** this PR?
Currently, Azure connections using client secrets are downloaded with obfuscated secrets, however the user may be unaware of this.

#### **What** has changed?
With this change, the user will be notified that the client secret must be updated before the resource can be applied. When exported, the resource will be placed in the `.requires_attention` directory.

#### **How** does it do it?
`func (me *Settings) FillDemoValues() []string` is provided for `auze.Settings`.

#### How is it **tested**?
N/A

#### How does it affect **users**?
Users will be notified that they need to update connections using a client secret.

**Issue:** CA-16696
