### PR TITLE
refactor: Trim account ID prefix when creating `ProviderConfiguration`

### DIFF
--- a/dynatrace/api/iam/bindings/service.go
+++ b/dynatrace/api/iam/bindings/service.go
@@ -183,7 +183,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	var responseBytes []byte
 	client := iam.NewIAMClient(me)
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/env/v2/accounts/%s/environments", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")), 200, false); err != nil {
+	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/env/v2/accounts/%s/environments", me.endpointURL, me.AccountID()), 200, false); err != nil {
 		return nil, err
 	}
 
@@ -192,7 +192,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 		return nil, err
 	}
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/bindings", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")), 200, false); err != nil {
+	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/bindings", me.endpointURL, me.AccountID()), 200, false); err != nil {
 		return nil, err
 	}
 

--- a/dynatrace/api/iam/boundaries/service.go
+++ b/dynatrace/api/iam/boundaries/service.go
@@ -75,7 +75,7 @@ func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
 
 	client := iam.NewIAMClient(me)
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")), 200, false); err != nil {
+	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries", me.endpointURL, me.AccountID()), 200, false); err != nil {
 		return nil, err
 	}
 
@@ -99,7 +99,7 @@ func (me *BoundaryServiceClient) Get(ctx context.Context, id string, v *boundari
 
 	client := iam.NewIAMClient(me)
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), id), 200, false); err != nil {
+	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id), 200, false); err != nil {
 		return err
 	}
 
@@ -121,7 +121,7 @@ func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.Polic
 
 	if responseBytes, err = client.POST(
 		ctx,
-		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")),
+		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries", me.endpointURL, me.AccountID()),
 		v,
 		201,
 		false,
@@ -148,7 +148,7 @@ func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *bound
 
 	if _, err = client.PUT_MULTI_RESPONSE(
 		ctx,
-		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), id),
+		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id),
 		v,
 		[]int{201, 204},
 		false,
@@ -167,7 +167,7 @@ func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
 
 	if _, err = client.DELETE(
 		ctx,
-		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), id),
+		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id),
 		204,
 		false,
 	); err != nil {
@@ -175,7 +175,7 @@ func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
 			clean.CleanUp.Register(func() {
 				client.DELETE(
 					ctx,
-					fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), id),
+					fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id),
 					204,
 					false,
 				)

--- a/dynatrace/api/iam/groups/service.go
+++ b/dynatrace/api/iam/groups/service.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -98,7 +97,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 	var responseBytes []byte
 
 	client := iam.NewIAMClient(me)
-	if responseBytes, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")), []*groups.Group{group}, 201, false); err != nil {
+	if responseBytes, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups", me.endpointURL, me.AccountID()), []*groups.Group{group}, 201, false); err != nil {
 		return nil, err
 	}
 
@@ -110,7 +109,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 	groupName := responseGroups[0].Name
 
 	if len(group.Permissions) > 0 {
-		if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), groupID), group.Permissions, 200, false); err != nil {
+		if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, me.AccountID(), groupID), group.Permissions, 200, false); err != nil {
 			return nil, err
 		}
 	}
@@ -128,7 +127,7 @@ func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *gr
 	var err error
 
 	client := iam.NewIAMClient(me)
-	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), uuid), group, 200, false); err != nil {
+	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s", me.endpointURL, me.AccountID(), uuid), group, 200, false); err != nil {
 		return err
 	}
 
@@ -137,7 +136,7 @@ func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *gr
 	if len(group.Permissions) > 0 {
 		permissions = group.Permissions
 	}
-	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), uuid), permissions, 200, false); err != nil {
+	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, me.AccountID(), uuid), permissions, 200, false); err != nil {
 		return err
 	}
 
@@ -203,7 +202,7 @@ func (me *GroupServiceClient) listUnguarded(ctx context.Context) ([]*ListGroup, 
 
 	client := iam.NewIAMClient(me)
 	var response ListGroupsResponse
-	accountID := strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")
+	accountID := me.AccountID()
 	if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups", me.endpointURL, accountID), 200, false, &response); err != nil {
 		return nil, err
 	}
@@ -217,7 +216,7 @@ func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Grou
 	}
 	for _, listStub := range stubs {
 		if listStub.UUID == id {
-			accountID := strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")
+			accountID := me.AccountID()
 			client := iam.NewIAMClient(me)
 			var groupStub ListGroup
 			if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, accountID, id), 200, false, &groupStub); err != nil {
@@ -237,7 +236,7 @@ func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Grou
 }
 
 func (me *GroupServiceClient) Delete(ctx context.Context, id string) error {
-	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), id), 200, false)
+	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s", me.endpointURL, me.AccountID(), id), 200, false)
 
 	// data sources MAY have cached a list of group IDs
 	// Updating the (publicly available) revision signals to them that either a CREATE or DELETE has happened since

--- a/dynatrace/api/iam/permissions/service.go
+++ b/dynatrace/api/iam/permissions/service.go
@@ -95,7 +95,7 @@ func (me *PermissionServiceClient) Create(ctx context.Context, permission *permi
 		ScopeType: scopeType,
 		Name:      permission.Name,
 	}}
-	if _, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), permission.GroupID), payload, 201, false); err != nil {
+	if _, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, me.AccountID(), permission.GroupID), payload, 201, false); err != nil {
 		return nil, err
 	}
 
@@ -121,7 +121,7 @@ func (me *PermissionServiceClient) Get(ctx context.Context, id string, v *permis
 	scope := parts[2]
 	scopeType := parts[3]
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), groupID), 200, false); err != nil {
+	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, me.AccountID(), groupID), 200, false); err != nil {
 		return err
 	}
 
@@ -168,7 +168,7 @@ func (me *PermissionServiceClient) List(ctx context.Context) (api.Stubs, error) 
 	for _, groupStub := range groupStubs {
 		groupID := groupStub.ID
 
-		accountID := strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")
+		accountID := me.AccountID()
 
 		var response GetGroupPermissionsResponse
 		if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, accountID, groupID), 200, false, &response); err != nil {
@@ -196,7 +196,7 @@ func (me *PermissionServiceClient) Delete(ctx context.Context, id string) error 
 	scope := parts[2]
 	scopeType := parts[3]
 
-	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions?scope=%s&permission-name=%s&scope-type=%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), groupID, url.QueryEscape(scope), url.QueryEscape(name), url.QueryEscape(scopeType)), 200, false)
+	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions?scope=%s&permission-name=%s&scope-type=%s", me.endpointURL, me.AccountID(), groupID, url.QueryEscape(scope), url.QueryEscape(name), url.QueryEscape(scopeType)), 200, false)
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("Permission %s not found", id)) {
 		return nil
 	}

--- a/dynatrace/api/iam/policies/policy_level.go
+++ b/dynatrace/api/iam/policies/policy_level.go
@@ -98,12 +98,12 @@ func fetchPolicyLevel(ctx context.Context, auth iam.Authenticator, uuid string) 
 	if exists {
 		return "global", "global", name, nil
 	}
-	accountID := strings.TrimPrefix(auth.AccountID(), "urn:dtaccount:")
-	if exists, name, err = CheckPolicyExists(ctx, auth, "account", accountID, uuid); err != nil {
+
+	if exists, name, err = CheckPolicyExists(ctx, auth, "account", auth.AccountID(), uuid); err != nil {
 		return "", "", name, err
 	}
 	if exists {
-		return "account", accountID, name, nil
+		return "account", auth.AccountID(), name, nil
 	}
 
 	var environmentIDs []string
@@ -306,11 +306,11 @@ func fetchAllPolicyLevels(ctx context.Context, auth iam.Authenticator) (m map[st
 // The operation is NOT guarded by a mutex. See `GetEnvironmentIDs` for a guarded version
 func getEnvironmentIDs(ctx context.Context, auth iam.Authenticator) ([]string, error) {
 	client := iam.NewIAMClient(auth)
-	accountID := strings.TrimPrefix(auth.AccountID(), "urn:dtaccount:")
+
 	var err error
 
 	var envResponse ListEnvResponse
-	if err = iam.GET(client, ctx, fmt.Sprintf("%s/env/v2/accounts/%s/environments", auth.EndpointURL(), accountID), 200, false, &envResponse); err != nil {
+	if err = iam.GET(client, ctx, fmt.Sprintf("%s/env/v2/accounts/%s/environments", auth.EndpointURL(), auth.AccountID()), 200, false, &envResponse); err != nil {
 		return nil, err
 	}
 

--- a/dynatrace/api/iam/policies/service.go
+++ b/dynatrace/api/iam/policies/service.go
@@ -246,17 +246,17 @@ func listForEnvironments(ctx context.Context, auth iam.Authenticator) (results c
 
 func listForAccount(ctx context.Context, auth iam.Authenticator) (results chan *api.Stub, err error) {
 	client := iam.NewIAMClient(auth)
-	accountID := strings.TrimPrefix(auth.AccountID(), "urn:dtaccount:")
+
 	results = make(chan *api.Stub)
 	go func() {
 		defer close(results)
 		var response ListPoliciesResponse
-		if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/policies", auth.EndpointURL(), accountID), 200, false, &response); err != nil {
+		if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/policies", auth.EndpointURL(), auth.AccountID()), 200, false, &response); err != nil {
 			return
 		}
 
 		for _, policy := range response.Policies {
-			results <- &api.Stub{ID: Join(policy.UUID, "account", accountID), Name: policy.Name}
+			results <- &api.Stub{ID: Join(policy.UUID, "account", auth.AccountID()), Name: policy.Name}
 		}
 	}()
 	return results, nil

--- a/dynatrace/api/iam/users/service.go
+++ b/dynatrace/api/iam/users/service.go
@@ -75,7 +75,7 @@ func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api
 	var err error
 
 	client := iam.NewIAMClient(me)
-	if _, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")), user, 201, false); err != nil {
+	if _, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users", me.endpointURL, me.AccountID()), user, 201, false); err != nil {
 		if err.Error() == "User already exists" {
 			if err = me.Update(ctx, user.Email, user); err != nil {
 				return nil, err
@@ -89,7 +89,7 @@ func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), user.Email), groups, 200, false); err != nil {
+	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, me.AccountID(), user.Email), groups, 200, false); err != nil {
 		return nil, err
 	}
 
@@ -112,7 +112,7 @@ func (me *UserServiceClient) Get(ctx context.Context, email string, v *users.Use
 
 	client := iam.NewIAMClient(me)
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), email), 200, false); err != nil {
+	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, me.AccountID(), email), 200, false); err != nil {
 		if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 			return rest.Error{Code: 404, Message: err.Error()}
 		}
@@ -140,7 +140,7 @@ func (me *UserServiceClient) Update(ctx context.Context, email string, user *use
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err = iam.NewIAMClient(me).PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), user.Email), groups, 200, false); err != nil {
+	if _, err = iam.NewIAMClient(me).PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, me.AccountID(), user.Email), groups, 200, false); err != nil {
 		return err
 	}
 
@@ -161,7 +161,7 @@ func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 	var responseBytes []byte
 
-	if responseBytes, err = iam.NewIAMClient(me).GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")), 200, false); err != nil {
+	if responseBytes, err = iam.NewIAMClient(me).GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users", me.endpointURL, me.AccountID()), 200, false); err != nil {
 		return nil, err
 	}
 
@@ -177,7 +177,7 @@ func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *UserServiceClient) Delete(ctx context.Context, email string) error {
-	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"), email), 200, false)
+	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, me.AccountID(), email), 200, false)
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 		return nil
 	}

--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -259,7 +259,7 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 		var response ListPolicyBindingsResponse
 		client := iam.NewIAMClient(me)
 
-		if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/bindings", me.endpointURL, strings.TrimPrefix(me.AccountID(), "urn:dtaccount:")), 200, false, &response); err != nil {
+		if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/bindings", me.endpointURL, me.AccountID()), 200, false, &response); err != nil {
 			return
 		}
 
@@ -268,7 +268,7 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 		for _, policy := range response.PolicyBindings {
 			for _, group := range policy.Groups {
 				if _, exists := groupIds[group]; !exists {
-					id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", strings.TrimPrefix(me.AccountID(), "urn:dtaccount:"))
+					id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", me.AccountID())
 					stubs = append(stubs, &api.Stub{ID: id, Name: "PolicyV2Bindings-" + id})
 					groupIds[group] = true
 				}

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -241,6 +241,8 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnost
 	iam_account_id = streamlineOAuthCreds(iam_account_id, account_id)
 	iam_endpoint_url = streamlineOAuthCreds(iam_endpoint_url, oauth_endpoint_url, rest.ProdIAMEndpointURL)
 
+	iam_account_id = strings.TrimPrefix(iam_account_id, "urn:dtaccount:")
+
 	var diags diag.Diagnostics
 
 	pc := &ProviderConfiguration{


### PR DESCRIPTION
#### **Why** this PR?
Currently the account ID prefix is trimmed in many different locations, with this change it is trimmed in a single location.

#### **What** has changed and **how** does it do it?
The account ID prefix is trimmed centrally in `provider/config.go` rather than in each IAM resource.

#### How is it **tested**?
-

#### How does it affect **users**?
-

**Issue:**  CA-16921
