### PR TITLE
fix: synthetic monitor update inconsistency

### DIFF
--- a/dynatrace/api/v2/synthetic/monitors/service.go
+++ b/dynatrace/api/v2/synthetic/monitors/service.go
@@ -128,7 +128,12 @@ func (me *service) Validate(v *monitors.Settings) error {
 }
 
 func (me *service) Update(ctx context.Context, id string, v *monitors.Settings) error {
-	return rest.APITokenClient(me.credentials).Put(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), v, 200).Finish()
+	err := rest.APITokenClient(me.credentials).Put(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), v, 200).Finish()
+	if err != nil {
+		return err
+	}
+	time.Sleep(3 * time.Second) // GET after update is eventually consistent
+	return nil
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {


### PR DESCRIPTION
#### **Why** this PR?
Synthetic monitors are eventually consistent, not only for creation but also for updates. Meaning a GET after an update may lead to an incomplete result (some properties are updated, and some aren't)

#### **What** has changed?
The state is now properly set after the update.

#### **How** does it do it?
By adding a 3-second sleep duration after the update.

#### How is it **tested**?
The test should not be flaky anymore

#### How does it affect **users**?
They're less likely to run into `terraform plan` updates after `terraform apply`.

**Issue:**
