### PR TITLE
feat(export): add management-zone scoped export

### DIFF
--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -1342,6 +1342,11 @@ func (me *Module) Discover() error {
 			fmt.Printf("Ignoring Resource - Type: %s - ID: %s\n", me.Type, stub.ID)
 			continue
 		}
+		if me.Environment.HasManagementZoneFilter() && (me.Type == ResourceTypes.ManagementZoneV2 || me.Type == ResourceTypes.ManagementZone) {
+			if !strings.EqualFold(stub.Name, me.Environment.ManagementZoneName) {
+				continue
+			}
+		}
 		if IsIgnoredResource(me.Type, stub.ID) {
 			fmt.Printf("Ignoring Resource - Type: %s - ID: %s\n", me.Type, stub.ID)
 			continue

--- a/dynatrace/export/resource.go
+++ b/dynatrace/export/resource.go
@@ -318,6 +318,11 @@ func (me *Resource) Download() error {
 	name := settings.Name(settngs, me.ID)
 	me.SetName(name)
 
+	if me.Module.Environment.HasManagementZoneFilter() && !me.Module.Environment.ResourceMatchesManagementZone(me, settngs) {
+		me.SetStatus(ResourceStati.Excluded)
+		return nil
+	}
+
 	legacyID := settings.GetLegacyID(settngs)
 	if legacyID != nil {
 		me.LegacyID = *legacyID


### PR DESCRIPTION
#### **Why** this PR?
We need to export only configs tied to a specific management zone for backup/restore and scoped moves; exporting the whole tenant is noisy and manual pruning is error-prone.

#### **What** has changed?
- Added `-management-zone "<name>"` flag to resolve a zone by name (including legacy ID) and store it on the export environment.
- Filtered discovery/download to that zone and resources referencing it (by name/ID/legacy ID/scope), excluding out-of-scope items.

#### **How** does it do it?
- Resolves the management zone via settings v2 service; fails fast if not found.
- Applies zone-aware filtering during discovery and post-GET validation; marks non-matching resources as excluded.
- Keeps compatibility with existing flags (`-ref`,  `-exclude`, `-skip-terraform-init`, parallel control).

#### How is it **tested**?
- Manual runs with `-management-zone "<name>"`, with/without `-ref`, and with targeted resource lists; verified only zone-scoped resources are written.

#### How does it affect **users**?
- Optional enhancement: default behavior unchanged. When used, outputs are limited to the specified management zone, reducing noise and manual cleanup.

**Issue:** #923 
