### PR TITLE
fix(network_monitor): fix invalid constraint update

### DIFF
--- a/dynatrace/api/v2/synthetic/monitors/settings/constraints.go
+++ b/dynatrace/api/v2/synthetic/monitors/settings/constraints.go
@@ -41,7 +41,19 @@ func (me Constraints) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *Constraints) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("constraint", me)
+	if err := decoder.DecodeSlice("constraint", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := Constraints{}
+	for _, entry := range *me {
+		if entry.Type != "" || entry.Properties != nil {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type Constraint struct {

--- a/dynatrace/api/v2/synthetic/monitors/testdata/create.tf
+++ b/dynatrace/api/v2/synthetic/monitors/testdata/create.tf
@@ -1,0 +1,95 @@
+resource "dynatrace_synthetic_location" "Test" {
+  name                                  = "Test"
+  auto_update_chromium                  = true
+  availability_location_outage          = true
+  availability_node_outage              = true
+  availability_notifications_enabled    = true
+  city                                  = "San Francisco de Asis"
+  country_code                          = "VE"
+  deployment_type                       = "STANDARD"
+  latitude                              = 10.0756
+  location_node_outage_delay_in_minutes = 3
+  longitude                             = -67.5442
+  nodes                                 = [ ]
+  region_code                           = "04"
+}
+
+resource "time_sleep" "wait_for_location" {
+  depends_on = [dynatrace_synthetic_location.Test]
+  create_duration = "15s"
+}
+
+resource "dynatrace_network_monitor" "DNS_Test" {
+  depends_on = [time_sleep.wait_for_location]
+  name          = "DNS Test"
+  description   = "This is an example DNS test"
+  type          = "MULTI_PROTOCOL"
+  enabled       = false
+  frequency_min = 15
+  locations     = [ dynatrace_synthetic_location.Test.id ]
+  outage_handling {
+    global_consecutive_outage_count_threshold = 1
+    global_outages                            = true
+  }
+  performance_thresholds {
+    enabled = true
+    thresholds {
+      threshold {
+        aggregation        = "AVG"
+        dealerting_samples = 5
+        samples            = 5
+        step_index         = 0
+        threshold          = 100
+        violating_samples  = 3
+      }
+    }
+  }
+  steps {
+    step {
+      name         = "DNS Test"
+      request_type = "DNS"
+      target_list  = [ "google.com", "yahoo.com" ]
+      properties = {
+        "DNS_RECORD_TYPES"  = "A"
+        "EXECUTION_TIMEOUT" = "PT2S"
+      }
+      constraints {
+        constraint {
+          type = "SUCCESS_RATE_PERCENT"
+          properties = {
+            "value"    = "90"
+            "operator" = ">="
+          }
+        }
+        constraint {
+          type = "SUCCESS_RATE_PERCENT"
+          properties = {
+            "value"    = "90"
+            "operator" = "<"
+          }
+        }
+      }
+      request_configurations {
+        request_configuration {
+          constraints {
+            constraint {
+              type = "DNS_STATUS_CODE"
+              properties = {
+                "operator"   = "="
+                "statusCode" = "0"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  tags {
+    tag {
+      context = "CONTEXTLESS"
+      key     = "Key1"
+      source  = "USER"
+      value   = "Value1"
+    }
+  }
+}

--- a/dynatrace/api/v2/synthetic/monitors/testdata/update.tf
+++ b/dynatrace/api/v2/synthetic/monitors/testdata/update.tf
@@ -1,0 +1,89 @@
+resource "dynatrace_synthetic_location" "Test" {
+  name                                  = "Test"
+  auto_update_chromium                  = true
+  availability_location_outage          = true
+  availability_node_outage              = true
+  availability_notifications_enabled    = true
+  city                                  = "San Francisco de Asis"
+  country_code                          = "VE"
+  deployment_type                       = "STANDARD"
+  latitude                              = 10.0756
+  location_node_outage_delay_in_minutes = 3
+  longitude                             = -67.5442
+  nodes                                 = [ ]
+  region_code                           = "04"
+}
+
+resource "time_sleep" "wait_for_location" {
+  depends_on = [dynatrace_synthetic_location.Test]
+  create_duration = "15s"
+}
+
+resource "dynatrace_network_monitor" "DNS_Test" {
+  depends_on = [time_sleep.wait_for_location]
+  name          = "DNS Test"
+  description   = "This is an example DNS test"
+  type          = "MULTI_PROTOCOL"
+  enabled       = false
+  frequency_min = 15
+  locations     = [ dynatrace_synthetic_location.Test.id ]
+  outage_handling {
+    global_consecutive_outage_count_threshold = 1
+    global_outages                            = true
+  }
+  performance_thresholds {
+    enabled = true
+    thresholds {
+      threshold {
+        aggregation        = "AVG"
+        dealerting_samples = 5
+        samples            = 5
+        step_index         = 0
+        threshold          = 100
+        violating_samples  = 3
+      }
+    }
+  }
+  steps {
+    step {
+      name         = "DNS Test"
+      request_type = "DNS"
+      target_list  = [ "google.com", "yahoo.com" ]
+      properties = {
+        "DNS_RECORD_TYPES"  = "A"
+        "EXECUTION_TIMEOUT" = "PT2S"
+      }
+      constraints {
+        constraint {
+          type = "SUCCESS_RATE_PERCENT"
+          properties = {
+            "value"    = "90"
+            "operator" = ">="
+          }
+        }
+        // removed constraint
+      }
+      request_configurations {
+        request_configuration {
+          constraints {
+            constraint {
+              type = "DNS_STATUS_CODE"
+              properties = {
+                "operator"   = "="
+                "statusCode" = "0"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  tags {
+    tag {
+      context = "CONTEXTLESS"
+      key     = "Key1"
+      source  = "USER"
+      value   = "Value1"
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
If constraints in `dynatrace_network_monitor` are removed, the item is actually not removed but set to empty instead. Because of that, the API rejects the payload.

#### **What** has changed?
Empty Set items are now correctly removed.

#### **How** does it do it?
By manually removing empty Set items, as this is a bug in the Terraform plugin SDK.

#### How is it **tested**?
New tests added that handle the create and update (with one constraint less) case.

#### How does it affect **users**?
They are now able to remove constraints.

**Issue:** DEM-19290
