### PR TITLE
fix(request-naming): Correctly decode `unknowns` from HCL for `BaseComparisonInfo`

### DIFF
--- a/dynatrace/api/v1/config/metrics/calculated/service/settings/comparisoninfo/comparison_info.go
+++ b/dynatrace/api/v1/config/metrics/calculated/service/settings/comparisoninfo/comparison_info.go
@@ -83,10 +83,23 @@ func (me *BaseComparisonInfo) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *BaseComparisonInfo) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeAll(map[string]any{
-		"type":     &me.Type,
-		"unknowns": &me.Unknowns,
-	})
+	if value, ok := decoder.GetOk("unknowns"); ok {
+		if err := json.Unmarshal([]byte(value.(string)), me); err != nil {
+			return err
+		}
+		if err := json.Unmarshal([]byte(value.(string)), &me.Unknowns); err != nil {
+			return err
+		}
+		delete(me.Unknowns, "type")
+		if len(me.Unknowns) == 0 {
+			me.Unknowns = nil
+		}
+	}
+	if value, ok := decoder.GetOk("type"); ok {
+		me.Type = Type(value.(string))
+	}
+
+	return nil
 }
 
 func (me *BaseComparisonInfo) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/metrics/calculated/service/settings/comparisoninfo/comparison_info_test.go
+++ b/dynatrace/api/v1/config/metrics/calculated/service/settings/comparisoninfo/comparison_info_test.go
@@ -1,0 +1,132 @@
+//go:build unit
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package comparisoninfo
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaseComparisonInfo_UnmarshalHCL_MarshalJSON(t *testing.T) {
+	s := new(BaseComparisonInfo).Schema()
+
+	cases := []struct {
+		name         string
+		input        map[string]interface{}
+		expectedJSON string
+	}{
+		{
+			name: "basic type only - STRING",
+			input: map[string]interface{}{
+				"type": "STRING",
+			},
+			expectedJSON: `{"negate":false,"type":"STRING"}`,
+		},
+		{
+			name: "empty unknowns string",
+			input: map[string]interface{}{
+				"type":     "STRING",
+				"unknowns": `{}`,
+			},
+			expectedJSON: `{"negate":false,"type":"STRING"}`,
+		},
+		{
+			name: "basic type only - NUMBER",
+			input: map[string]interface{}{
+				"type": "NUMBER",
+			},
+			expectedJSON: `{"negate":false,"type":"NUMBER"}`,
+		},
+		{
+			name: "basic type only - BOOLEAN",
+			input: map[string]interface{}{
+				"type": "BOOLEAN",
+			},
+			expectedJSON: `{"negate":false,"type":"BOOLEAN"}`,
+		},
+		{
+			name: "type with unknowns containing extra fields",
+			input: map[string]interface{}{
+				"type":     "STRING",
+				"unknowns": `{"comparison":"EQUALS","value":"test-value"}`,
+			},
+			expectedJSON: `{"negate":false,"type":"STRING","comparison":"EQUALS","value":"test-value"}`,
+		},
+		{
+			name: "unknowns with negate set to true",
+			input: map[string]interface{}{
+				"type":     "STRING",
+				"unknowns": `{"negate":true,"comparison":"CONTAINS"}`,
+			},
+			// negate from unknowns is unmarshalled, then MarshalJSON outputs it
+			expectedJSON: `{"negate":true,"type":"STRING","comparison":"CONTAINS"}`,
+		},
+		{
+			name: "unknowns containing type field - explicit type takes precedence",
+			input: map[string]interface{}{
+				"type":     "NUMBER",
+				"unknowns": `{"type":"STRING","comparison":"EQUALS"}`,
+			},
+			// The explicit "type" field in HCL takes precedence over unknowns
+			expectedJSON: `{"negate":false,"type":"NUMBER","comparison":"EQUALS"}`,
+		},
+		{
+			name: "unknowns with nested object",
+			input: map[string]interface{}{
+				"type":     "TAG",
+				"unknowns": `{"value":{"context":"CONTEXTLESS","key":"my-tag"}}`,
+			},
+			expectedJSON: `{"negate":false,"type":"TAG","value":{"context":"CONTEXTLESS","key":"my-tag"}}`,
+		},
+		{
+			name: "unknowns allows for complex type - STRING_ONE_AGENT_ATTRIBUTE",
+			input: map[string]interface{}{
+				"type":     "STRING_ONE_AGENT_ATTRIBUTE",
+				"unknowns": `{"caseSensitive":false,"comparison":"CONTAINS","oneAgentAttributeKey":"http.route","value":"/services/*"}`,
+			},
+			expectedJSON: `{"negate":false,"type":"STRING_ONE_AGENT_ATTRIBUTE","caseSensitive":false,"comparison":"CONTAINS","oneAgentAttributeKey":"http.route","value":"/services/*"}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Create test resource data from HCL input
+			d := schema.TestResourceDataRaw(t, s, c.input)
+			require.NotNil(t, d)
+
+			// Unmarshal HCL into BaseComparisonInfo
+			var info BaseComparisonInfo
+			decoder := hcl.DecoderFrom(d)
+			err := info.UnmarshalHCL(decoder)
+			require.NoError(t, err)
+
+			// Marshal to JSON
+			actualJSON, err := info.MarshalJSON()
+			require.NoError(t, err)
+
+			// Compare JSON output
+			assert.JSONEq(t, c.expectedJSON, string(actualJSON))
+		})
+	}
+}

--- a/dynatrace/api/v1/config/requestnaming/testdata/terraform/with-generic-comparison.tf
+++ b/dynatrace/api/v1/config/requestnaming/testdata/terraform/with-generic-comparison.tf
@@ -1,0 +1,21 @@
+resource "dynatrace_request_naming" "terraform-request-naming-global" {
+  enabled        = true
+  naming_pattern = "terraform-request-naming-global"
+  conditions {
+    condition {
+      attribute = "ONE_AGENT_ATTRIBUTE"
+      comparison {
+        generic {
+          type     = "STRING_ONE_AGENT_ATTRIBUTE"
+          unknowns = jsonencode({
+            "caseSensitive": false,
+            "comparison": "CONTAINS",
+            "oneAgentAttributeKey": "http.route",
+            "value": "/services/*",
+            "values": null
+          })
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
Currently, users can not use the `generic` comparison type, as `unknowns` cannot be used.

#### **What** has changed?
The way `unknowns` was decoded was wrong and always yielded an empty result. This PR fixes this.

#### **How** does it do it?
If `unknowns` is present in the HCL, we unmarshal it via `json.Unmarshal`

#### How is it **tested**?
No test. Manual check that for `dynatrace_request_naming` with `unknowns` set in `comparison`, the correct payload is sent.

#### How does it affect **users**?
It fixes a bug and enables users to make use of `unknowns` in `comparison` in `dynatrace_request_naming`.

**Issue:**
CA-17511