### PR TITLE
chore: add custom_filter to Davis event configs

### DIFF
--- a/docs/resources/automation_workflow.md
+++ b/docs/resources/automation_workflow.md
@@ -109,6 +109,7 @@ resource "dynatrace_automation_workflow" "Sample_Worklow_TF" {
           }
           on_problem_close = false
           types            = ["CUSTOM_ANNOTATION"]
+          custom_filter = ""
         }
       }
     }
@@ -229,6 +230,7 @@ Optional:
 
 Optional:
 
+- `custom_filter` (String) Additional DQL matcher expression to further filter events to match
 - `entity_tags` (Map of String) key/value pairs for entity tags to match for. For tags that don't require a value, just specify an empty string as value. Multiple values can be provided separated by whitespace (e.g. "val1 val2") and will be parsed as multiple tag values. Omit this attribute if all entities should match
 - `entity_tags_match` (String) Specifies whether all or just any of the configured entity tags need to match. Possible values: `all` and `any`. Omit this attribute if all entities should match
 - `names` (Block List, Max: 1) The Davis Events to match on (see [below for nested schema](#nestedblock--trigger--event--config--davis_event--names))
@@ -262,7 +264,7 @@ Required:
 
 Optional:
 
-- `custom_filter` (String)
+- `custom_filter` (String) Additional DQL matcher expression to further filter events to match
 - `entity_tags` (Map of String) key/value pairs for entity tags to match for. For tags that don't require a value, just specify an empty string as value. Multiple values can be provided separated by whitespace (e.g. "val1 val2") and will be parsed as multiple tag values. Omit this attribute if all entities should match
 - `entity_tags_match` (String) Specifies whether all or just any of the configured entity tags need to match. Possible values: `all` and `any`. Omit this attribute if all entities should match
 - `on_problem_close` (Boolean) If set to `true` closing a problem also is considered an event that triggers the execution

--- a/dynatrace/api/automation/workflows/settings/davis_event_config.go
+++ b/dynatrace/api/automation/workflows/settings/davis_event_config.go
@@ -31,6 +31,7 @@ type DavisEventConfig struct {
 	OnProblemClose  bool                   `json:"onProblemClose" default:"false"` // If set to `true` closing a problem also is considered an event that triggers the execution
 	Types           []string               `json:"types" flags:"uniqueitems"`      // The types of davis events to trigger an execution
 	Names           DavisEventNames        `json:"names"`
+	CustomFilter    string                 `json:"customFilter,omitempty"`
 }
 
 func (me *DavisEventConfig) Schema(prefix string) map[string]*schema.Schema {
@@ -68,6 +69,11 @@ func (me *DavisEventConfig) Schema(prefix string) map[string]*schema.Schema {
 			Optional:    true,
 			Elem:        &schema.Resource{Schema: new(DavisEventNames).Schema("names")},
 		},
+		"custom_filter": {
+			Type:        schema.TypeString,
+			Description: "Additional DQL matcher expression to further filter events to match",
+			Optional:    true,
+		},
 	}
 }
 
@@ -80,6 +86,7 @@ func (me *DavisEventConfig) MarshalHCL(properties hcl.Properties) error {
 		"on_problem_close":  me.OnProblemClose,
 		"types":             me.Types,
 		"names":             me.Names,
+		"custom_filter":     me.CustomFilter,
 	})
 }
 
@@ -92,6 +99,7 @@ func (me *DavisEventConfig) UnmarshalHCL(decoder hcl.Decoder) error {
 		"on_problem_close":  &me.OnProblemClose,
 		"types":             &me.Types,
 		"names":             &me.Names,
+		"custom_filter":     &me.CustomFilter,
 	})
 }
 

--- a/dynatrace/api/automation/workflows/settings/davis_problem_config.go
+++ b/dynatrace/api/automation/workflows/settings/davis_problem_config.go
@@ -63,9 +63,8 @@ func (me *DavisProblemConfig) Schema(prefix string) map[string]*schema.Schema {
 		},
 		"custom_filter": {
 			Type:        schema.TypeString,
-			Description: "",
+			Description: "Additional DQL matcher expression to further filter events to match",
 			Optional:    true,
-			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 	}
 }

--- a/dynatrace/api/automation/workflows/testdata/example-a.tf
+++ b/dynatrace/api/automation/workflows/testdata/example-a.tf
@@ -86,6 +86,7 @@ resource "dynatrace_automation_workflow" "Sample_Worklow_TF" {
           }
           on_problem_close = false
           types            = ["CUSTOM_ANNOTATION"]
+          custom_filter = "matchesPhrase(custom.event.type, \"DEPLOY\")"
         }
       }
     }

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-a.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-a.tf
@@ -85,6 +85,7 @@ resource "dynatrace_automation_workflow" "#name#" {
           entity_tags_match  = "all"
           # on_problem_close = false
           types              = [ "CUSTOM_ANNOTATION" ]
+          custom_filter = "matchesPhrase(custom.event.type, \"DEPLOY\")"
         }
       }
     }


### PR DESCRIPTION
#### Why this PR?
The custom_filter field for the Davis event trigger in workflows is not supported yet. Downloading doesn't set it and deploying doesn't work.

#### **What** has changed?
The custom_filter field can be set for the Davis event trigger.

#### **How** does it do it?
By adding the fields to the schema and adjusting parsing logic.

#### How is it **tested**?
Added this property to a test file. Test is working and an empty plan implies that deploy and download is working.

#### How does it affect **users**?
They are now able to make use of the custom_filter option of Davis event trigger types.

**Issue:** CA-17055
