### PR TITLE
feat: Add `dynatrace_iam_service_user` resource

### DIFF
--- a/dynatrace/api/iam/serviceusers/service.go
+++ b/dynatrace/api/iam/serviceusers/service.go
@@ -1,0 +1,254 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package serviceusers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
+	serviceusers "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+)
+
+type iamClientGetter interface {
+	New() iam.IAMClient
+}
+
+type iamClientGetterImp struct {
+	clientID     string
+	accountID    string
+	clientSecret string
+	tokenURL     string
+	endpointURL  string
+}
+
+func (me *iamClientGetterImp) ClientID() string {
+	return me.clientID
+}
+
+func (me *iamClientGetterImp) AccountID() string {
+	return me.accountID
+}
+
+func (me *iamClientGetterImp) ClientSecret() string {
+	return me.clientSecret
+}
+
+func (me *iamClientGetterImp) TokenURL() string {
+	return me.tokenURL
+}
+
+func (me *iamClientGetterImp) EndpointURL() string {
+	return me.endpointURL
+}
+
+func (me *iamClientGetterImp) New() iam.IAMClient {
+	return iam.NewIAMClient(me)
+}
+
+type serviceUserServiceClient struct {
+	iamClientGetter iamClientGetter
+	accountID       string
+	endpointURL     string
+}
+
+func Service(credentials *rest.Credentials) settings.CRUDService[*serviceusers.ServiceUser] {
+	return &serviceUserServiceClient{
+		iamClientGetter: &iamClientGetterImp{
+			clientID:     credentials.IAM.ClientID,
+			accountID:    credentials.IAM.AccountID,
+			clientSecret: credentials.IAM.ClientSecret,
+			tokenURL:     credentials.IAM.TokenURL,
+			endpointURL:  credentials.IAM.EndpointURL,
+		},
+		accountID:   credentials.IAM.AccountID,
+		endpointURL: credentials.IAM.EndpointURL,
+	}
+}
+
+func (me *serviceUserServiceClient) SchemaID() string {
+	return "accounts:iam:serviceusers"
+}
+
+// createResponse represents the response from creating a service user
+type createResponse struct {
+	UID   string `json:"uid"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+func (me *serviceUserServiceClient) Create(ctx context.Context, serviceUser *serviceusers.ServiceUser) (*api.Stub, error) {
+	responseBytes, err := me.iamClientGetter.New().POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", me.endpointURL, me.accountID), serviceUser, 201, false)
+	if err != nil {
+		return nil, err
+	}
+
+	var response createResponse
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		return nil, err
+	}
+
+	if err := me.updateGroupAssignments(ctx, serviceUser.Email, serviceUser.Groups); err != nil {
+		deleteErr := me.Delete(ctx, response.UID)
+		if deleteErr != nil {
+			return nil, fmt.Errorf("failed to create service user: %v; additionally failed to clean up service user: %v", err, deleteErr)
+		}
+		return nil, err
+	}
+
+	return &api.Stub{ID: response.UID, Name: response.Name}, nil
+}
+
+// getServiceUserResponse represents the response from getting a service user
+type getServiceUserResponse struct {
+	UID         string `json:"uid"`
+	Email       string `json:"email"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func (me *serviceUserServiceClient) Get(ctx context.Context, uid string, v *serviceusers.ServiceUser) error {
+	responseBytes, err := me.iamClientGetter.New().GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, uid), 200, false)
+	if err != nil {
+		return err
+	}
+
+	var response getServiceUserResponse
+	if err = json.Unmarshal(responseBytes, &response); err != nil {
+		return err
+	}
+
+	groups, err := me.getUserGroups(ctx, response.Email)
+	if err != nil {
+		return err
+	}
+
+	v.UID = response.UID
+	v.Email = response.Email
+	v.Name = response.Name
+	v.Description = response.Description
+	v.Groups = groups
+
+	return nil
+}
+
+// groupStub represents a group membership
+type groupStub struct {
+	UUID string `json:"uuid"`
+}
+
+// getUserPartialResponse represents the partial response from getting user information.
+type getUserPartialResponse struct {
+	Groups []*groupStub `json:"groups"`
+}
+
+func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email string) ([]string, error) {
+	responseBytes, err := me.iamClientGetter.New().GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, me.accountID, email), 200, false)
+	if err != nil {
+		return nil, err
+	}
+
+	var response getUserPartialResponse
+	if err = json.Unmarshal(responseBytes, &response); err != nil {
+		return nil, err
+	}
+
+	groups := []string{}
+	for _, group := range response.Groups {
+		groups = append(groups, group.UUID)
+	}
+
+	return groups, nil
+}
+
+func (me *serviceUserServiceClient) Update(ctx context.Context, uid string, serviceUser *serviceusers.ServiceUser) error {
+	// Update the service user details
+	if _, err := me.iamClientGetter.New().PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, uid), serviceUser, 200, false); err != nil {
+		return err
+	}
+
+	// Update group assignments
+	return me.updateGroupAssignments(ctx, serviceUser.Email, serviceUser.Groups)
+}
+
+func (me *serviceUserServiceClient) updateGroupAssignments(ctx context.Context, serviceUserEmail string, groups []string) error {
+	_, err := me.iamClientGetter.New().PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, me.accountID, serviceUserEmail), groups, 200, false)
+	return err
+}
+
+// serviceUserStub represents a service user in the list response
+type serviceUserStub struct {
+	UID   string `json:"uid"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+// listServiceUsersResponse represents the paginated response from listing service users
+type listServiceUsersResponse struct {
+	Count    int                `json:"count"`
+	Items    []*serviceUserStub `json:"results"`
+	NextPage string             `json:"nextPageKey,omitempty"`
+}
+
+func (me *serviceUserServiceClient) List(ctx context.Context) (api.Stubs, error) {
+	client := me.iamClientGetter.New()
+
+	var stubs api.Stubs
+	url := fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", me.endpointURL, me.accountID)
+
+	for {
+		responseBytes, err := client.GET(ctx, url, 200, false)
+		if err != nil {
+			return nil, err
+		}
+
+		var response listServiceUsersResponse
+		if err := json.Unmarshal(responseBytes, &response); err != nil {
+			return nil, err
+		}
+
+		for _, item := range response.Items {
+			stubs = append(stubs, &api.Stub{ID: item.UID, Name: item.Name})
+		}
+
+		// Handle pagination
+		if response.NextPage == "" {
+			break
+		}
+		url = fmt.Sprintf("%s/iam/v1/accounts/%s/service-users?nextPageKey=%s", me.endpointURL, me.accountID, response.NextPage)
+	}
+
+	return stubs, nil
+}
+
+func (me *serviceUserServiceClient) Delete(ctx context.Context, uid string) error {
+	_, err := me.iamClientGetter.New().DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, uid), 200, false)
+	if err != nil {
+		// ignore error if service user does not exist
+		if strings.Contains(err.Error(), fmt.Sprintf("User %s does not exist", uid)) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/dynatrace/api/iam/serviceusers/service_test.go
+++ b/dynatrace/api/iam/serviceusers/service_test.go
@@ -1,0 +1,574 @@
+//go:build unit
+
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package serviceusers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
+	serviceusers "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers/settings"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testAccountID = "test-account-id"
+const testEndpointURL = "https://api-test.dynatrace.com"
+
+type mockIAMClient struct {
+	POSTFunc   func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
+	PUTFunc    func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
+	GETFunc    func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
+	DELETEFunc func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
+}
+
+func (me *mockIAMClient) POST(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+	return me.POSTFunc(ctx, url, payload, expectedResponseCode, forceNewBearer)
+}
+
+func (me *mockIAMClient) PUT(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+	return me.PUTFunc(ctx, url, payload, expectedResponseCode, forceNewBearer)
+}
+
+func (me *mockIAMClient) PUT_MULTI_RESPONSE(ctx context.Context, url string, payload any, expectedResponseCodes []int, forceNewBearer bool) ([]byte, error) {
+	panic("mock doesnt support PUT_MULTI_RESPONSE")
+}
+
+func (me *mockIAMClient) GET(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+	return me.GETFunc(ctx, url, expectedResponseCode, forceNewBearer)
+}
+
+func (me *mockIAMClient) DELETE(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+	return me.DELETEFunc(ctx, url, expectedResponseCode, forceNewBearer)
+}
+
+func (me *mockIAMClient) DELETE_MULTI_RESPONSE(ctx context.Context, url string, expectedResponseCodes []int, forceNewBearer bool) ([]byte, error) {
+	panic("mock doesnt support DELETE_MULTI_RESPONSE")
+}
+
+func createTestServiceUserServiceClient(client *mockIAMClient) *serviceUserServiceClient {
+	return &serviceUserServiceClient{
+		iamClientGetter: &mockIAMClientGetter{
+			client: client,
+		},
+		accountID:   testAccountID,
+		endpointURL: testEndpointURL,
+	}
+}
+
+type mockIAMClientGetter struct {
+	client *mockIAMClient
+}
+
+func (me *mockIAMClientGetter) New() iam.IAMClient {
+	return me.client
+}
+
+func TestService_Create(t *testing.T) {
+	t.Run("successful creation", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", testEndpointURL, testAccountID), url)
+				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
+			},
+			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", testEndpointURL, testAccountID, "test@example.com"), url)
+				return nil, nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{
+			Name:        "Test User",
+			Email:       "test@example.com",
+			Description: "Test description",
+			Groups:      []string{"group-1", "group-2"},
+		}
+
+		stub, err := client.Create(t.Context(), serviceUser)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-uid", stub.ID)
+		assert.Equal(t, "Test User", stub.Name)
+	})
+
+	t.Run("creation fails on POST", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("POST failed")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{
+			Name:  "Test User",
+			Email: "test@example.com",
+		}
+
+		_, err := client.Create(t.Context(), serviceUser)
+		assert.EqualError(t, err, "POST failed")
+	})
+
+	t.Run("creation fails on group assignment and cleanup succeeds", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
+			},
+			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("group assignment failed")
+			},
+			DELETEFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{
+			Name:   "Test User",
+			Email:  "test@example.com",
+			Groups: []string{"group-1"},
+		}
+
+		_, err := client.Create(t.Context(), serviceUser)
+		assert.EqualError(t, err, "group assignment failed")
+	})
+
+	t.Run("creation fails on group assignment and cleanup fails", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
+			},
+			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("group assignment failed")
+			},
+			DELETEFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("delete failed")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{
+			Name:   "Test User",
+			Email:  "test@example.com",
+			Groups: []string{"group-1"},
+		}
+
+		_, err := client.Create(t.Context(), serviceUser)
+		assert.EqualError(t, err, "failed to create service user: group assignment failed; additionally failed to clean up service user: delete failed")
+	})
+
+	t.Run("creation fails on invalid JSON response", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{invalid json`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{
+			Name:  "Test User",
+			Email: "test@example.com",
+		}
+
+		_, err := client.Create(t.Context(), serviceUser)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid character")
+	})
+}
+
+func TestService_Get(t *testing.T) {
+	t.Run("successful get with groups", func(t *testing.T) {
+		getCallCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				getCallCount++
+				if getCallCount == 1 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", testEndpointURL, testAccountID, "test-uid"), url)
+					return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`), nil
+				}
+				if getCallCount == 2 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", testEndpointURL, testAccountID, "test@example.com"), url)
+					return []byte(`{"uid":"test-uid","groups":[{"uuid":"group-1","groupName":"Group 1"},{"uuid":"group-2","groupName":"Group 2"}]}`), nil
+				}
+				assert.FailNow(t, "unexpected call to GET")
+				return nil, errors.New("unexpected call to GET")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{}
+
+		err := client.Get(t.Context(), "test-uid", serviceUser)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, getCallCount)
+		assert.Equal(t, "test@example.com", serviceUser.Email)
+		assert.Equal(t, "Test User", serviceUser.Name)
+		assert.Equal(t, "Test description", serviceUser.Description)
+		assert.ElementsMatch(t, []string{"group-1", "group-2"}, serviceUser.Groups)
+	})
+
+	t.Run("successful get without groups", func(t *testing.T) {
+		getCallCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				getCallCount++
+				if getCallCount == 1 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", testEndpointURL, testAccountID, "test-uid"), url)
+					return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`), nil
+				}
+				if getCallCount == 2 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", testEndpointURL, testAccountID, "test@example.com"), url)
+					return []byte(`{"uid":"test-uid","groups":[]}`), nil
+				}
+				assert.FailNow(t, "unexpected call to GET")
+				return nil, errors.New("unexpected call to GET")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{}
+
+		err := client.Get(t.Context(), "test-uid", serviceUser)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, getCallCount)
+		assert.Equal(t, "test@example.com", serviceUser.Email)
+		assert.Empty(t, serviceUser.Groups)
+	})
+
+	t.Run("get fails on service user fetch", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("GET failed")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{}
+
+		err := client.Get(t.Context(), "test-uid", serviceUser)
+		assert.EqualError(t, err, "GET failed")
+	})
+
+	t.Run("get fails on user groups fetch", func(t *testing.T) {
+		getCallCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				getCallCount++
+				if getCallCount == 1 {
+					return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`), nil
+				}
+				if getCallCount == 2 {
+					return nil, errors.New("groups fetch failed")
+				}
+				assert.FailNow(t, "unexpected call to GET")
+				return nil, errors.New("unexpected call to GET")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{}
+
+		err := client.Get(t.Context(), "test-uid", serviceUser)
+		assert.EqualError(t, err, "groups fetch failed")
+	})
+
+	t.Run("get returns 404 when user not found", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("Service user test-uid does not exist")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{}
+
+		err := client.Get(t.Context(), "test-uid", serviceUser)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Service user test-uid does not exist")
+	})
+
+	t.Run("get fails on invalid JSON for service user", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{invalid json`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{}
+
+		err := client.Get(t.Context(), "test-uid", serviceUser)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid character")
+	})
+
+	t.Run("get fails on invalid JSON for user groups", func(t *testing.T) {
+		getCallCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				getCallCount++
+				if getCallCount == 1 {
+					return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`), nil
+				}
+				if getCallCount == 2 {
+					return []byte(`{invalid json`), nil
+				}
+				assert.FailNow(t, "unexpected call to GET")
+				return nil, errors.New("unexpected call to GET")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{}
+
+		err := client.Get(t.Context(), "test-uid", serviceUser)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid character")
+	})
+}
+
+func TestService_List(t *testing.T) {
+	t.Run("successful list without pagination", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{
+					"count": 2,
+					"results": [
+						{"uid": "uid-1", "email": "user1@example.com", "name": "User 1"},
+						{"uid": "uid-2", "email": "user2@example.com", "name": "User 2"}
+					]
+				}`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		stubs, err := client.List(t.Context())
+		assert.NoError(t, err)
+		assert.Len(t, stubs, 2)
+		assert.Equal(t, "uid-1", stubs[0].ID)
+		assert.Equal(t, "User 1", stubs[0].Name)
+		assert.Equal(t, "uid-2", stubs[1].ID)
+		assert.Equal(t, "User 2", stubs[1].Name)
+	})
+
+	t.Run("successful list with pagination", func(t *testing.T) {
+		callCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				callCount++
+				if callCount == 1 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", testEndpointURL, testAccountID), url)
+					return []byte(`{
+						"count": 2,
+						"results": [
+							{"uid": "uid-1", "email": "user1@example.com", "name": "User 1"}
+						],
+						"nextPageKey": "page2"
+					}`), nil
+				}
+				if callCount == 2 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users?nextPageKey=page2", testEndpointURL, testAccountID), url)
+					return []byte(`{
+					"count": 2,
+					"results": [
+						{"uid": "uid-2", "email": "user2@example.com", "name": "User 2"}
+					]
+				}`), nil
+				}
+				assert.FailNow(t, "unexpected call to GET")
+				return nil, errors.New("unexpected call to GET")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		stubs, err := client.List(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, 2, callCount)
+		assert.Len(t, stubs, 2)
+	})
+
+	t.Run("list fails", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("GET failed")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		_, err := client.List(t.Context())
+		assert.EqualError(t, err, "GET failed")
+	})
+
+	t.Run("list empty", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{
+					"count": 0,
+					"results": []
+				}`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		stubs, err := client.List(t.Context())
+		assert.NoError(t, err)
+		assert.Empty(t, stubs)
+	})
+
+	t.Run("list fails on invalid JSON response", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{invalid json`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		_, err := client.List(t.Context())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid character")
+	})
+}
+
+func TestService_Update(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		putCallCount := 0
+		mockClient := &mockIAMClient{
+			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				putCallCount++
+				if putCallCount == 1 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", testEndpointURL, testAccountID, "test-uid"), url)
+					return nil, nil
+				}
+
+				if putCallCount == 2 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", testEndpointURL, testAccountID, "test@example.com"), url)
+					return nil, nil
+				}
+
+				assert.FailNow(t, "unexpected call to PUT")
+				return nil, errors.New("unexpected call to PUT")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{
+			Name:        "Updated User",
+			Email:       "test@example.com",
+			Description: "Updated description",
+			Groups:      []string{"group-1", "group-2"},
+		}
+
+		err := client.Update(t.Context(), "test-uid", serviceUser)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, putCallCount)
+	})
+
+	t.Run("update fails on user details", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("PUT failed")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{
+			Name:  "Updated User",
+			Email: "test@example.com",
+		}
+
+		err := client.Update(t.Context(), "test-uid", serviceUser)
+		assert.EqualError(t, err, "PUT failed")
+	})
+
+	t.Run("update fails on group assignment", func(t *testing.T) {
+		putCallCount := 0
+		mockClient := &mockIAMClient{
+			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				putCallCount++
+				if putCallCount == 1 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", testEndpointURL, testAccountID, "test-uid"), url)
+					return nil, nil
+				}
+				if putCallCount == 2 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", testEndpointURL, testAccountID, "test@example.com"), url)
+					return nil, errors.New("group assignment failed")
+				}
+				assert.FailNow(t, "unexpected call to PUT")
+				return nil, errors.New("unexpected call to PUT")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		serviceUser := &serviceusers.ServiceUser{
+			Name:   "Updated User",
+			Email:  "test@example.com",
+			Groups: []string{"group-1"},
+		}
+
+		err := client.Update(t.Context(), "test-uid", serviceUser)
+		assert.EqualError(t, err, "group assignment failed")
+	})
+}
+
+func TestService_Delete(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			DELETEFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", testEndpointURL, testAccountID, "test-uid"), url)
+				return nil, nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		err := client.Delete(t.Context(), "test-uid")
+		assert.NoError(t, err)
+	})
+
+	t.Run("delete fails", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			DELETEFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("DELETE failed")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		err := client.Delete(t.Context(), "test-uid")
+		assert.EqualError(t, err, "DELETE failed")
+	})
+
+	t.Run("delete ignores user does not exist error", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			DELETEFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("User test-uid does not exist")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		err := client.Delete(t.Context(), "test-uid")
+		assert.NoError(t, err)
+	})
+}
+
+func TestService_SchemaID(t *testing.T) {
+	client := createTestServiceUserServiceClient(&mockIAMClient{})
+	schemaID := client.SchemaID()
+	assert.Equal(t, "accounts:iam:serviceusers", schemaID)
+}

--- a/dynatrace/api/iam/serviceusers/settings/service_user.go
+++ b/dynatrace/api/iam/serviceusers/settings/service_user.go
@@ -1,0 +1,88 @@
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package serviceusers
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ServiceUser struct {
+	UID         string   `json:"uid,omitempty"`
+	Email       string   `json:"email,omitempty"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Groups      []string `json:"-"`
+}
+
+func (me *ServiceUser) GetName() string {
+	return me.Name
+}
+
+func (me *ServiceUser) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The name of the service user",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The description of the service user",
+		},
+		"groups": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			MinItems:    1,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "The UUIDs of the groups the service user belongs to",
+		},
+		"uid": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The unique identifier of the service user",
+		},
+		"email": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The email of the service user",
+		},
+	}
+}
+
+func (me *ServiceUser) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"name":        me.Name,
+		"description": me.Description,
+		"groups":      me.Groups,
+		"uid":         me.UID,
+		"email":       me.Email,
+	})
+}
+
+func (me *ServiceUser) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"name":        &me.Name,
+		"description": &me.Description,
+		"groups":      &me.Groups,
+		"uid":         &me.UID,
+		"email":       &me.Email,
+	})
+}

--- a/dynatrace/export/enums.go
+++ b/dynatrace/export/enums.go
@@ -234,6 +234,7 @@ var ResourceTypes = struct {
 	AlertingProfile                         ResourceType
 	RequestNamings                          ResourceType
 	IAMUser                                 ResourceType
+	IAMServiceUser                          ResourceType
 	IAMGroup                                ResourceType
 	IAMPermission                           ResourceType
 	IAMPolicy                               ResourceType
@@ -641,6 +642,7 @@ var ResourceTypes = struct {
 	"dynatrace_alerting_profile",
 	"dynatrace_request_namings",
 	"dynatrace_iam_user",
+	"dynatrace_iam_service_user",
 	"dynatrace_iam_group",
 	"dynatrace_iam_permission",
 	"dynatrace_iam_policy",

--- a/dynatrace/export/resource_descriptor.go
+++ b/dynatrace/export/resource_descriptor.go
@@ -314,6 +314,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/boundaries"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/groups"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/policies"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/users"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/v2bindings"
 	platformbuckets "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/platform/buckets"
@@ -902,6 +903,10 @@ var AllResources = map[ResourceType]ResourceDescriptor{
 	),
 	ResourceTypes.IAMUser: NewResourceDescriptor(
 		users.Service,
+		Dependencies.ID(ResourceTypes.IAMGroup),
+	),
+	ResourceTypes.IAMServiceUser: NewResourceDescriptor(
+		serviceusers.Service,
 		Dependencies.ID(ResourceTypes.IAMGroup),
 	),
 	ResourceTypes.IAMGroup: NewResourceDescriptor(

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -351,6 +351,7 @@ func Provider() *schema.Provider {
 			"dynatrace_synthetic_location":                            resources.NewGeneric(export.ResourceTypes.SyntheticLocation).Resource(),
 			"dynatrace_network_zone":                                  resources.NewGeneric(export.ResourceTypes.NetworkZone).Resource(),
 			"dynatrace_iam_user":                                      resources.NewGeneric(export.ResourceTypes.IAMUser, resources.CredValIAM).Resource(),
+			"dynatrace_iam_service_user":                              resources.NewGeneric(export.ResourceTypes.IAMServiceUser, resources.CredValIAM).Resource(),
 			"dynatrace_iam_group":                                     resources.NewGeneric(export.ResourceTypes.IAMGroup, resources.CredValIAM).Resource(),
 			"dynatrace_iam_permission":                                resources.NewGeneric(export.ResourceTypes.IAMPermission, resources.CredValIAM).Resource(),
 			"dynatrace_iam_policy":                                    resources.NewGeneric(export.ResourceTypes.IAMPolicy, resources.CredValIAM).Resource(),


### PR DESCRIPTION
#### **Why** this PR?
This PR adds support for service users by introducing the `dynatrace_iam_service_user` resource and data source.

#### **What** has changed and **how** does it do it?
The `dynatrace_iam_service_user` resource works similarly to `dynatrace_iam_user` resource, allowing the `name`, `description` and `groups` of the service user to be specified.

As groups are assigned using a second API call, a freshly created service user must be explicitly deleted if this second API call fails. This adds complexity to service, and might be addressed by adding a dedicated resource to assign groups in the future.

The `dynatrace_iam_service_user` data source allows a service user can be looked up directly by `id` or by the first matching `name` or `email`. Currently, only a single service user is returned.

#### How is it **tested**?
Currently, IAM resources or data sources in the provider are not covered by E2E tests.
This PR includes tests for the CRUD operations of the service user service as well as the data source read operation.

#### How does it affect **users**?
Users will be able to manage service users using the provider.

**Issue:** CA-16921
