### PR TITLE
feat: Add `dynatrace_iam_service_user` data source

### DIFF
--- a/datasources/iam/serviceusers/data_source.go
+++ b/datasources/iam/serviceusers/data_source.go
@@ -1,0 +1,181 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package serviceusers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers"
+	su "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: logging.EnableDSCtx(DataSourceRead),
+		Description: "Fetches IAM service user details by name, ID, or email",
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The name of the service user",
+				ExactlyOneOf: []string{"name", "id", "email"},
+			},
+			"id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The UUID of the service user",
+				ExactlyOneOf: []string{"name", "id", "email"},
+			},
+			"email": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The email of the service user",
+				ExactlyOneOf: []string{"name", "id", "email"},
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the service user",
+			},
+			"groups": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: "The UUIDs of the groups the service user belongs to",
+			},
+		},
+	}
+}
+
+func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	creds, err := config.Credentials(m, config.CredValIAM)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	service := serviceusers.NewService(creds)
+	return dataSourceReadWithService(ctx, d, service)
+}
+
+func dataSourceReadWithService(ctx context.Context, d *schema.ResourceData, service serviceusers.ServiceUserService) diag.Diagnostics {
+	id, serviceUser, err := findServiceUser(ctx, d, service)
+	if err != nil {
+		d.SetId("")
+		return diag.FromErr(err)
+	}
+
+	d.SetId(id)
+	if err := d.Set("name", serviceUser.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("email", serviceUser.Email); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", serviceUser.Description); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("groups", serviceUser.Groups); err != nil {
+		return diag.FromErr(err)
+	}
+	return diag.Diagnostics{}
+}
+
+func findServiceUser(ctx context.Context, d *schema.ResourceData, service serviceusers.ServiceUserService) (string, *su.ServiceUser, error) {
+	if id, ok := tryGetStringByKey(d, "id"); ok {
+		return findServiceUserByID(ctx, id, service)
+	} else if name, ok := tryGetStringByKey(d, "name"); ok {
+		return findServiceUserByName(ctx, name, service)
+	} else if email, ok := tryGetStringByKey(d, "email"); ok {
+		return findServiceUserByEmail(ctx, email, service)
+	}
+
+	return "", nil, errors.New("either id, name, or email must be provided for lookup")
+}
+
+func findServiceUserByID(ctx context.Context, id string, service serviceusers.ServiceUserService) (string, *su.ServiceUser, error) {
+	var serviceUser su.ServiceUser
+	if err := service.Get(ctx, id, &serviceUser); err != nil {
+		return "", nil, err
+	}
+
+	return id, &serviceUser, nil
+}
+
+func findServiceUserByName(ctx context.Context, name string, service serviceusers.ServiceUserService) (string, *su.ServiceUser, error) {
+	stubs, err := service.GetAll(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var foundID string
+	for _, stub := range stubs {
+		if stub.Name == name {
+			if foundID != "" {
+				return "", nil, fmt.Errorf("multiple service users found with name '%s'", name)
+			}
+			foundID = stub.UID
+		}
+	}
+
+	if foundID == "" {
+		return "", nil, fmt.Errorf("no service user found with name '%s'", name)
+	}
+
+	var serviceUser su.ServiceUser
+	if err := service.Get(ctx, foundID, &serviceUser); err != nil {
+		return "", nil, err
+	}
+
+	return foundID, &serviceUser, nil
+}
+
+func findServiceUserByEmail(ctx context.Context, email string, service serviceusers.ServiceUserService) (string, *su.ServiceUser, error) {
+	stubs, err := service.GetAll(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+
+	for _, stub := range stubs {
+		if stub.Email == email {
+			var serviceUser su.ServiceUser
+			if err := service.Get(ctx, stub.UID, &serviceUser); err != nil {
+				return "", nil, err
+			}
+
+			return stub.UID, &serviceUser, nil
+		}
+	}
+
+	return "", nil, fmt.Errorf("no service user found with email '%s'", email)
+}
+
+func tryGetStringByKey(d *schema.ResourceData, key string) (string, bool) {
+	v, ok := d.GetOk(key)
+	if !ok {
+		return "", false
+	}
+
+	vStr, ok := v.(string)
+	return vStr, ok
+}

--- a/datasources/iam/serviceusers/data_source_test.go
+++ b/datasources/iam/serviceusers/data_source_test.go
@@ -1,0 +1,349 @@
+//go:build unit
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package serviceusers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers"
+	su "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers/settings"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockCRUDService implements settings.CRUDService for testing
+type mockCRUDService struct {
+	getFunc    func(ctx context.Context, id string, v *su.ServiceUser) error
+	getAllFunc func(ctx context.Context) ([]serviceusers.ServiceUserStub, error)
+}
+
+func (m *mockCRUDService) Get(ctx context.Context, id string, v *su.ServiceUser) error {
+	return m.getFunc(ctx, id, v)
+}
+
+func (m *mockCRUDService) GetAll(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+	return m.getAllFunc(ctx)
+}
+
+func (m *mockCRUDService) Update(ctx context.Context, id string, v *su.ServiceUser) error {
+	panic("unexpected call to Update")
+}
+
+func (m *mockCRUDService) List(ctx context.Context) (api.Stubs, error) {
+	panic("unexpected call to List")
+}
+func (m *mockCRUDService) Create(ctx context.Context, v *su.ServiceUser) (*api.Stub, error) {
+	panic("unexpected call to Create")
+}
+func (m *mockCRUDService) Delete(ctx context.Context, id string) error {
+	panic("unexpected call to Delete")
+}
+func (m *mockCRUDService) SchemaID() string { return "" }
+
+func TestDataSourceReadWithService(t *testing.T) {
+	t.Run("lookup by ID succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"id": "test-uid",
+		})
+
+		mockService := &mockCRUDService{
+			getFunc: func(ctx context.Context, id string, v *su.ServiceUser) error {
+				assert.Equal(t, "test-uid", id)
+				v.Name = "Test User"
+				v.Email = "test@example.com"
+				v.Description = "Test description"
+				v.Groups = []string{"group-1"}
+				return nil
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.Empty(t, diags)
+		assert.Equal(t, "test-uid", d.Id())
+		assert.Equal(t, "Test User", d.Get("name"))
+		assert.Equal(t, "test@example.com", d.Get("email"))
+		assert.Equal(t, "Test description", d.Get("description"))
+
+		groups := d.Get("groups").(*schema.Set)
+		assert.NotNil(t, groups)
+		assert.Equal(t, []interface{}{"group-1"}, groups.List())
+	})
+
+	t.Run("lookup by ID fails if get fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"id": "test-uid",
+		})
+
+		mockService := &mockCRUDService{
+			getFunc: func(ctx context.Context, id string, v *su.ServiceUser) error {
+				return assert.AnError
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, assert.AnError.Error())
+	})
+
+	t.Run("lookup by name succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"name": "Test User",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{
+					{UID: "uid-1", Name: "Other User", Email: "other@example.com", Description: "Not the one"},
+					{UID: "uid-2", Name: "Test User", Email: "test@example.com", Description: "Found user"},
+				}, nil
+			},
+			getFunc: func(ctx context.Context, id string, v *su.ServiceUser) error {
+				if id == "uid-2" {
+					v.Name = "Test User"
+					v.Email = "test@example.com"
+					v.Description = "Found user"
+					v.Groups = []string{"group-1"}
+					return nil
+				}
+
+				assert.FailNow(t, "unexpected ID in Get:", id)
+				return assert.AnError
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.Empty(t, diags)
+		assert.Equal(t, "uid-2", d.Id())
+		assert.Equal(t, "Test User", d.Get("name"))
+		assert.Equal(t, "test@example.com", d.Get("email"))
+		assert.Equal(t, "Found user", d.Get("description"))
+		groups := d.Get("groups").(*schema.Set)
+		assert.NotNil(t, groups)
+		assert.Equal(t, []interface{}{"group-1"}, groups.List())
+	})
+
+	t.Run("lookup by name with duplicates fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"name": "Duplicate User",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{
+					{UID: "uid-1", Name: "Duplicate User", Email: "first@example.com", Description: "First duplicate"},
+					{UID: "uid-2", Name: "Duplicate User", Email: "second@example.com", Description: "Second duplicate"},
+				}, nil
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, "multiple service users found with name")
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("lookup by name not found", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"name": "Nonexistent User",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{
+					{UID: "uid-1", Name: "Other User", Email: "other@example.com", Description: "Not the one"},
+				}, nil
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, "no service user found with name")
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("lookup by name fails if get all fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"name": "Test User",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return nil, assert.AnError
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, assert.AnError.Error())
+	})
+
+	t.Run("lookup by name fails if get fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"name": "Test User",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{
+					{UID: "uid-1", Name: "Test User", Email: "test@example.com", Description: "Found by email"},
+				}, nil
+			},
+			getFunc: func(ctx context.Context, id string, v *su.ServiceUser) error {
+				return assert.AnError
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, assert.AnError.Error())
+	})
+
+	t.Run("lookup by name fails if get all returns empty", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"name": "Test User",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{}, nil
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, "no service user found with name")
+	})
+
+	t.Run("lookup by email succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"email": "test@example.com",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{
+					{UID: "uid-1", Name: "Test User", Email: "test@example.com", Description: "Found by email"},
+				}, nil
+			},
+			getFunc: func(ctx context.Context, id string, v *su.ServiceUser) error {
+				v.Name = "Test User"
+				v.Email = "test@example.com"
+				v.Description = "Found by email"
+				v.Groups = []string{"group-1"}
+				return nil
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.Empty(t, diags)
+		assert.Equal(t, "uid-1", d.Id())
+		assert.Equal(t, "test@example.com", d.Get("email"))
+		assert.Equal(t, "Found by email", d.Get("description"))
+		groups := d.Get("groups").(*schema.Set)
+		assert.NotNil(t, groups)
+		assert.Equal(t, []interface{}{"group-1"}, groups.List())
+	})
+
+	t.Run("lookup by email not found", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"email": "nonexistent@example.com",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{
+					{UID: "uid-1", Name: "Other User", Email: "other@example.com", Description: "Not the one"},
+				}, nil
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, "no service user found with email")
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("lookup by email fails if get all fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"email": "test@example.com",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return nil, assert.AnError
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, assert.AnError.Error())
+	})
+
+	t.Run("lookup by email fails if get fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"email": "test@example.com",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{
+					{UID: "uid-1", Name: "Test User", Email: "test@example.com", Description: "Found by email"},
+				}, nil
+			},
+			getFunc: func(ctx context.Context, id string, v *su.ServiceUser) error {
+				return assert.AnError
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, assert.AnError.Error())
+	})
+
+	t.Run("lookup by email fails if get all returns empty", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]interface{}{
+			"email": "test@example.com",
+		})
+
+		mockService := &mockCRUDService{
+			getAllFunc: func(ctx context.Context) ([]serviceusers.ServiceUserStub, error) {
+				return []serviceusers.ServiceUserStub{}, nil
+			},
+		}
+
+		diags := dataSourceReadWithService(t.Context(), d, mockService)
+
+		assert.NotEmpty(t, diags)
+		assert.Contains(t, diags[0].Summary, "no service user found with email")
+	})
+}

--- a/dynatrace/api/iam/serviceusers/service.go
+++ b/dynatrace/api/iam/serviceusers/service.go
@@ -29,6 +29,11 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 )
 
+type ServiceUserService interface {
+	settings.CRUDService[*serviceusers.ServiceUser]
+	GetAll(ctx context.Context) ([]ServiceUserStub, error)
+}
+
 type iamClientGetter interface {
 	New() iam.IAMClient
 }
@@ -71,7 +76,7 @@ type serviceUserServiceClient struct {
 	endpointURL     string
 }
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*serviceusers.ServiceUser] {
+func NewService(credentials *rest.Credentials) ServiceUserService {
 	return &serviceUserServiceClient{
 		iamClientGetter: &iamClientGetterImp{
 			clientID:     credentials.IAM.ClientID,
@@ -83,6 +88,10 @@ func Service(credentials *rest.Credentials) settings.CRUDService[*serviceusers.S
 		accountID:   credentials.IAM.AccountID,
 		endpointURL: credentials.IAM.EndpointURL,
 	}
+}
+
+func Service(credentials *rest.Credentials) settings.CRUDService[*serviceusers.ServiceUser] {
+	return NewService(credentials)
 }
 
 func (me *serviceUserServiceClient) SchemaID() string {
@@ -198,24 +207,25 @@ func (me *serviceUserServiceClient) updateGroupAssignments(ctx context.Context, 
 	return err
 }
 
-// serviceUserStub represents a service user in the list response
-type serviceUserStub struct {
-	UID   string `json:"uid"`
-	Email string `json:"email"`
-	Name  string `json:"name"`
+// ServiceUserStub represents a service user in the list response
+type ServiceUserStub struct {
+	UID         string `json:"uid"`
+	Email       string `json:"email"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 }
 
 // listServiceUsersResponse represents the paginated response from listing service users
 type listServiceUsersResponse struct {
-	Count    int                `json:"count"`
-	Items    []*serviceUserStub `json:"results"`
-	NextPage string             `json:"nextPageKey,omitempty"`
+	Count    int               `json:"count"`
+	Items    []ServiceUserStub `json:"results"`
+	NextPage string            `json:"nextPageKey,omitempty"`
 }
 
-func (me *serviceUserServiceClient) List(ctx context.Context) (api.Stubs, error) {
+func (me *serviceUserServiceClient) GetAll(ctx context.Context) ([]ServiceUserStub, error) {
 	client := me.iamClientGetter.New()
 
-	var stubs api.Stubs
+	var stubs []ServiceUserStub
 	url := fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", me.endpointURL, me.accountID)
 
 	for {
@@ -229,15 +239,30 @@ func (me *serviceUserServiceClient) List(ctx context.Context) (api.Stubs, error)
 			return nil, err
 		}
 
-		for _, item := range response.Items {
-			stubs = append(stubs, &api.Stub{ID: item.UID, Name: item.Name})
-		}
+		stubs = append(stubs, response.Items...)
 
 		// Handle pagination
 		if response.NextPage == "" {
 			break
 		}
 		url = fmt.Sprintf("%s/iam/v1/accounts/%s/service-users?nextPageKey=%s", me.endpointURL, me.accountID, response.NextPage)
+	}
+
+	return stubs, nil
+}
+
+func (me *serviceUserServiceClient) List(ctx context.Context) (api.Stubs, error) {
+	var stubs api.Stubs
+	serviceUserStubs, err := me.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, serviceUserStub := range serviceUserStubs {
+		stubs = append(stubs, &api.Stub{
+			ID:   serviceUserStub.UID,
+			Name: serviceUserStub.Name,
+		})
 	}
 
 	return stubs, nil

--- a/dynatrace/api/iam/serviceusers/service_test.go
+++ b/dynatrace/api/iam/serviceusers/service_test.go
@@ -362,6 +362,193 @@ func TestService_Get(t *testing.T) {
 	})
 }
 
+func TestService_GetAll(t *testing.T) {
+	t.Run("successful get all without pagination", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", testEndpointURL, testAccountID), url)
+				return []byte(`{
+					"count": 2,
+					"results": [
+						{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": "Desc 1"},
+						{"uid": "uid-2", "email": "user2@example.com", "name": "User 2", "description": "Desc 2"}
+					]
+				}`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		stubs, err := client.GetAll(t.Context())
+		assert.NoError(t, err)
+		assert.Len(t, stubs, 2)
+		assert.Equal(t, "uid-1", stubs[0].UID)
+		assert.Equal(t, "user1@example.com", stubs[0].Email)
+		assert.Equal(t, "User 1", stubs[0].Name)
+		assert.Equal(t, "Desc 1", stubs[0].Description)
+		assert.Equal(t, "uid-2", stubs[1].UID)
+		assert.Equal(t, "user2@example.com", stubs[1].Email)
+		assert.Equal(t, "User 2", stubs[1].Name)
+		assert.Equal(t, "Desc 2", stubs[1].Description)
+	})
+
+	t.Run("successful get all with pagination", func(t *testing.T) {
+		callCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				callCount++
+				if callCount == 1 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", testEndpointURL, testAccountID), url)
+					return []byte(`{
+						"count": 2,
+						"results": [
+							{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": "Desc 1"}
+						],
+						"nextPageKey": "page2"
+					}`), nil
+				}
+				if callCount == 2 {
+					assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users?nextPageKey=page2", testEndpointURL, testAccountID), url)
+					return []byte(`{
+						"count": 2,
+						"results": [
+							{"uid": "uid-2", "email": "user2@example.com", "name": "User 2", "description": "Desc 2"}
+						]
+					}`), nil
+				}
+				assert.FailNow(t, "unexpected call to GET")
+				return nil, errors.New("unexpected call to GET")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		stubs, err := client.GetAll(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, 2, callCount)
+		assert.Len(t, stubs, 2)
+		assert.Equal(t, "uid-1", stubs[0].UID)
+		assert.Equal(t, "uid-2", stubs[1].UID)
+	})
+
+	t.Run("successful get all with multiple pagination pages", func(t *testing.T) {
+		callCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				callCount++
+				if callCount == 1 {
+					return []byte(`{
+						"count": 3,
+						"results": [{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": ""}],
+						"nextPageKey": "page2"
+					}`), nil
+				}
+				if callCount == 2 {
+					return []byte(`{
+						"count": 3,
+						"results": [{"uid": "uid-2", "email": "user2@example.com", "name": "User 2", "description": ""}],
+						"nextPageKey": "page3"
+					}`), nil
+				}
+				if callCount == 3 {
+					return []byte(`{
+						"count": 3,
+						"results": [{"uid": "uid-3", "email": "user3@example.com", "name": "User 3", "description": ""}]
+					}`), nil
+				}
+				assert.FailNow(t, "unexpected call to GET")
+				return nil, errors.New("unexpected call to GET")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		stubs, err := client.GetAll(t.Context())
+		assert.NoError(t, err)
+		assert.Equal(t, 3, callCount)
+		assert.Len(t, stubs, 3)
+	})
+
+	t.Run("get all fails", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return nil, errors.New("GET failed")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		_, err := client.GetAll(t.Context())
+		assert.EqualError(t, err, "GET failed")
+	})
+
+	t.Run("get all fails on second page", func(t *testing.T) {
+		callCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				callCount++
+				if callCount == 1 {
+					return []byte(`{
+						"count": 2,
+						"results": [{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": ""}],
+						"nextPageKey": "page2"
+					}`), nil
+				}
+				return nil, errors.New("pagination failed")
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		_, err := client.GetAll(t.Context())
+		assert.EqualError(t, err, "pagination failed")
+	})
+
+	t.Run("get all empty", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{
+					"count": 0,
+					"results": []
+				}`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		stubs, err := client.GetAll(t.Context())
+		assert.NoError(t, err)
+		assert.Empty(t, stubs)
+	})
+
+	t.Run("get all fails on invalid JSON response", func(t *testing.T) {
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				return []byte(`{invalid json`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		_, err := client.GetAll(t.Context())
+		assert.ErrorContains(t, err, "invalid character")
+	})
+
+	t.Run("get all fails on invalid JSON response on second page", func(t *testing.T) {
+		callCount := 0
+		mockClient := &mockIAMClient{
+			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+				callCount++
+				if callCount == 1 {
+					return []byte(`{
+						"count": 2,
+						"results": [{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": ""}],
+						"nextPageKey": "page2"
+					}`), nil
+				}
+				return []byte(`{invalid json`), nil
+			},
+		}
+
+		client := createTestServiceUserServiceClient(mockClient)
+		_, err := client.GetAll(t.Context())
+		assert.ErrorContains(t, err, "invalid character")
+	})
+}
+
 func TestService_List(t *testing.T) {
 	t.Run("successful list without pagination", func(t *testing.T) {
 		mockClient := &mockIAMClient{

--- a/dynatrace/export/resource_descriptor.go
+++ b/dynatrace/export/resource_descriptor.go
@@ -429,7 +429,6 @@ import (
 	openpipelineusersessionsingestsources "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/usersessions/ingestsources"
 	openpipelineusersessionspipelines "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/usersessions/pipelines"
 	openpipelineusersessionsrouting "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/openpipeline/usersessions/routing"
-
 	//azureconnection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/azure"
 	//azureconnectionauthentication "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/authentication"
 )

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -48,6 +48,7 @@ import (
 	environments2 "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/environments"
 	ds_iam_groups "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/groups"
 	ds_iam_policies "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/policies"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/serviceusers"
 	ds_iam_users "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/iam/users"
 	metricsds "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/metrics/calculated/service"
 	mgmzds "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/mgmz"
@@ -233,6 +234,7 @@ func Provider() *schema.Provider {
 			"dynatrace_entities":                     entities.DataSource(),
 			"dynatrace_iam_user":                     ds_iam_users.DataSource(),
 			"dynatrace_iam_environments":             environments2.DataSource(),
+			"dynatrace_iam_service_user":             serviceusers.DataSource(),
 			"dynatrace_request_naming":               requestnaming.DataSource(),
 			"dynatrace_dashboard":                    dashboard.DataSource(),
 			"dynatrace_slo":                          slo.DataSource(),

--- a/templates/data-sources/iam_service_user.md.tmpl
+++ b/templates/data-sources/iam_service_user.md.tmpl
@@ -1,0 +1,64 @@
+---
+layout: ""
+page_title: "dynatrace_iam_service_user Data Source - terraform-provider-dynatrace"
+subcategory: "IAM"
+description: |-
+  The data source `dynatrace_iam_service_user` covers queries for a service user.
+---
+
+# dynatrace_iam_service_user (Data Source)
+
+-> **Dynatrace SaaS only**
+
+-> To utilize this resource, please define the environment variables `DT_CLIENT_ID`, `DT_CLIENT_SECRET`, `DT_ACCOUNT_ID` with an OAuth client including the following permission: **Allow read access for identity resources (users and groups)** (`account-idm-read`).
+
+This data source allows you to query a service user by ID, name, or email address. Note: as the name of a service user is not necessarily unique, the data source will produce an error if two or more service users exist with the specified name.
+
+## Example Usage
+Query a service user by name:
+```terraform
+data "dynatrace_iam_service_user" "test_service_user" {
+  name = "test"
+} 
+
+output "test_service_user" {
+    value = data.dynatrace_iam_service_user.test_service_user
+}
+```
+
+Query a service user by ID:
+```terraform
+data "dynatrace_iam_service_user" "test_service_user" {
+  id = "12345678-90ab-cdef-1234-567890abcdef"
+} 
+
+output "test_service_user" {
+  value = data.dynatrace_iam_service_user.test_service_user
+}
+```
+
+Query a service user by email:
+```terraform
+data "dynatrace_iam_service_user" "test_service_user" {
+  email = "12345678-90ab-cdef-1234-567890abcdef@service.sso.dynatrace.com"
+} 
+
+output "test_service_user" {
+  value = data.dynatrace_iam_service_user.test_service_user
+}
+```
+
+## Example Output
+```
+test_service_user = {
+  "description" = "Test service user"
+  "email" = "12345678-90ab-cdef-1234-567890abcdef@service.sso.dynatrace.com"
+  "groups" = tolist([
+    "abcdef12-3456-7890-abcd-ef1234567890",
+  ])
+  "id" = "12345678-90ab-cdef-1234-567890abcdef"
+  "name" = "test"
+}
+```
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/data-sources/iam_user.md.tmpl
+++ b/templates/data-sources/iam_user.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "dynatrace_iam_user Data Source - terraform-provider-dynatrace"
 subcategory: "IAM"
 description: |-
-  The data source `dynatrace_iam_user` covers queries for the groups a user is a member of
+  The data source `dynatrace_iam_user` covers queries for the groups a user is a member of.
 ---
 
 # dynatrace_iam_user (Data Source)
@@ -12,7 +12,7 @@ description: |-
 
 -> To utilize this resource, please define the environment variables `DT_CLIENT_ID`, `DT_CLIENT_SECRET`, `DT_ACCOUNT_ID` with an OAuth client including the following permission: **Allow read access for identity resources (users and groups)** (`account-idm-read`).
 
-This data source allows you to specify the email address of the user and produces an ordered list of group IDs this user is a member of
+This data source allows you to specify the email address of the user and produces an ordered list of group IDs this user is a member of.
 
 ## Example Usage
 


### PR DESCRIPTION
#### **Why** this PR?
This PR adds the `dynatrace_iam_service_user` data source which allows a service user to be retrieved by ID:

```
data "dynatrace_iam_service_user" "sus" {
    id = "01234567-0123-4567-89ab-cdef01234567"
} 
```

or email:

```
data "dynatrace_iam_service_user" "sus" {
    email = "01234567-0123-4567-89ab-cdef01234567@service.sso.dynatrace.com"
}
```

or name:

```
data "dynatrace_iam_service_user" "su" {
  name = "test"
} 
```

The data block will then have a value like:
```
{
  "description" = "Test service user"
  "email" = "01234567-0123-4567-89ab-cdef01234567@service.sso.dynatrace.com"
  "groups" = tolist([
    "01234567-0123-4567-89ab-cdef01234567",
  ])
  "id" = "01234567-0123-4567-89ab-cdef01234567"
  "name" = "test"
}
```

#### **What** has changed?
Adds `dynatrace_iam_service_user` data source.

#### **How** does it do it?
Adds `DataSource()` that returns a `schema.Resource` with an associated `ReadContext`.

#### How is it **tested**?
Explicit tests for the data source are added, including tests for retrieval by ID, name, and email.

#### How does it affect **users**?
`dynatrace_iam_service_user` data source is available.

**Issue:** CA-17089
