### PR TITLE
chore: deprecate old OpenPipeline business event processing and security resources

### DIFF
--- a/dynatrace/api/builtin/bizevents/processing/buckets/settings/settings.go
+++ b/dynatrace/api/builtin/bizevents/processing/buckets/settings/settings.go
@@ -30,6 +30,10 @@ type Settings struct {
 	InsertAfter string `json:"-"`
 }
 
+func (me *Settings) Deprecated() string {
+	return "Classic bizevents processing rules have been deprecated in favor of OpenPipeline. Please migrate your OpenPipeline configurations and use `dynatrace_openpipeline_v2_*` instead."
+}
+
 func (me *Settings) Name() string {
 	return me.RuleName
 }

--- a/dynatrace/api/builtin/bizevents/processing/metrics/settings/settings.go
+++ b/dynatrace/api/builtin/bizevents/processing/metrics/settings/settings.go
@@ -33,6 +33,10 @@ type Settings struct {
 	MeasureAttribute *string  `json:"measureAttribute,omitempty"` // Attribute
 }
 
+func (me *Settings) Deprecated() string {
+	return "Classic bizevents processing rules have been deprecated in favor of OpenPipeline. Please migrate your OpenPipeline configurations and use `dynatrace_openpipeline_v2_*` instead."
+}
+
 func (me *Settings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"dimensions": {

--- a/dynatrace/api/builtin/bizevents/processing/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/bizevents/processing/pipelines/settings/settings.go
@@ -32,6 +32,10 @@ type Settings struct {
 	InsertAfter          string               `json:"-"`
 }
 
+func (me *Settings) Deprecated() string {
+	return "Classic bizevents processing rules have been deprecated in favor of OpenPipeline. Please migrate your OpenPipeline configurations and use `dynatrace_openpipeline_v2_*` instead."
+}
+
 func (me *Settings) Name() string {
 	return me.RuleName
 }

--- a/dynatrace/api/builtin/bizevents/security/contextrules/settings/settings.go
+++ b/dynatrace/api/builtin/bizevents/security/contextrules/settings/settings.go
@@ -27,6 +27,10 @@ type Settings struct {
 	InsertAfter         string               `json:"-"`
 }
 
+func (me *Settings) Deprecated() string {
+	return "Classic bizevents processing rules have been deprecated in favor of OpenPipeline. Please migrate your OpenPipeline configurations and use `dynatrace_openpipeline_v2_*` instead."
+}
+
 func (me *Settings) Name() string {
 	return me.SecurityContextRule.RuleName
 }

--- a/templates/resources/business_events_buckets.md.tmpl
+++ b/templates/resources/business_events_buckets.md.tmpl
@@ -1,12 +1,15 @@
 ---
 layout: ""
 page_title: "dynatrace_business_events_buckets Resource - terraform-provider-dynatrace"
-subcategory: "Business Events"
+subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_business_events_buckets` covers configuration for business event bucket assignment
 ---
 
 # dynatrace_business_events_buckets (Resource)
+
+~> **Warning** This resource has been deprecated in favor of OpenPipeline.
+Please migrate your OpenPipeline configurations and use `dynatrace_openpipeline_v2_*` instead.
 
 -> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
 
@@ -27,4 +30,3 @@ The full documentation of the export feature is available [here](https://dt-url.
 {{ tffile "dynatrace/api/builtin/bizevents/processing/buckets/testdata/terraform/example_a.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
- 

--- a/templates/resources/business_events_metrics.md.tmpl
+++ b/templates/resources/business_events_metrics.md.tmpl
@@ -1,12 +1,15 @@
 ---
 layout: ""
 page_title: "dynatrace_business_events_metrics Resource - terraform-provider-dynatrace"
-subcategory: "Business Events"
+subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_business_events_metrics` covers configuration for business event metric extraction
 ---
 
 # dynatrace_business_events_metrics (Resource)
+
+~> **Warning** This resource has been deprecated in favor of OpenPipeline.
+Please migrate your OpenPipeline configurations and use `dynatrace_openpipeline_v2_*` instead.
 
 -> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
 
@@ -27,4 +30,3 @@ The full documentation of the export feature is available [here](https://dt-url.
 {{ tffile "dynatrace/api/builtin/bizevents/processing/metrics/testdata/terraform/example_a.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
- 

--- a/templates/resources/business_events_processing.md.tmpl
+++ b/templates/resources/business_events_processing.md.tmpl
@@ -1,12 +1,15 @@
 ---
 layout: ""
 page_title: "dynatrace_business_events_processing Resource - terraform-provider-dynatrace"
-subcategory: "Business Events"
+subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_business_events_processing` covers configuration for business event processing
 ---
 
 # dynatrace_business_events_processing (Resource)
+
+~> **Warning** This resource has been deprecated in favor of OpenPipeline.
+Please migrate your OpenPipeline configurations and use `dynatrace_openpipeline_v2_*` instead.
 
 -> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
 
@@ -27,4 +30,3 @@ The full documentation of the export feature is available [here](https://dt-url.
 {{ tffile "dynatrace/api/builtin/bizevents/processing/pipelines/testdata/terraform/example_a.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
- 

--- a/templates/resources/business_events_security_context.md.tmpl
+++ b/templates/resources/business_events_security_context.md.tmpl
@@ -1,12 +1,15 @@
 ---
 layout: ""
 page_title: "dynatrace_business_events_security_context Resource - terraform-provider-dynatrace"
-subcategory: "Business Events"
+subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_business_events_security_context` covers configuration for business security context
 ---
 
 # dynatrace_business_events_security_context (Resource)
+
+~> **Warning** This resource has been deprecated in favor of OpenPipeline.
+Please migrate your OpenPipeline configurations and use `dynatrace_openpipeline_v2_*` instead.
 
 -> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
 
@@ -27,4 +30,3 @@ The full documentation of the export feature is available [here](https://dt-url.
 {{ tffile "dynatrace/api/builtin/bizevents/security/contextrules/testdata/terraform/example_a.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
- 


### PR DESCRIPTION
#### **Why** this PR?
If the OpenPipeline configs are migrated, the following schemas are disabled:
- `builtin:bizevents-processing-buckets.rule`
- `builtin:bizevents-processing-metrics.rule`
- `builtin:bizevents-processing-pipelines.rule`
- `builtin:bizevents-security-context-rules`

Therefore, adding a deprecation notice to the resource and its documentation is needed.

#### **What** has changed?
A deprecation notice will be shown in the documentation and when using the aforementioned resources.

#### **How** does it do it?
By adding a deprecation notice to the resource and documentation.

#### How is it **tested**?
Not needed.

#### How does it affect **users**?
They will now see a deprecation notice when using the resource or when they look at the documentation.

**Issue:** CA-17601
