### PR TITLE
chore(workflows): Deprecate Davis event config `types` field

### DIFF
--- a/dynatrace/api/automation/workflows/settings/davis_event_config.go
+++ b/dynatrace/api/automation/workflows/settings/davis_event_config.go
@@ -60,6 +60,7 @@ func (me *DavisEventConfig) Schema(prefix string) map[string]*schema.Schema {
 			MinItems:    1,
 			Optional:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
+			Deprecated:  "This field has been deprecated",
 		},
 		"names": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/automation/workflows/testdata/example-a.tf
+++ b/dynatrace/api/automation/workflows/testdata/example-a.tf
@@ -85,7 +85,6 @@ resource "dynatrace_automation_workflow" "Sample_Worklow_TF" {
             asdf = ""
           }
           on_problem_close = false
-          types            = ["CUSTOM_ANNOTATION"]
           custom_filter = "matchesPhrase(custom.event.type, \"DEPLOY\")"
         }
       }

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-a.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-a.tf
@@ -84,7 +84,6 @@ resource "dynatrace_automation_workflow" "#name#" {
           }
           entity_tags_match  = "all"
           # on_problem_close = false
-          types              = [ "CUSTOM_ANNOTATION" ]
           custom_filter = "matchesPhrase(custom.event.type, \"DEPLOY\")"
         }
       }


### PR DESCRIPTION
#### **Why** this PR?
The `types` field of the Davis event trigger config is deprecated. This should be reflected in the resource.

#### **What** has changed?
The `types` field of the Davis even config trigger is now marked as deprecated

#### **How** does it do it?
By adding a deprecation notice to the field.

#### How is it **tested**?
No tests needed. This is config

#### How does it affect **users**?
They will see a deprecation notice when using it and in the docs.

**Issue:** CA-17127
