### PR TITLE
feat: environments data source `dynatrace_iam_environments`

### DIFF
--- a/datasources/iam/environments/data_source.go
+++ b/datasources/iam/environments/data_source.go
@@ -1,0 +1,143 @@
+/**
+* @license
+* Copyright 2020 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package environments
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Attribute keys
+const (
+	// this one is different from attrID inside environments list because "id" is a reserved keyword on root level.
+	attrEnvID        = "env_id"
+	attrID           = "id"
+	attrName         = "name"
+	attrActive       = "active"
+	attrEnvironments = "environments"
+	attrURL          = "url"
+)
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: logging.EnableDSCtx(DataSourceRead),
+		Description: "Returns the environments matching the provided filter criteria",
+		Schema: map[string]*schema.Schema{
+			attrEnvID: {
+				Type:        schema.TypeString,
+				Description: "Filter by ID of the environment",
+				Optional:    true,
+			},
+			attrName: {
+				Type:        schema.TypeString,
+				Description: "Filter by friendly name of the environment",
+				Optional:    true,
+			},
+			attrActive: {
+				Type:        schema.TypeBool,
+				Description: "Filter by active status of the environment",
+				Optional:    true,
+			},
+			attrEnvironments: {
+				Type:        schema.TypeList,
+				Description: "List of environments matching the filter criteria",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						attrID: {
+							Type:        schema.TypeString,
+							Description: "The ID of the environment",
+							Computed:    true,
+						},
+						attrName: {
+							Type:        schema.TypeString,
+							Description: "Friendly name of the environment",
+							Computed:    true,
+						},
+						attrActive: {
+							Type:        schema.TypeBool,
+							Description: "Property to determine if environment is active",
+							Computed:    true,
+						},
+						attrURL: {
+							Type:        schema.TypeString,
+							Description: "The URL of the environment",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	creds, err := config.Credentials(m, config.CredValIAM)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	service := newEnvironmentService(creds)
+	envs, err := service.Get(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Get filter values
+	filterID, hasFilterID := d.GetOk(attrEnvID)
+	filterName, hasFilterName := d.GetOk(attrName)
+	filterActive, hasFilterActive := d.GetOk(attrActive)
+	// Create a unique ID for the data source based on filter criteria
+	dataSourceID := fmt.Sprintf("%#v.%#v.%#v.%#v", creds.IAM.AccountID, filterID, filterName, filterActive)
+
+	// Filter environments based on provided criteria
+	var filteredEnvs []map[string]any
+	for _, env := range envs {
+		// Apply filters
+		if hasFilterID && env.ID != filterID.(string) {
+			continue
+		}
+		if hasFilterName && env.Name != filterName.(string) {
+			continue
+		}
+		if hasFilterActive && env.Active != filterActive.(bool) {
+			continue
+		}
+
+		// Add matching environment to result
+		filteredEnvs = append(filteredEnvs, map[string]any{
+			attrID:     env.ID,
+			attrName:   env.Name,
+			attrActive: env.Active,
+			attrURL:    env.URL,
+		})
+	}
+
+	d.SetId(dataSourceID)
+
+	if err := d.Set(attrEnvironments, filteredEnvs); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
+}

--- a/datasources/iam/environments/service.go
+++ b/datasources/iam/environments/service.go
@@ -1,0 +1,93 @@
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package environments
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+)
+
+const baseURL = "/env/v2/accounts"
+
+type environmentsService struct {
+	clientID     string
+	accountID    string
+	clientSecret string
+	tokenURL     string
+	endpointURL  string
+}
+
+func newEnvironmentService(credentials *rest.Credentials) *environmentsService {
+	return &environmentsService{
+		clientID:     credentials.IAM.ClientID,
+		accountID:    credentials.IAM.AccountID,
+		clientSecret: credentials.IAM.ClientSecret,
+		tokenURL:     credentials.IAM.TokenURL,
+		endpointURL:  credentials.IAM.EndpointURL,
+	}
+}
+
+func (ec *environmentsService) ClientID() string {
+	return ec.clientID
+}
+
+func (ec *environmentsService) AccountID() string {
+	return ec.accountID
+}
+
+func (ec *environmentsService) ClientSecret() string {
+	return ec.clientSecret
+}
+
+func (ec *environmentsService) TokenURL() string {
+	return ec.tokenURL
+}
+
+func (ec *environmentsService) EndpointURL() string {
+	return ec.endpointURL
+}
+
+type Environment struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Active bool   `json:"active"`
+	URL    string `json:"url"`
+}
+
+type Response struct {
+	Data []Environment `json:"data"`
+}
+
+func (ec *environmentsService) Get(ctx context.Context) ([]Environment, error) {
+	u, err := url.JoinPath(ec.endpointURL, baseURL, ec.AccountID(), "environments")
+
+	if err != nil {
+		return nil, err
+	}
+
+	client := iam.NewIAMClient(ec)
+	var result Response
+	err = iam.GET(client, ctx, u, 200, false, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Data, nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -45,6 +45,7 @@ import (
 	georegions "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/geographicregions/regions"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/host"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/hub/items"
+	environments2 "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/environments"
 	ds_iam_groups "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/groups"
 	ds_iam_policies "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/policies"
 	ds_iam_users "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/users"
@@ -231,6 +232,7 @@ func Provider() *schema.Provider {
 			"dynatrace_entity":                       entity.DataSource(),
 			"dynatrace_entities":                     entities.DataSource(),
 			"dynatrace_iam_user":                     ds_iam_users.DataSource(),
+			"dynatrace_iam_environments":             environments2.DataSource(),
 			"dynatrace_request_naming":               requestnaming.DataSource(),
 			"dynatrace_dashboard":                    dashboard.DataSource(),
 			"dynatrace_slo":                          slo.DataSource(),

--- a/templates/data-sources/iam_environments.md.tmpl
+++ b/templates/data-sources/iam_environments.md.tmpl
@@ -1,0 +1,41 @@
+---
+layout: ""
+page_title: "dynatrace_iam_environments Data Source - terraform-provider-dynatrace"
+subcategory: "IAM"
+description: |-
+  The data source `dynatrace_iam_environments` covers queries for the environments in a Dynatrace account
+---
+
+# dynatrace_iam_environments (Data Source)
+
+-> **Dynatrace SaaS only**
+
+-> To utilize this data source, please define the environment variables `DT_CLIENT_ID`, `DT_CLIENT_SECRET`, and `DT_ACCOUNT_ID` with an OAuth client including the following permission: **View environments** (`account-env-read`).
+
+This data source allows you to query the environments in a Dynatrace account and filter them by their active status, id, or name.
+
+## Example Usage
+
+### Query active environments
+```terraform
+data "dynatrace_iam_environments" "active_environments" {
+  active = true
+}
+
+output "active_environments" {
+  value = data.dynatrace_iam_environments.active_environments.environments[*].id
+}
+```
+
+### Query environment by name
+```terraform
+data "dynatrace_iam_environments" "by_name" {
+  name = "production"
+}
+
+output "environment_id" {
+  value = data.dynatrace_iam_environments.by_name.environments[0].id
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
#### **Why** this PR?
To support the case where someone needs all available environments of an account.

#### **What** has changed?
A new data source `dynatrace_iam_environments` is added.

#### **How** does it do it?
By querying `/env/v2/accounts/{account_id}/environments` of an account and filtering based on the set properties of the data source.

#### How is it **tested**?
Manual tests.

#### How does it affect **users**?
They can now query their available environments.

**Issue:** CA-17072
Fixes #869

### Additional notes
Because `id` is reserved by the plugin SDK, I used `uuid` to have a separation.

A better approach would have been to have a parent `filter` object that contains the fields that can be filtered on. I decided against that because we aren't using this structure for other data sources.