### PR TITLE
feat: resource updates for v329

### DIFF
--- a/dynatrace/api/builtin/alerting/profile/schema.json
+++ b/dynatrace/api/builtin/alerting/profile/schema.json
@@ -16,7 +16,7 @@
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
-	"description": "Alerting profiles enable you to set up fine-grained alert-filtering rules that are based on the severity, customer impact, associated tags, and/or duration of detected problems. Alerting profiles enable you to control exactly which conditions result in problem notifications and which don't. This includes all problem-push notifications that are sent via the Dynatrace mobile app and displayed in the Dynatrace web UI. Alerting profiles can also be used to set up filtered problem-notification integrations with 3rd party messaging systems like Slack, Splunk On-Call, and PagerDuty.",
+	"description": "Alerting profiles enable you to set up fine-grained alert-filtering rules that are based on the severity, customer impact, associated tags, and/or duration of detected problems. They enable you to control exactly which conditions result in problem notifications and which don't. Alerting profiles can also be used to set up filtered problem-notification integrations with 3rd party messaging systems like Slack, Splunk On-Call, and PagerDuty.",
 	"displayName": "Problem alerting profiles",
 	"documentation": "",
 	"dynatrace": "1",
@@ -422,6 +422,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1000,
 	"metadata": {
 		"addItemButton": "Add alerting profile"
@@ -993,5 +994,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "8.6.2"
+	"version": "8.6.3"
 }

--- a/dynatrace/api/builtin/alerting/profile/service.go
+++ b/dynatrace/api/builtin/alerting/profile/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
+const SchemaVersion = "8.6.3"
 const SchemaID = "builtin:alerting.profile"
-const SchemaVersion = "8.6.2"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*profile.Profile] {
 	return settings20.Service(credentials, SchemaID, SchemaVersion, &settings20.ServiceOptions[*profile.Profile]{LegacyID: settings.LegacyObjIDDecode, Duplicates: Duplicates})

--- a/dynatrace/api/builtin/disk/analytics/extension/schema.json
+++ b/dynatrace/api/builtin/disk/analytics/extension/schema.json
@@ -8,6 +8,7 @@
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"metadata": {
 		"minAgentVersion": "1.233"
@@ -16,7 +17,7 @@
 	"properties": {
 		"diskDeviceMonitoringExtensionActive": {
 			"default": false,
-			"description": "The Disk Analytics feature requires an extension to be added to your environment. The Disk Analytics extension consumes custom metrics and [Davis data units](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation).\n\nAfter you have installed the Disk Analytics extension, you can enable the Data Collection in host or host-group level settings. If you enable the Data Collection without adding the extension the data is only visible in the data explorer.\n\nFor details, see [Disk Analytics extension documentation](https://dt-url.net/3a03v9v).",
+			"description": "The Disk Analytics feature requires an extension to be added to your environment. You can add the Disk Analytics extension to your environment from [Dynatrace Hub](/ui/hub/ext/com.dynatrace.extension.disk-devices#information). The Disk Analytics extension consumes custom metrics and [Davis data units](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation).\n\nAfter you have added the Disk Analytics extension, you can enable the Data Collection in host or host-group level settings. If you enable the Data Collection without adding the extension the data is only visible in the data explorer.\n\nFor details, see [Disk Analytics extension documentation](https://dt-url.net/3a03v9v).",
 			"displayName": "Enable Disk Analytics data collection",
 			"documentation": "",
 			"maxObjects": 1,
@@ -30,5 +31,5 @@
 	],
 	"schemaId": "builtin:disk.analytics.extension",
 	"types": {},
-	"version": "0.0.8"
+	"version": "0.0.9"
 }

--- a/dynatrace/api/builtin/disk/analytics/extension/service.go
+++ b/dynatrace/api/builtin/disk/analytics/extension/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@
 package extension
 
 import (
-	extension "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/disk/analytics/extension/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/disk/analytics/extension/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.0.8"
+const SchemaVersion = "0.0.9"
 const SchemaID = "builtin:disk.analytics.extension"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*extension.Settings] {
-	return settings20.Service[*extension.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/disk/analytics/extension/settings/settings.go
+++ b/dynatrace/api/builtin/disk/analytics/extension/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 )
 
 type Settings struct {
-	Enabled bool   `json:"diskDeviceMonitoringExtensionActive"` // The Disk Analytics feature requires an extension to be added to your environment. The Disk Analytics extension consumes custom metrics and [Davis data units](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation).\n\nAfter you have installed the Disk Analytics extension, you can enable the Data Collection in host or host-group level settings. If you enable the Data Collection without adding the extension the data is only visible in the data explorer.\n\nFor details, see [Disk Analytics extension documentation](https://dt-url.net/3a03v9v).
+	Enabled bool   `json:"diskDeviceMonitoringExtensionActive"` // The Disk Analytics feature requires an extension to be added to your environment. You can add the Disk Analytics extension to your environment from [Dynatrace Hub](/ui/hub/ext/com.dynatrace.extension.disk-devices#information). The Disk Analytics extension consumes custom metrics and [Davis data units](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation).\n\nAfter you have added the Disk Analytics extension, you can enable the Data Collection in host or host-group level settings. If you enable the Data Collection without adding the extension the data is only visible in the data explorer.\n\nFor details, see [Disk Analytics extension documentation](https://dt-url.net/3a03v9v).
 	Scope   string `json:"-" scope:"scope"`                     // The scope of this setting (HOST, HOST_GROUP)
 }
 
@@ -35,7 +35,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "The Disk Analytics feature requires an extension to be added to your environment. The Disk Analytics extension consumes custom metrics and [Davis data units](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation).\n\nAfter you have installed the Disk Analytics extension, you can enable the Data Collection in host or host-group level settings. If you enable the Data Collection without adding the extension the data is only visible in the data explorer.\n\nFor details, see [Disk Analytics extension documentation](https://dt-url.net/3a03v9v).",
+			Description: "The Disk Analytics feature requires an extension to be added to your environment. You can add the Disk Analytics extension to your environment from [Dynatrace Hub](/ui/hub/ext/com.dynatrace.extension.disk-devices#information). The Disk Analytics extension consumes custom metrics and [Davis data units](https://www.dynatrace.com/support/help/shortlink/metric-cost-calculation).\n\nAfter you have added the Disk Analytics extension, you can enable the Data Collection in host or host-group level settings. If you enable the Data Collection without adding the extension the data is only visible in the data explorer.\n\nFor details, see [Disk Analytics extension documentation](https://dt-url.net/3a03v9v).",
 			Required:    true,
 		},
 		"scope": {

--- a/dynatrace/api/builtin/disk/options/schema.json
+++ b/dynatrace/api/builtin/disk/options/schema.json
@@ -50,6 +50,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -84,11 +85,24 @@
 			"nullable": false,
 			"type": "list"
 		},
+		"monitorTmpfs": {
+			"default": false,
+			"description": "Activate tmpfs monitoring on Linux systems",
+			"displayName": "Enable tmpfs disk monitoring",
+			"documentation": "",
+			"maxObjects": 1,
+			"metadata": {
+				"minAgentVersion": "1.331"
+			},
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "boolean"
+		},
 		"nfsShowAll": {
 			"default": false,
-			"description": "When disabled OneAgent will try to deduplicate some of nfs disks. Disabled by default, applies only to Linux hosts. Requires OneAgent 1.209 or later",
-			"displayName": "Show all NFS disks",
-			"documentation": "",
+			"description": "When disabled OneAgent will try to deduplicate some of nfs mount points. Disabled by default, applies only to Linux hosts.",
+			"displayName": "Show all NFS mount points",
+			"documentation": "Applies only to Linux hosts",
 			"maxObjects": 1,
 			"metadata": {
 				"minAgentVersion": "1.209"
@@ -164,5 +178,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.2.11"
+	"version": "1.2.14"
 }

--- a/dynatrace/api/builtin/disk/options/service.go
+++ b/dynatrace/api/builtin/disk/options/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@
 package options
 
 import (
-	options "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/disk/options/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/disk/options/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.2.11"
+const SchemaVersion = "1.2.14"
 const SchemaID = "builtin:disk.options"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*options.Settings] {
-	return settings20.Service[*options.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/disk/options/settings/disk_complex.go
+++ b/dynatrace/api/builtin/disk/options/settings/disk_complex.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,8 +46,8 @@ func (me *DiskComplexes) UnmarshalHCL(decoder hcl.Decoder) error {
 
 type DiskComplex struct {
 	Filesystem *string    `json:"filesystem,omitempty"` // **File system type field:** the type of the file system to be excluded from monitoring. Examples:\n\n* ext4\n* ext3\n* btrfs\n* ext*\n\n⚠️ Starting from **OneAgent 1.299+** file system types are not case sensitive! \n\nThe wildcard in the last example means to exclude matching file systems such as types ext4 and ext3
-	Mountpoint *string    `json:"mountpoint,omitempty"` // **Disk or mount point path field:** the path to where the disk to be excluded from monitoring is mounted. Examples:\n\n* /mnt/my_disk\n* /staff/emp1\n* C:\\\n* /staff/*\n* /disk*\n\n ⚠️ Mount point paths are case sensitive! \n\nThe wildcard in **/staff/*** means to exclude every child folder of /staff.\n\nThe wildcard in **/disk*** means to exclude every mount point starting with /disk, for example /disk1, /disk99,  /diskabc
-	Os         OsTypeEnum `json:"os"`                   // Possible Values: `OS_TYPE_AIX`, `OS_TYPE_DARWIN`, `OS_TYPE_HPUX`, `OS_TYPE_LINUX`, `OS_TYPE_SOLARIS`, `OS_TYPE_UNKNOWN`, `OS_TYPE_WINDOWS`, `OS_TYPE_ZOS`
+	Mountpoint *string    `json:"mountpoint,omitempty"` // **Disk or mount point path field:** the path to where the disk to be excluded from monitoring is mounted. Examples:\n\n* /mnt/my_disk\n* /staff/emp1\n* C:\\\n* /staff/*\n* /disk*\n\n ⚠️ Mount point paths are case sensitive! \n\nThe wildcard in **/staff/*** means to exclude every child folder of /staff.\n\nThe wildcard in **/disk*** means to exclude every mount point starting with /disk, for example /disk1, /disk99,  /diskabc\n\n ⚠️ Filtering is done before resolving symbolic links.
+	Os         OsTypeEnum `json:"os"`                   // Operating system. Possible Values: `OS_TYPE_AIX`, `OS_TYPE_DARWIN`, `OS_TYPE_HPUX`, `OS_TYPE_LINUX`, `OS_TYPE_SOLARIS`, `OS_TYPE_UNKNOWN`, `OS_TYPE_WINDOWS`, `OS_TYPE_ZOS`
 }
 
 func (me *DiskComplex) Schema() map[string]*schema.Schema {
@@ -55,16 +55,16 @@ func (me *DiskComplex) Schema() map[string]*schema.Schema {
 		"filesystem": {
 			Type:        schema.TypeString,
 			Description: "**File system type field:** the type of the file system to be excluded from monitoring. Examples:\n\n* ext4\n* ext3\n* btrfs\n* ext*\n\n⚠️ Starting from **OneAgent 1.299+** file system types are not case sensitive! \n\nThe wildcard in the last example means to exclude matching file systems such as types ext4 and ext3",
-			Optional:    true,
+			Optional:    true, // nullable
 		},
 		"mountpoint": {
 			Type:        schema.TypeString,
-			Description: "**Disk or mount point path field:** the path to where the disk to be excluded from monitoring is mounted. Examples:\n\n* /mnt/my_disk\n* /staff/emp1\n* C:\\\n* /staff/*\n* /disk*\n\n ⚠️ Mount point paths are case sensitive! \n\nThe wildcard in **/staff/*** means to exclude every child folder of /staff.\n\nThe wildcard in **/disk*** means to exclude every mount point starting with /disk, for example /disk1, /disk99,  /diskabc",
-			Optional:    true,
+			Description: "**Disk or mount point path field:** the path to where the disk to be excluded from monitoring is mounted. Examples:\n\n* /mnt/my_disk\n* /staff/emp1\n* C:\\\n* /staff/*\n* /disk*\n\n ⚠️ Mount point paths are case sensitive! \n\nThe wildcard in **/staff/*** means to exclude every child folder of /staff.\n\nThe wildcard in **/disk*** means to exclude every mount point starting with /disk, for example /disk1, /disk99,  /diskabc\n\n ⚠️ Filtering is done before resolving symbolic links.",
+			Optional:    true, // nullable
 		},
 		"os": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `OS_TYPE_AIX`, `OS_TYPE_DARWIN`, `OS_TYPE_HPUX`, `OS_TYPE_LINUX`, `OS_TYPE_SOLARIS`, `OS_TYPE_UNKNOWN`, `OS_TYPE_WINDOWS`, `OS_TYPE_ZOS`",
+			Description: "Operating system. Possible Values: `OS_TYPE_AIX`, `OS_TYPE_DARWIN`, `OS_TYPE_HPUX`, `OS_TYPE_LINUX`, `OS_TYPE_SOLARIS`, `OS_TYPE_UNKNOWN`, `OS_TYPE_WINDOWS`, `OS_TYPE_ZOS`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/disk/options/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/disk/options/testdata/terraform/example_a.tf
@@ -2,6 +2,7 @@
 resource "dynatrace_disk_options" "#name#" {
   disable_nfs_disk_monitoring = false
   nfs_show_all = true
+  monitor_tmpfs = true
   scope        = "HOST-1234567890000000"
   exclusions {
     exclusion {

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/schema.json
@@ -80,7 +80,7 @@
 		}
 	},
 	"maturity": "EARLY_ADOPTER",
-	"maxObjects": 100,
+	"maxObjects": 500,
 	"metadata": {
 		"$ref": "#/types/Metadata"
 	},
@@ -337,5 +337,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "0.0.10"
+	"version": "0.0.11"
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/service.go
@@ -31,7 +31,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.0.10"
+const SchemaVersion = "0.0.11"
 const SchemaID = "builtin:hyperscaler-authentication.connections.azure"
 const DefaultTimeout = 2 * time.Minute
 

--- a/dynatrace/api/builtin/oneagent/masking/schema.json
+++ b/dynatrace/api/builtin/oneagent/masking/schema.json
@@ -1,13 +1,18 @@
 {
 	"allowedScopes": [
 		"PROCESS_GROUP",
+		"CLOUD_APPLICATION",
+		"CLOUD_APPLICATION_NAMESPACE",
+		"KUBERNETES_CLUSTER",
+		"HOST_GROUP",
 		"environment"
 	],
-	"description": "Use the settings on this page to exclude sensitive data from URLs captured directly by OneAgent, so it never leaves your environment. The settings below are executed directly on the OneAgent and will exclude the data points from being sent to Dynatrace servers. These data points will no longer be available to you in Dynatrace.\n\nNote: The RUM JavaScript is **not** affected by these settings!",
+	"description": "Use the settings on this page to exclude sensitive data from exceptions and URLs captured directly by OneAgent, so it never leaves your environment. The settings below are executed directly on the OneAgent and will exclude the data points from being sent to Dynatrace servers. These data points will no longer be available to you in Dynatrace.\n\nNote: The RUM JavaScript is **not** affected by these settings!\n\nA detailed reference and change log can be found [here](https://dt-url.net/kd039dm).",
 	"displayName": "OneAgent side masking",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"metadata": {
 		"minAgentVersion": "1.277"
@@ -16,9 +21,9 @@
 	"properties": {
 		"isEmailMaskingEnabled": {
 			"default": false,
-			"description": "Exclude email addresses from URLs",
+			"description": "Exclude email addresses from URLs and exceptions",
 			"displayName": "Email addresses",
-			"documentation": "Enables masking of emails and user information in URLs.\n\nExamples: https://the-internet.com/mail/admin@the-internet.com/newItems\n-\u003e [https://the-internet.com/mail/\u003cmasked\u003e/newItems]()\n\nftp://user:hunter2@domain.com -\u003e [ftp://\u003cmasked\u003e@domain.com]() (Domain is not masked, as it's recognised as part of the authority.)\n\n\n",
+			"documentation": "Enables masking of emails and user information in URLs and exceptions.\n\nExamples: https://the-internet.com/mail/admin@the-internet.com/newItems\n-\u003e [https://the-internet.com/mail/\u003cmasked\u003e/newItems]()\n\nftp://user:hunter2@domain.com -\u003e [ftp://\u003cmasked\u003e@domain.com]() (Domain is not masked, as it's recognised as part of the authority.)\n\n\n",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
@@ -26,7 +31,7 @@
 		},
 		"isFinancialMaskingEnabled": {
 			"default": false,
-			"description": "Exclude IBANs and payment card numbers from URLs",
+			"description": "Exclude IBANs and payment card numbers from URLs and exceptions",
 			"displayName": "Financial and payment card numbers",
 			"documentation": "Enables masking of IBAN- and payment card-like strings (numbers).\n\nExample: [https://the-internet.com/CC/1234 4321 5678 8756/test]() -\u003e\n[https://the-internet.com/CC/\u003cmasked\u003e/test]()\n",
 			"maxObjects": 1,
@@ -36,7 +41,7 @@
 		},
 		"isNumbersMaskingEnabled": {
 			"default": false,
-			"description": "Exclude hexadecimal IDs and consecutive numbers above 5 digits from URLs",
+			"description": "Exclude hexadecimal IDs and consecutive numbers above 5 digits from URLs and exceptions",
 			"displayName": "IDs and numbers",
 			"documentation": "Numbers can contain symbols **-**, **.**, **:**, ' '(whitespace) between digits, these are not counted. Maximum value is 255.\n\nExample: https://the-internet.com/IP/123:12:32:65 -\u003e [https://the-internet.com/IP/\u003cmasked\u003e]()",
 			"maxObjects": 1,
@@ -61,5 +66,5 @@
 	],
 	"schemaId": "builtin:oneagent.side.masking.settings",
 	"types": {},
-	"version": "1"
+	"version": "1.0.1"
 }

--- a/dynatrace/api/builtin/oneagent/masking/service.go
+++ b/dynatrace/api/builtin/oneagent/masking/service.go
@@ -18,15 +18,15 @@
 package masking
 
 import (
-	masking "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/oneagent/masking/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/oneagent/masking/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1"
+const SchemaVersion = "1.0.1"
 const SchemaID = "builtin:oneagent.side.masking.settings"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*masking.Settings] {
-	return settings20.Service[*masking.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/oneagent/masking/settings/settings.go
+++ b/dynatrace/api/builtin/oneagent/masking/settings/settings.go
@@ -15,7 +15,7 @@
 * limitations under the License.
  */
 
-package masking
+package settings
 
 import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
@@ -23,11 +23,11 @@ import (
 )
 
 type Settings struct {
-	IsEmailMaskingEnabled     bool    `json:"isEmailMaskingEnabled"`     // Exclude email addresses from URLs
-	IsFinancialMaskingEnabled bool    `json:"isFinancialMaskingEnabled"` // Exclude IBANs and payment card numbers from URLs
-	IsNumbersMaskingEnabled   bool    `json:"isNumbersMaskingEnabled"`   // Exclude hexadecimal IDs and consecutive numbers above 5 digits from URLs
+	IsEmailMaskingEnabled     bool    `json:"isEmailMaskingEnabled"`     // Exclude email addresses from URLs and exceptions
+	IsFinancialMaskingEnabled bool    `json:"isFinancialMaskingEnabled"` // Exclude IBANs and payment card numbers from URLs and exceptions
+	IsNumbersMaskingEnabled   bool    `json:"isNumbersMaskingEnabled"`   // Exclude hexadecimal IDs and consecutive numbers above 5 digits from URLs and exceptions
 	IsQueryMaskingEnabled     bool    `json:"isQueryMaskingEnabled"`     // Exclude query parameters from URLs and web requests
-	ProcessGroupID            *string `json:"-" scope:"processGroupId"`  // The scope of this settings. If the settings should cover the whole environment, just don't specify any scope.
+	ProcessGroupID            *string `json:"-" scope:"processGroupId"`  // The scope of this setting (PROCESS_GROUP, CLOUD_APPLICATION, CLOUD_APPLICATION_NAMESPACE, KUBERNETES_CLUSTER, HOST_GROUP). Omit this property if you want to cover the whole environment.
 }
 
 func (me *Settings) Name() string {
@@ -41,17 +41,17 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"is_email_masking_enabled": {
 			Type:        schema.TypeBool,
-			Description: "Exclude email addresses from URLs",
+			Description: "Exclude email addresses from URLs and exceptions",
 			Required:    true,
 		},
 		"is_financial_masking_enabled": {
 			Type:        schema.TypeBool,
-			Description: "Exclude IBANs and payment card numbers from URLs",
+			Description: "Exclude IBANs and payment card numbers from URLs and exceptions",
 			Required:    true,
 		},
 		"is_numbers_masking_enabled": {
 			Type:        schema.TypeBool,
-			Description: "Exclude hexadecimal IDs and consecutive numbers above 5 digits from URLs",
+			Description: "Exclude hexadecimal IDs and consecutive numbers above 5 digits from URLs and exceptions",
 			Required:    true,
 		},
 		"is_query_masking_enabled": {
@@ -61,7 +61,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"process_group_id": {
 			Type:        schema.TypeString,
-			Description: "The scope of this settings. If the settings should cover the whole environment, just don't specify any scope.",
+			Description: "The scope of this setting (PROCESS_GROUP, CLOUD_APPLICATION, CLOUD_APPLICATION_NAMESPACE, KUBERNETES_CLUSTER, HOST_GROUP). Omit this property if you want to cover the whole environment.",
 			Optional:    true,
 			Default:     "environment",
 		},

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (bizevents)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.bizevents.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (bizevents)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.bizevents.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (bizevents)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.bizevents.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (davis.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.davis.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (davis.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.davis.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (davis.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.davis.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (davis.problems)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.davis.problems.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (davis.problems)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.davis.problems.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (davis.problems)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.davis.problems.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (events.sdlc)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.sdlc.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (events.sdlc)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.sdlc.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (events.sdlc)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.sdlc.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (events.security)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.security.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (events.security)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.security.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (events.security)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.events.security.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (logs)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.logs.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (logs)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.logs.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (logs)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.logs.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (metrics)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.metrics.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (metrics)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.metrics.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (metrics)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.metrics.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (security.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.security.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (security.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.security.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (security.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.security.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (spans)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.spans.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (spans)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.spans.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (spans)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.spans.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (system.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.system.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (system.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.system.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (system.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.system.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (user.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.user.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (user.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.user.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (user.events)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.user.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"description": "Contains configuration of ingest sources",
-	"displayName": "Ingest sources configuration",
+	"displayName": "Ingest sources configuration (usersessions)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -336,7 +336,7 @@
 			"displayName": "Endpoint segment",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": false,
 			"precondition": {
 				"expectedValue": "http",
@@ -2355,6 +2355,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2470,6 +2475,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2607,8 +2652,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2672,6 +2716,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2725,6 +2774,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3097,5 +3151,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.usersessions.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
@@ -21,7 +21,7 @@
 		}
 	],
 	"description": "Contains configuration of pipelines",
-	"displayName": "Ingest pipelines configuration",
+	"displayName": "Ingest pipelines configuration (usersessions)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -2350,6 +2350,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2465,6 +2470,46 @@
 						{
 							"maxLength": 32,
 							"type": "LENGTH"
+						},
+						{
+							"customMessage": "Must not be 'name'",
+							"pattern": "^(?i)(?!name$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'lifetime'",
+							"pattern": "^(?i)(?!lifetime$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'type'",
+							"pattern": "^(?i)(?!type$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'id'",
+							"pattern": "^(?i)(?!id$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'tags'",
+							"pattern": "^(?i)(?!tags$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not be 'dt.security_context'",
+							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.system.'",
+							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.smartscape.'",
+							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"type": "PATTERN"
 						}
 					],
 					"default": "",
@@ -2602,8 +2647,7 @@
 						{
 							"type": "UNIQUE",
 							"uniqueProperties": [
-								"idComponent",
-								"referencedFieldName"
+								"idComponent"
 							]
 						}
 					],
@@ -2667,6 +2711,11 @@
 							"type": "PATTERN"
 						},
 						{
+							"customMessage": "Must not be 'CUSTOM_DEVICE'",
+							"pattern": "^(?!CUSTOM_DEVICE$).*$",
+							"type": "PATTERN"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
@@ -2720,6 +2769,11 @@
 						{
 							"customMessage": "Edge type must match the pattern [a-z][a-z0-9._]{0,31}",
 							"pattern": "^[a-z][a-z0-9._]{0,31}$",
+							"type": "PATTERN"
+						},
+						{
+							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
+							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3031,5 +3085,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.usersessions.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"description": "Contains configuration of routing",
-	"displayName": "Ingest routing configuration",
+	"displayName": "Ingest routing configuration (usersessions)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.26.1"
+	"version": "1.34.1"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.26.1"
+const SchemaVersion = "1.34.1"
 const SchemaID = "builtin:openpipeline.usersessions.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/problem/fields/schema.json
+++ b/dynatrace/api/builtin/problem/fields/schema.json
@@ -7,6 +7,7 @@
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "EARLY_ADOPTER",
 	"maxObjects": 40,
 	"multiObject": true,
 	"ordered": false,
@@ -80,12 +81,14 @@
 	},
 	"schemaConstraints": [
 		{
-			"customValidatorId": "problem-fields-duplicate-problem-field-validator",
-			"skipAsyncValidation": false,
-			"type": "CUSTOM_VALIDATOR_REF"
+			"flattenCollections": false,
+			"type": "UNIQUE",
+			"uniqueProperties": [
+				"problemField"
+			]
 		}
 	],
 	"schemaId": "builtin:problem.fields",
 	"types": {},
-	"version": "1.8"
+	"version": "1.9"
 }

--- a/dynatrace/api/builtin/problem/fields/service.go
+++ b/dynatrace/api/builtin/problem/fields/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@
 package fields
 
 import (
-	fields "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/problem/fields/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/problem/fields/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.8"
+const SchemaVersion = "1.9"
 const SchemaID = "builtin:problem.fields"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*fields.Settings] {
-	return settings20.Service[*fields.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/problem/notifications/ansible/settings/ansible_tower.go
+++ b/dynatrace/api/builtin/problem/notifications/ansible/settings/ansible_tower.go
@@ -52,12 +52,12 @@ func (me *AnsibleTower) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The display name within the Dynatrace WebUI.",
+			Description: "The name of the notification configuration.",
 			Required:    true,
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The notification is active (`true`) or inactive (`false`). Default is `false`.",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Optional:    true,
 		},
 		"profile": {
@@ -67,28 +67,28 @@ func (me *AnsibleTower) Schema() map[string]*schema.Schema {
 		},
 		"insecure": {
 			Type:        schema.TypeBool,
-			Description: "Accept any, including self-signed and invalid, SSL certificate (`true`) or only trusted (`false`) certificates. Default is `false`.",
 			Optional:    true,
+			Description: "Accept any SSL certificate (including self-signed and invalid certificates)",
 		},
 		"custom_message": {
 			Type:        schema.TypeString,
-			Description: "The custom message of the notification. This message will be displayed in the extra variables **Message** field of your job template. You can use the following placeholders:  * `{ImpactedEntities}`: Details about the entities impacted by the problem in form of a JSON array.  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{PID}`: The ID of the reported problem.  * `{ProblemDetailsText}`: All problem event details, including root cause, as a text-formatted string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`.  * `{Tags}`: The list of tags that are defined for all impacted entities, separated by commas",
+			Description: "This message will be displayed in the Extra Variables **Message** field of your job template. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntities}**: Details about the entities impacted by the problem in form of a json array.\n\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemDetailsText}**: All problem event details including root cause as a text-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:    true,
 		},
 		"job_template_url": {
 			Type:        schema.TypeString,
-			Description: "The URL of the target Ansible Tower job template",
+			Description: "The URL of the target job template.\n\nFor example, https://<Ansible server name>/#/templates/job_template/<JobTemplateID>\n\n**Note:** Be sure to select the **Prompt on Launch** option in the Extra Variables section of your job template configuration.",
 			Required:    true,
 		},
 		"password": {
 			Type:        schema.TypeString,
+			Description: "Account password.",
 			Sensitive:   true,
-			Description: "The password for the Ansible Tower account",
 			Optional:    true,
 		},
 		"username": {
 			Type:        schema.TypeString,
-			Description: "The username of the Ansible Tower account",
+			Description: "Account username.",
 			Required:    true,
 		},
 		"legacy_id": {

--- a/dynatrace/api/builtin/problem/notifications/email/settings/email.go
+++ b/dynatrace/api/builtin/problem/notifications/email/settings/email.go
@@ -40,12 +40,12 @@ func (me *Email) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The name of the notification configuration",
+			Description: "The name of the notification configuration.",
 			Required:    true,
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Optional:    true,
 		},
 		"profile": {
@@ -55,39 +55,36 @@ func (me *Email) Schema() map[string]*schema.Schema {
 		},
 		"bcc": {
 			Type:        schema.TypeSet,
-			Optional:    true,
-			MinItems:    1,
-			Description: "The list of the email BCC-recipients",
-			Elem:        &schema.Schema{Type: schema.TypeString},
-		},
-		"cc": {
-			Type:        schema.TypeSet,
-			Optional:    true,
-			MinItems:    1,
-			Description: "The list of the email CC-recipients",
-			Elem:        &schema.Schema{Type: schema.TypeString},
-		},
-		"to": {
-			Type:        schema.TypeSet,
-			Required:    true,
-			MinItems:    1,
-			Description: "The list of the email recipients",
+			Description: "BCC",
+			Optional:    true, // minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		"body": {
 			Type:        schema.TypeString,
-			Description: "The template of the email notification.  You can use the following placeholders:  * `{ImpactedEntities}`: Details about the entities impacted by the problem in form of a JSON array.  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{PID}`: The ID of the reported problem.  * `{ProblemDetailsHTML}`: All problem event details, including root cause, as an HTML-formatted string.  * `{ProblemDetailsJSON}`: All problem event details, including root cause, as a JSON object.  * `{ProblemDetailsMarkdown}`: All problem event details, including root cause, as a [Markdown-formatted](https://www.markdownguide.org/cheat-sheet/) string.  * `{ProblemDetailsText}`: All problem event details, including root cause, as a text-formatted string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`.  * `{Tags}`: The list of tags that are defined for all impacted entities, separated by commas",
+			Description: "The template of the email notifications. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntities}**: Details about the entities impacted by the problem in form of a json array.\n\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemDetailsHTML}**: All problem event details including root cause as an HTML-formatted string.\n\n**{ProblemDetailsJSONv2}**: Problem as json object following the structure from the [Dynatrace Problems V2 API](https://dt-url.net/7a03ti2). The optional fields evidenceDetails and impactAnalysis are included, but recentComments is not.\n\n**{ProblemDetailsJSON}**: Problem as json object following the structure from the [Dynatrace Problems V1 API](https://dt-url.net/qn23tk2).\n\n**{ProblemDetailsMarkdown}**: All problem event details including root cause as a Markdown-formatted string.\n\n**{ProblemDetailsText}**: All problem event details including root cause as a text-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:    true,
 		},
-		"subject": {
-			Type:        schema.TypeString,
-			Description: "The subject of the email notifications",
-			Required:    true,
+		"cc": {
+			Type:        schema.TypeSet,
+			Description: "CC",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		"notify_closed_problems": {
 			Type:        schema.TypeBool,
 			Description: "Send email if problem is closed",
 			Optional:    true,
+		},
+		"to": {
+			Type:        schema.TypeSet,
+			Description: "To",
+			Required:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"subject": {
+			Type:        schema.TypeString,
+			Description: "The subject of the email notifications. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
+			Required:    true,
 		},
 		"legacy_id": {
 			Type:        schema.TypeString,

--- a/dynatrace/api/builtin/problem/notifications/http/header.go
+++ b/dynatrace/api/builtin/problem/notifications/http/header.go
@@ -143,21 +143,21 @@ func (me *Header) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The name of the HTTP header",
+			Description: "The name of the HTTP header.",
 			Required:    true,
 			ForceNew:    ForceNewOnHeaders,
 		},
 		"secret_value": {
 			Type:        schema.TypeString,
-			Description: "The value of the HTTP header as a sensitive property. May contain an empty value. `secret_value` and `value` are mutually exclusive. Only one of those two is allowed to be specified.",
+			Description: "The secret value of the HTTP header. May contain an empty value.",
+			Optional:    true, // precondition
 			Sensitive:   true,
-			Optional:    true,
 			ForceNew:    ForceNewOnHeaders,
 		},
 		"value": {
 			Type:        schema.TypeString,
-			Description: "The value of the HTTP header. May contain an empty value. `secret_value` and `value` are mutually exclusive. Only one of those two is allowed to be specified.",
-			Optional:    true,
+			Description: "The value of the HTTP header. May contain an empty value.",
+			Optional:    true, // precondition
 			ForceNew:    ForceNewOnHeaders,
 		},
 	}

--- a/dynatrace/api/builtin/problem/notifications/http/header.go
+++ b/dynatrace/api/builtin/problem/notifications/http/header.go
@@ -163,6 +163,16 @@ func (me *Header) Schema() map[string]*schema.Schema {
 	}
 }
 
+func (me *Header) HandlePreconditions() error {
+	if (me.SecretValue == nil) && (me.Secret) {
+		me.SecretValue = opt.NewString("")
+	}
+	if (me.Value == nil) && (!me.Secret) {
+		me.Value = opt.NewString("")
+	}
+	return nil
+}
+
 func (me *Header) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Encode("name", me.Name); err != nil {
 		return err

--- a/dynatrace/api/builtin/problem/notifications/jira/settings/jira.go
+++ b/dynatrace/api/builtin/problem/notifications/jira/settings/jira.go
@@ -54,12 +54,12 @@ func (me *Jira) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The name of the notification configuration",
+			Description: "The name of the notification configuration.",
 			Required:    true,
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -67,40 +67,40 @@ func (me *Jira) Schema() map[string]*schema.Schema {
 			Description: "The ID of the associated alerting profile",
 			Required:    true,
 		},
-		"url": {
-			Type:        schema.TypeString,
-			Description: "The URL of the Jira API endpoint",
-			Required:    true,
-		},
-		"username": {
-			Type:        schema.TypeString,
-			Description: "The username of the Jira profile",
-			Required:    true,
-		},
 		"api_token": {
 			Type:        schema.TypeString,
-			Sensitive:   true,
 			Description: "The API token for the Jira profile. Using password authentication [was deprecated by Jira](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/)",
 			Optional:    true,
+			Sensitive:   true,
 		},
-		"project_key": {
+		"description": {
 			Type:        schema.TypeString,
-			Description: "The project key of the Jira issue to be created by this notification",
+			Description: "The description of the Jira issue to be created by this notification. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemDetailsText}**: All problem event details including root cause as a text-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:    true,
 		},
 		"issue_type": {
 			Type:        schema.TypeString,
-			Description: "The type of the Jira issue to be created by this notification",
+			Description: "The type of the Jira issue to be created by this notification.\n\nTo find all available issue types, or to create your own issue type, within JIRA go to Options > Issues.",
+			Required:    true,
+		},
+		"project_key": {
+			Type:        schema.TypeString,
+			Description: "The project key of the Jira issue to be created by this notification.",
 			Required:    true,
 		},
 		"summary": {
 			Type:        schema.TypeString,
-			Description: "The summary of the Jira issue to be created by this notification.  You can use the following placeholders:  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{PID}`: The ID of the reported problem.  * `{ProblemDetailsText}`: All problem event details, including root cause, as a text-formatted string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`.  * `{Tags}`: The list of tags that are defined for all impacted entities, separated by commas",
+			Description: "The summary of the Jira issue to be created by this notification. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:    true,
 		},
-		"description": {
+		"url": {
 			Type:        schema.TypeString,
-			Description: "The description of the Jira issue to be created by this notification.   You can use same placeholders as in issue summary",
+			Description: "The URL of the Jira API endpoint.",
+			Required:    true,
+		},
+		"username": {
+			Type:        schema.TypeString,
+			Description: "The username of the Jira profile.",
 			Required:    true,
 		},
 		"legacy_id": {

--- a/dynatrace/api/builtin/problem/notifications/opsgenie/settings/ops_genie.go
+++ b/dynatrace/api/builtin/problem/notifications/opsgenie/settings/ops_genie.go
@@ -57,7 +57,7 @@ func (me *OpsGenie) Schema() map[string]*schema.Schema {
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -68,18 +68,18 @@ func (me *OpsGenie) Schema() map[string]*schema.Schema {
 
 		"api_key": {
 			Type:        schema.TypeString,
-			Description: "The API key to access OpsGenie",
-			Sensitive:   true,
+			Description: "The API key to access OpsGenie.\n\nGo to OpsGenie-Integrations and create a new Dynatrace integration. Copy the newly created API key.",
 			Optional:    true,
+			Sensitive:   true,
 		},
 		"domain": {
 			Type:        schema.TypeString,
-			Description: "The region domain of the OpsGenie",
+			Description: "The region domain of the OpsGenie.\n\nFor example, **api.opsgenie.com** for US or **api.eu.opsgenie.com** for EU.",
 			Required:    true,
 		},
 		"message": {
 			Type:        schema.TypeString,
-			Description: "The content of the message.  You can use the following placeholders:  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem",
+			Description: "The content of the message. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ImpactedEntityNames}**: The entity impacted by the problem (or multiple impacted entities).",
 			Required:    true,
 		},
 		"legacy_id": {

--- a/dynatrace/api/builtin/problem/notifications/pagerduty/settings/pager_duty.go
+++ b/dynatrace/api/builtin/problem/notifications/pagerduty/settings/pager_duty.go
@@ -55,7 +55,7 @@ func (me *PagerDuty) Schema() map[string]*schema.Schema {
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -66,18 +66,18 @@ func (me *PagerDuty) Schema() map[string]*schema.Schema {
 
 		"account": {
 			Type:        schema.TypeString,
-			Description: "The name of the PagerDuty account",
+			Description: "The name of the PagerDuty account.",
 			Required:    true,
 		},
 		"api_key": {
 			Type:        schema.TypeString,
-			Sensitive:   true,
-			Description: "The API key to access PagerDuty",
+			Description: "The Events API key to access PagerDuty.",
 			Optional:    true,
+			Sensitive:   true,
 		},
 		"service": {
 			Type:        schema.TypeString,
-			Description: "The name of the PagerDuty Service",
+			Description: "The name of the service.",
 			Required:    true,
 		},
 		"legacy_id": {

--- a/dynatrace/api/builtin/problem/notifications/schema.json
+++ b/dynatrace/api/builtin/problem/notifications/schema.json
@@ -29,9 +29,9 @@
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
-	"description": "Although the Dynatrace mobile app is the preferred method for receiving real-time notifications related to problems in your environment, if your organization uses email or a different ticket/incident management system for alerting, click Add notification to configure integration with Dynatrace.",
+	"description": "Integrate Dynatrace problem notifications with your organization's existing incident-management system or team-collaboration channel. Alerting profiles are used within problem integrations to filter the total number of alerts to a subset that is relevant for your team.",
 	"displayName": "Problem notifications",
-	"documentation": "Integrate Dynatrace problem notifications with your organization's existing incident-management system or team-collaboration channel. Alerting profiles are used within problem integrations to filter the total number of alerts to a subset that is relevant for your team.\n\nFor details see [Third-party integrations](https://dt-url.net/j803tgc).",
+	"documentation": "\n\nFor details see [Third-party integrations](https://dt-url.net/j803tgc).",
 	"dynatrace": "1",
 	"enums": {
 		"NotificationType": {
@@ -98,6 +98,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1000,
 	"metadata": {
 		"addItemButton": "Add notification"
@@ -1963,5 +1964,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.7.2"
+	"version": "1.7.3"
 }

--- a/dynatrace/api/builtin/problem/notifications/service.go
+++ b/dynatrace/api/builtin/problem/notifications/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
+const SchemaVersion = "1.7.3"
 const SchemaID = "builtin:problem.notifications"
-const SchemaVersion = "1.7.2"
 
 type filter struct {
 	Type Type

--- a/dynatrace/api/builtin/problem/notifications/servicenow/settings/service_now.go
+++ b/dynatrace/api/builtin/problem/notifications/servicenow/settings/service_now.go
@@ -53,11 +53,6 @@ func (me *ServiceNow) FillDemoValues() []string {
 
 func (me *ServiceNow) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"format_problem_details_as_text": {
-			Type:        schema.TypeBool,
-			Description: "Use text format for problem details instead of HTML.",
-			Optional:    true, // nullable
-		},
 		"name": {
 			Type:        schema.TypeString,
 			Description: "The name of the notification configuration",
@@ -65,7 +60,7 @@ func (me *ServiceNow) Schema() map[string]*schema.Schema {
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -74,41 +69,46 @@ func (me *ServiceNow) Schema() map[string]*schema.Schema {
 			Required:    true,
 		},
 
-		"events": {
+		"format_problem_details_as_text": {
 			Type:        schema.TypeBool,
-			Description: "Send events into ServiceNow ITOM",
-			Optional:    true,
-		},
-		"incidents": {
-			Type:        schema.TypeBool,
-			Description: "Send incidents into ServiceNow ITSM",
-			Required:    true,
-		},
-		"url": {
-			Type:        schema.TypeString,
-			Description: "The URL of the on-premise ServiceNow installation. This field is mutually exclusive with the **instance** field. You can only use one of them",
-			Optional:    true,
-		},
-		"username": {
-			Type:        schema.TypeString,
-			Description: "The username of the ServiceNow account.   Make sure that your user account has the `rest_service`, `web_request_admin`, and `x_dynat_ruxit.Integration` roles",
-			Required:    true,
+			Description: "Use text format for problem details instead of HTML.",
+			Optional:    true, // nullable
 		},
 		"instance": {
 			Type:        schema.TypeString,
-			Description: "The ServiceNow instance identifier. It refers to the first part of your own ServiceNow URL. This field is mutually exclusive with the **url** field. You can only use one of them",
-			Optional:    true,
+			Description: "The ServiceNow instance identifier. It refers to the first part of your own ServiceNow URL. \n\n This field is mutually exclusive with the **url** field. You can only use one of them.",
+			Optional:    true, // precondition
 		},
 		"message": {
 			Type:        schema.TypeString,
-			Description: "The content of the ServiceNow description. You can use the following placeholders:  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{PID}`: The ID of the reported problem.  * `{ProblemDetailsHTML}`: All problem event details, including root cause, as an HTML-formatted string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`.  * `{Tags}`: The list of tags that are defined for all impacted entities, separated by commas",
+			Description: "The content of the ServiceNow description. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemDetailsHTML}**: All problem event details including root cause as an HTML-formatted string.\n\n**{ProblemDetailsText}**: All problem event details including root cause as a text-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:    true,
 		},
 		"password": {
 			Type:        schema.TypeString,
-			Description: "The password to the ServiceNow account",
-			Sensitive:   true,
+			Description: "The password to the ServiceNow account.",
 			Optional:    true,
+			Sensitive:   true,
+		},
+		"events": {
+			Type:        schema.TypeBool,
+			Description: "Send events into ServiceNow ITOM.",
+			Optional:    true,
+		},
+		"incidents": {
+			Type:        schema.TypeBool,
+			Description: "Send incidents into ServiceNow ITSM.",
+			Required:    true,
+		},
+		"url": {
+			Type:        schema.TypeString,
+			Description: "The URL of the on-premise ServiceNow installation. \n\n This field is mutually exclusive with the **instanceName** field. You can only use one of them.",
+			Optional:    true, // nullable
+		},
+		"username": {
+			Type:        schema.TypeString,
+			Description: "The username of the ServiceNow account. \n\n Make sure that your user account has the `web_service_admin` and `x_dynat_ruxit.Integration` roles.",
+			Required:    true,
 		},
 		"legacy_id": {
 			Type:        schema.TypeString,

--- a/dynatrace/api/builtin/problem/notifications/slack/settings/slack.go
+++ b/dynatrace/api/builtin/problem/notifications/slack/settings/slack.go
@@ -50,12 +50,12 @@ func (me *Slack) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The name of the notification configuration",
+			Description: "The name of the notification configuration.",
 			Required:    true,
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -64,21 +64,21 @@ func (me *Slack) Schema() map[string]*schema.Schema {
 			Required:    true,
 		},
 
+		"channel": {
+			Type:        schema.TypeString,
+			Description: "The channel (for example, `#general`) or the user (for example, `@john.smith`) to send the message to.",
+			Required:    true,
+		},
 		"message": {
 			Type:        schema.TypeString,
-			Description: "The content of the message.  You can use the following placeholders:  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{PID}`: The ID of the reported problem.  * `{ProblemDetailsText}`: All problem event details, including root cause, as a text-formatted string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`.  * `{Tags}`: The list of tags that are defined for all impacted entities, separated by commas",
+			Description: "The content of the message. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemDetailsText}**: All problem event details including root cause as a text-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:    true,
 		},
 		"url": {
 			Type:        schema.TypeString,
+			Description: "Set up an incoming WebHook integration within your Slack account. Copy and paste the generated WebHook URL into the field above.",
+			Required:    true,
 			Sensitive:   true,
-			Description: "The URL of the Slack WebHook. This is confidential information, therefore GET requests return this field with the `null` value, and it is optional for PUT requests",
-			Required:    true,
-		},
-		"channel": {
-			Type:        schema.TypeString,
-			Description: "The channel (for example, `#general`) or the user (for example, `@john.smith`) to send the message to",
-			Required:    true,
 		},
 		"legacy_id": {
 			Type:        schema.TypeString,

--- a/dynatrace/api/builtin/problem/notifications/trello/settings/trello.go
+++ b/dynatrace/api/builtin/problem/notifications/trello/settings/trello.go
@@ -54,12 +54,12 @@ func (me *Trello) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The name of the notification configuration",
+			Description: "The name of the notification configuration.",
 			Required:    true,
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -68,40 +68,40 @@ func (me *Trello) Schema() map[string]*schema.Schema {
 			Required:    true,
 		},
 
-		"resolved_list_id": {
-			Type:        schema.TypeString,
-			Description: "The Trello list to which the card of the resolved problem should be assigned",
-			Required:    true,
-		},
-		"text": {
-			Type:        schema.TypeString,
-			Description: "The text of the generated Trello card.  You can use the following placeholders:  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{PID}`: The ID of the reported problem.  * `{ProblemDetailsMarkdown}`: All problem event details, including root cause, as a [Markdown-formatted](https://www.markdownguide.org/cheat-sheet/) string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`.  * `{Tags}`: The list of tags that are defined for all impacted entities, separated by commas",
-			Required:    true,
-		},
 		"application_key": {
 			Type:        schema.TypeString,
-			Description: "The application key for the Trello account",
+			Description: "The application key for the Trello account.\n\nYou must be logged into Trello to have Trello automatically generate an application key for you. [Get application key](https://trello.com/app-key)",
 			Required:    true,
 		},
 		"authorization_token": {
 			Type:        schema.TypeString,
-			Description: "The application token for the Trello account",
-			Optional:    true,
+			Description: "The authorization token for the Trello account.",
+			Required:    true,
 			Sensitive:   true,
 		},
 		"board_id": {
 			Type:        schema.TypeString,
-			Description: "The Trello board to which the card should be assigned",
+			Description: "Trello board ID problem cards should be assigned to",
 			Required:    true,
 		},
 		"description": {
 			Type:        schema.TypeString,
-			Description: "The description of the Trello card.   You can use same placeholders as in card text",
+			Description: "The description of the Trello card. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemDetailsMarkdown}**: All problem event details including root cause as a Markdown-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:    true,
 		},
 		"list_id": {
 			Type:        schema.TypeString,
-			Description: "The Trello list to which the card should be assigned",
+			Description: "Trello list ID new problem cards should be assigned to",
+			Required:    true,
+		},
+		"resolved_list_id": {
+			Type:        schema.TypeString,
+			Description: "Trello list ID resolved problem cards should be assigned to",
+			Required:    true,
+		},
+		"text": {
+			Type:        schema.TypeString,
+			Description: "The card text and problem placeholders to appear on new problem cards. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:    true,
 		},
 		"legacy_id": {

--- a/dynatrace/api/builtin/problem/notifications/victorops/settings/victor_ops.go
+++ b/dynatrace/api/builtin/problem/notifications/victorops/settings/victor_ops.go
@@ -50,12 +50,12 @@ func (me *VictorOps) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The name of the notification configuration",
+			Description: "The name of the notification configuration.",
 			Required:    true,
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -66,18 +66,18 @@ func (me *VictorOps) Schema() map[string]*schema.Schema {
 
 		"api_key": {
 			Type:        schema.TypeString,
-			Description: "The API key for the target Splunk On-Call account",
-			Sensitive:   true,
+			Description: "The API key for the target Splunk On-Call account.\n\nReceive your Splunk On-Call API key by navigating to: Settings -> Integrations -> Rest Endpoint -> Dynatrace.",
 			Optional:    true,
+			Sensitive:   true,
 		},
 		"message": {
 			Type:        schema.TypeString,
-			Description: "The content of the message.  You can use the following placeholders:  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{ProblemDetailsText}`: All problem event details, including root cause, as a text-formatted string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`",
+			Description: "The content of the message. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{ProblemDetailsText}**: All problem event details including root cause as a text-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.",
 			Required:    true,
 		},
 		"routing_key": {
 			Type:        schema.TypeString,
-			Description: "The routing key, defining the group to be notified",
+			Description: "The routing key, defining the group to be notified.",
 			Required:    true,
 		},
 		"legacy_id": {

--- a/dynatrace/api/builtin/problem/notifications/webhook/settings/web_hook.go
+++ b/dynatrace/api/builtin/problem/notifications/webhook/settings/web_hook.go
@@ -196,6 +196,9 @@ func (me *WebHook) HandlePreconditions() error {
 	if (me.SecretUrl == nil) && (me.UrlContainsSecret != nil && *me.UrlContainsSecret) {
 		return fmt.Errorf("'secret_url' must be specified if 'url_contains_secret' is set to '%v'", me.UrlContainsSecret)
 	}
+	if (me.SecretUrl != nil) && (me.UrlContainsSecret != nil && !*me.UrlContainsSecret) {
+		return fmt.Errorf("'secret_url' must not be specified if 'url_contains_secret' is set to '%v'", me.UrlContainsSecret)
+	}
 	return nil
 }
 

--- a/dynatrace/api/builtin/problem/notifications/webhook/settings/web_hook.go
+++ b/dynatrace/api/builtin/problem/notifications/webhook/settings/web_hook.go
@@ -78,12 +78,12 @@ func (me *WebHook) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The name of the notification configuration",
+			Description: "The name of the notification configuration.",
 			Required:    true,
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -92,45 +92,29 @@ func (me *WebHook) Schema() map[string]*schema.Schema {
 			Required:    true,
 		},
 
-		"notify_event_merges": {
-			Type:        schema.TypeBool,
-			Description: "Call webhook if new events merge into existing problems",
-			Optional:    true,
-		},
 		"insecure": {
 			Type:        schema.TypeBool,
-			Description: "Accept any, including self-signed and invalid, SSL certificate (`true`) or only trusted (`false`) certificates",
+			Description: "Accept any SSL certificate (including self-signed and invalid certificates)",
 			Optional:    true,
 		},
 		"headers": {
 			Type:        schema.TypeList,
-			Optional:    true,
+			Description: "A list of the additional HTTP headers.",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(http.Headers).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
-			Description: "A list of the additional HTTP headers",
-			Elem:        &schema.Resource{Schema: new(http.Headers).Schema()},
 			ForceNew:    http.ForceNewOnHeaders,
-		},
-		"payload": {
-			Type:             schema.TypeString,
-			Description:      "The content of the notification message. You can use the following placeholders:  * `{ImpactedEntities}`: Details about the entities impacted by the problem in form of a JSON array.  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{PID}`: The ID of the reported problem.  * `{ProblemDetailsHTML}`: All problem event details, including root cause, as an HTML-formatted string.  * `{ProblemDetailsJSON}`: All problem event details, including root cause, as a JSON object.  * `{ProblemDetailsMarkdown}`: All problem event details, including root cause, as a [Markdown-formatted](https://www.markdownguide.org/cheat-sheet/) string.  * `{ProblemDetailsText}`: All problem event details, including root cause, as a text-formatted string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`.  * `{Tags}`: The list of tags that are defined for all impacted entities, separated by commas",
-			Required:         true,
-			DiffSuppressFunc: hcl.SuppressJSONorEOT,
-		},
-		"url": {
-			Type:        schema.TypeString,
-			Description: "The URL of the WebHook endpoint",
-			Optional:    true, // precondition
 		},
 		"notify_closed_problems": {
 			Type:        schema.TypeBool,
-			Description: "Send email if problem is closed",
+			Description: "Call webhook if problem is closed",
 			Optional:    true,
 		},
-		"use_oauth_2": {
+		"notify_event_merges": {
 			Type:        schema.TypeBool,
-			Description: "Use OAuth 2.0 for authentication",
-			Optional:    true, // nullable
+			Description: "Call webhook if new events merge into existing problems",
+			Optional:    true,
 		},
 		"oauth_2_credentials": {
 			Type:        schema.TypeList,
@@ -140,15 +124,31 @@ func (me *WebHook) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"payload": {
+			Type:             schema.TypeString,
+			Description:      "The content of the notification message. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntities}**: Details about the entities impacted by the problem in form of a json array.\n\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemDetailsHTML}**: All problem event details including root cause as an HTML-formatted string.\n\n**{ProblemDetailsJSONv2}**: Problem as json object following the structure from the [Dynatrace Problems V2 API](https://dt-url.net/7a03ti2). The optional fields evidenceDetails and impactAnalysis are included, but recentComments is not.\n\n**{ProblemDetailsJSON}**: Problem as json object following the structure from the [Dynatrace Problems V1 API](https://dt-url.net/qn23tk2).\n\n**{ProblemDetailsMarkdown}**: All problem event details including root cause as a Markdown-formatted string.\n\n**{ProblemDetailsText}**: All problem event details including root cause as a text-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
+			Required:         true,
+			DiffSuppressFunc: hcl.SuppressJSONorEOT,
+		},
 		"secret_url": {
 			Type:        schema.TypeString,
 			Description: "The secret URL of the webhook endpoint.",
 			Optional:    true, // precondition
 			Sensitive:   true,
 		},
+		"url": {
+			Type:        schema.TypeString,
+			Description: "The URL of the webhook endpoint.",
+			Optional:    true, // precondition
+		},
 		"url_contains_secret": {
 			Type:        schema.TypeBool,
 			Description: "Secret webhook URL",
+			Optional:    true, // nullable
+		},
+		"use_oauth_2": {
+			Type:        schema.TypeBool,
+			Description: "Use OAuth 2.0 for authentication",
 			Optional:    true, // nullable
 		},
 		"legacy_id": {

--- a/dynatrace/api/builtin/problem/notifications/xmatters/settings/x_matters.go
+++ b/dynatrace/api/builtin/problem/notifications/xmatters/settings/x_matters.go
@@ -58,12 +58,12 @@ func (me *XMatters) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "The name of the notification configuration",
+			Description: "The name of the notification configuration.",
 			Required:    true,
 		},
 		"active": {
 			Type:        schema.TypeBool,
-			Description: "The configuration is enabled (`true`) or disabled (`false`)",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"profile": {
@@ -72,29 +72,29 @@ func (me *XMatters) Schema() map[string]*schema.Schema {
 			Required:    true,
 		},
 
-		"url": {
-			Type:        schema.TypeString,
-			Description: "The URL of the WebHook endpoint",
-			Required:    true,
-		},
 		"insecure": {
 			Type:        schema.TypeBool,
-			Description: "Accept any, including self-signed and invalid, SSL certificate (`true`) or only trusted (`false`) certificates",
+			Description: "Accept any SSL certificate (including self-signed and invalid certificates)",
 			Optional:    true,
 		},
 		"headers": {
 			Type:        schema.TypeList,
-			Optional:    true,
+			Description: "A list of the additional HTTP headers.",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(http.Headers).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
-			Description: "A list of the additional HTTP headers",
-			Elem:        &schema.Resource{Schema: new(http.Headers).Schema()},
 		},
 		"payload": {
 			Type:             schema.TypeString,
-			Description:      "The content of the notification message. You can use the following placeholders:  * `{ImpactedEntities}`: Details about the entities impacted by the problem in form of a JSON array.  * `{ImpactedEntity}`: The entity impacted by the problem or *X* impacted entities.  * `{PID}`: The ID of the reported problem.  * `{ProblemDetailsHTML}`: All problem event details, including root cause, as an HTML-formatted string.  * `{ProblemDetailsJSON}`: All problem event details, including root cause, as a JSON object.  * `{ProblemDetailsMarkdown}`: All problem event details, including root cause, as a [Markdown-formatted](https://www.markdownguide.org/cheat-sheet/) string.  * `{ProblemDetailsText}`: All problem event details, including root cause, as a text-formatted string.  * `{ProblemID}`: The display number of the reported problem.  * `{ProblemImpact}`: The [impact level](https://www.dynatrace.com/support/help/shortlink/impact-analysis) of the problem. Possible values are `APPLICATION`, `SERVICE`, and `INFRASTRUCTURE`.  * `{ProblemSeverity}`: The [severity level](https://www.dynatrace.com/support/help/shortlink/event-types) of the problem. Possible values are `AVAILABILITY`, `ERROR`, `PERFORMANCE`, `RESOURCE_CONTENTION`, and `CUSTOM_ALERT`.  * `{ProblemTitle}`: A short description of the problem.  * `{ProblemURL}`: The URL of the problem within Dynatrace.  * `{State}`: The state of the problem. Possible values are `OPEN` and `RESOLVED`.  * `{Tags}`: The list of tags that are defined for all impacted entities, separated by commas",
+			Description:      "The content of the notification message. Type '{' for placeholder suggestions.. #### Available placeholders\n**{ImpactedEntities}**: Details about the entities impacted by the problem in form of a json array.\n\n**{ImpactedEntity}**: A short description of the problem and impacted entity (or multiple impacted entities).\n\n**{ImpactedEntityNames}**: The entity impacted by the problem.\n\n**{NamesOfImpactedEntities}**: The names of all entities that are impacted by the problem.\n\n**{PID}**: Unique system identifier of the reported problem.\n\n**{ProblemDetailsHTML}**: All problem event details including root cause as an HTML-formatted string.\n\n**{ProblemDetailsJSONv2}**: Problem as json object following the structure from the [Dynatrace Problems V2 API](https://dt-url.net/7a03ti2). The optional fields evidenceDetails and impactAnalysis are included, but recentComments is not.\n\n**{ProblemDetailsJSON}**: Problem as json object following the structure from the [Dynatrace Problems V1 API](https://dt-url.net/qn23tk2).\n\n**{ProblemDetailsMarkdown}**: All problem event details including root cause as a Markdown-formatted string.\n\n**{ProblemDetailsText}**: All problem event details including root cause as a text-formatted string.\n\n**{ProblemID}**: Display number of the reported problem.\n\n**{ProblemImpact}**: Impact level of the problem. Possible values are APPLICATION, SERVICE, or INFRASTRUCTURE.\n\n**{ProblemSeverity}**: Severity level of the problem. Possible values are AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, or CUSTOM_ALERT.\n\n**{ProblemTitle}**: Short description of the problem.\n\n**{ProblemURL}**: URL of the problem within Dynatrace.\n\n**{State}**: Problem state. Possible values are OPEN or RESOLVED.\n\n**{Tags}**: Comma separated list of tags that are defined for all impacted entities. To refer to the value of a specific tag, specify the tag's key in square brackets: **{Tags[key]}**. If the tag does not have any assigned value, the placeholder will be replaced by an empty string. The placeholder will not be replaced if the tag key does not exist.",
 			Required:         true,
 			DiffSuppressFunc: hcl.SuppressJSONorEOT,
+		},
+		"url": {
+			Type:        schema.TypeString,
+			Description: "The URL of the xMatters webhook.",
+			Required:    true,
 		},
 		"legacy_id": {
 			Type:        schema.TypeString,

--- a/dynatrace/api/builtin/processavailability/schema.json
+++ b/dynatrace/api/builtin/processavailability/schema.json
@@ -78,6 +78,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 400,
 	"metadata": {
 		"addItemButton": "Add monitoring rule",
@@ -129,7 +130,7 @@
 			"default": 1,
 			"description": "",
 			"displayName": "Minimum number of matching processes",
-			"documentation": "Specify a minimum number of processes matching the monitoring rule. If it's not satisfied, an alert will open.",
+			"documentation": "Specify a minimum number of processes matching the monitoring rule. An alert is triggered if any host falls below this threshold.",
 			"maxObjects": 1,
 			"metadata": {
 				"minAgentVersion": "1.287"
@@ -472,5 +473,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.0.16"
+	"version": "1.0.17"
 }

--- a/dynatrace/api/builtin/processavailability/service.go
+++ b/dynatrace/api/builtin/processavailability/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.16"
+const SchemaVersion = "1.0.17"
 const SchemaID = "builtin:processavailability"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*processavailability.Settings] {

--- a/dynatrace/api/builtin/processavailability/settings/detection_condition.go
+++ b/dynatrace/api/builtin/processavailability/settings/detection_condition.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ package processavailability
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/slices"
 )
 
 type DetectionConditions []*DetectionCondition
@@ -49,9 +49,9 @@ func (me *DetectionConditions) UnmarshalHCL(decoder hcl.Decoder) error {
 
 type DetectionCondition struct {
 	Condition             *string                `json:"condition,omitempty"`             // - $contains(svc) – Matches if svc appears anywhere in the process property value.\n- $eq(svc.exe) – Matches if svc.exe matches the process property value exactly.\n- $prefix(svc) – Matches if app matches the prefix of the process property value.\n- $suffix(svc.py) – Matches if svc.py matches the suffix of the process property value.\n\nFor example, $suffix(svc.py) would detect processes named loyaltysvc.py and paymentssvc.py.\n\nFor more details, see [Process availability](https://dt-url.net/v923x37).
-	HostMetadataCondition *HostMetadataCondition `json:"hostMetadataCondition,omitempty"` // Host custom metadata refers to user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\nBy defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\nSee [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).
-	Property              *ProcessItem           `json:"property,omitempty"`              // Possible Values: `CommandLine`, `Executable`, `ExecutablePath`, `User`
-	RuleType              RuleType               `json:"ruleType"`                        // Possible Values: `RuleTypeHost`, `RuleTypeProcess`
+	HostMetadataCondition *HostMetadataCondition `json:"hostMetadataCondition,omitempty"` // Host resource attributes are dimensions enriching the host including custom metadata which are user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\nBy defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\nSee [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).\n\nNote: Starting from version 1.325 host resource attributes are supported in addition to host custom metadata.
+	Property              *ProcessItem           `json:"property,omitempty"`              // Select process property. Possible Values: `commandLine`, `executable`, `executablePath`, `user`
+	RuleType              RuleType               `json:"ruleType"`                        // Rule scope. Possible Values: `RuleTypeHost`, `RuleTypeProcess`
 }
 
 func (me *DetectionCondition) Schema() map[string]*schema.Schema {
@@ -63,7 +63,7 @@ func (me *DetectionCondition) Schema() map[string]*schema.Schema {
 		},
 		"host_metadata_condition": {
 			Type:        schema.TypeList,
-			Description: "Host custom metadata refers to user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\nBy defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\nSee [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).",
+			Description: "Host resource attributes are dimensions enriching the host including custom metadata which are user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\nBy defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\nSee [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).\n\nNote: Starting from version 1.325 host resource attributes are supported in addition to host custom metadata.",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(HostMetadataCondition).Schema()},
 			MinItems:    1,
@@ -71,12 +71,12 @@ func (me *DetectionCondition) Schema() map[string]*schema.Schema {
 		},
 		"property": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `CommandLine`, `Executable`, `ExecutablePath`, `User`",
+			Description: "Select process property. Possible Values: `commandLine`, `executable`, `executablePath`, `user`",
 			Optional:    true, // precondition
 		},
 		"rule_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `RuleTypeHost`, `RuleTypeProcess`",
+			Description: "Rule scope. Possible Values: `RuleTypeHost`, `RuleTypeProcess`",
 			Optional:    true,
 			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 				// rule_type was introduced in v286 as a required field, added code below to have successful results for old/new tenants.

--- a/dynatrace/api/builtin/processavailability/settings/host_metadata_condition.go
+++ b/dynatrace/api/builtin/processavailability/settings/host_metadata_condition.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import (
 )
 
 type HostMetadataCondition struct {
-	KeyMustExist      bool   `json:"keyMustExist"`      // When enabled, the condition requires a metadata key to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.
-	MetadataCondition string `json:"metadataCondition"` // This string has to match a required format.\n\n- `$contains(production)` – Matches if `production` appears anywhere in the host metadata value.\n- `$eq(production)` – Matches if `production` matches the host metadata value exactly.\n- `$prefix(production)` – Matches if `production` matches the prefix of the host metadata value.\n- `$suffix(production)` – Matches if `production` matches the suffix of the host metadata value.\n\nAvailable logic operations:\n- `$not($eq(production))` – Matches if the host metadata value is different from `production`.\n- `$and($prefix(production),$suffix(main))` – Matches if host metadata value starts with `production` and ends with `main`.\n- `$or($prefix(production),$suffix(main))` – Matches if host metadata value starts with `production` or ends with `main`.\n\nBrackets **(** and **)** that are part of the matched property **must be escaped with a tilde (~)**
+	KeyMustExist      bool   `json:"keyMustExist"`      // When enabled, the condition requires a resource attribute to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.
+	MetadataCondition string `json:"metadataCondition"` // This string has to match a required format.\n\n- `$match(ver*_1.2.?)` – Matches string with wildcards: `*` any number (including zero) of characters and `?` exactly one character.\n- `$contains(production)` – Matches if `production` appears anywhere in the host metadata value.\n- `$eq(production)` – Matches if `production` matches the host metadata value exactly.\n- `$prefix(production)` – Matches if `production` matches the prefix of the host metadata value.\n- `$suffix(production)` – Matches if `production` matches the suffix of the host metadata value.\n\nAvailable logic operations:\n- `$not($eq(production))` – Matches if the host metadata value is different from `production`.\n- `$and($prefix(production),$suffix(main))` – Matches if host metadata value starts with `production` and ends with `main`.\n- `$or($prefix(production),$suffix(main))` – Matches if host metadata value starts with `production` or ends with `main`.\n\nBrackets **(** and **)** that are part of the matched property **must be escaped with a tilde (~)**
 	MetadataKey       string `json:"metadataKey"`       // Key
 }
 
@@ -32,13 +32,13 @@ func (me *HostMetadataCondition) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"key_must_exist": {
 			Type:        schema.TypeBool,
-			Description: "When enabled, the condition requires a metadata key to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.",
+			Description: "When enabled, the condition requires a resource attribute to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.",
 			Optional:    true,
 			Default:     true,
 		},
 		"metadata_condition": {
 			Type:        schema.TypeString,
-			Description: "This string has to match a required format.\n\n- `$contains(production)` – Matches if `production` appears anywhere in the host metadata value.\n- `$eq(production)` – Matches if `production` matches the host metadata value exactly.\n- `$prefix(production)` – Matches if `production` matches the prefix of the host metadata value.\n- `$suffix(production)` – Matches if `production` matches the suffix of the host metadata value.\n\nAvailable logic operations:\n- `$not($eq(production))` – Matches if the host metadata value is different from `production`.\n- `$and($prefix(production),$suffix(main))` – Matches if host metadata value starts with `production` and ends with `main`.\n- `$or($prefix(production),$suffix(main))` – Matches if host metadata value starts with `production` or ends with `main`.\n\nBrackets **(** and **)** that are part of the matched property **must be escaped with a tilde (~)**",
+			Description: "This string has to match a required format.\n\n- `$match(ver*_1.2.?)` – Matches string with wildcards: `*` any number (including zero) of characters and `?` exactly one character.\n- `$contains(production)` – Matches if `production` appears anywhere in the host metadata value.\n- `$eq(production)` – Matches if `production` matches the host metadata value exactly.\n- `$prefix(production)` – Matches if `production` matches the prefix of the host metadata value.\n- `$suffix(production)` – Matches if `production` matches the suffix of the host metadata value.\n\nAvailable logic operations:\n- `$not($eq(production))` – Matches if the host metadata value is different from `production`.\n- `$and($prefix(production),$suffix(main))` – Matches if host metadata value starts with `production` and ends with `main`.\n- `$or($prefix(production),$suffix(main))` – Matches if host metadata value starts with `production` or ends with `main`.\n\nBrackets **(** and **)** that are part of the matched property **must be escaped with a tilde (~)**",
 			Required:    true,
 		},
 		"metadata_key": {

--- a/dynatrace/api/builtin/processavailability/settings/settings.go
+++ b/dynatrace/api/builtin/processavailability/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,11 +25,11 @@ import (
 type Settings struct {
 	Enabled          bool                `json:"enabled"`            // This setting is enabled (`true`) or disabled (`false`)
 	Metadata         MetadataItems       `json:"metadata,omitempty"` // Set of additional key-value properties to be attached to the triggered event. You can retrieve the available property keys using the [Events API v2](https://dt-url.net/9622g1w). Additionally any Host resource attribute can be dynamically substituted (agent 1.325+).
-	Name             string              `json:"name"`               // Monitored rule name
+	MinimumProcesses int                 `json:"minimumProcesses"`   // Specify a minimum number of processes matching the monitoring rule. An alert is triggered if any host falls below this threshold.
+	Name             string              `json:"name"`               // Monitoring rule name
+	OperatingSystem  []OperatingSystem   `json:"operatingSystem"`    // Select the operating systems on which the monitoring rule should be applied.. Possible Values: `AIX`, `LINUX`, `WINDOWS`
 	Rules            DetectionConditions `json:"rules,omitempty"`    // Define process detection rules by selecting a process property and a condition. Each monitoring rule can have multiple detection rules associated with it.
 	Scope            *string             `json:"-" scope:"scope"`    // The scope of this setting (HOST, HOST_GROUP). Omit this property if you want to cover the whole environment.
-	MinimumProcesses int                 `json:"minimumProcesses"`   // Specify a minimum number of processes matching the monitoring rule. If it's not satisfied, an alert will open.
-	OperatingSystem  []OperatingSystem   `json:"operatingSystem"`    // Select the operating systems on which the monitoring rule should be applied.
 	InsertAfter      string              `json:"-"`
 }
 
@@ -43,20 +43,43 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"metadata": {
 			Type:        schema.TypeList,
 			Description: "Set of additional key-value properties to be attached to the triggered event. You can retrieve the available property keys using the [Events API v2](https://dt-url.net/9622g1w). Additionally any Host resource attribute can be dynamically substituted (agent 1.325+).",
-			Optional:    true,
+			Optional:    true, // minobjects == 0
 			Elem:        &schema.Resource{Schema: new(MetadataItems).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"minimum_processes": {
+			Type:        schema.TypeInt,
+			Description: "Specify a minimum number of processes matching the monitoring rule. An alert is triggered if any host falls below this threshold.",
+			Optional:    true,
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				// minimum_processes was introduced in v286 as a required field, added code below to have successful results for old/new tenants.
+				return newValue == "0"
+			},
+			// Default: 1,
 		},
 		"name": {
 			Type:        schema.TypeString,
 			Description: "Monitoring rule name",
 			Required:    true,
 		},
+		"operating_system": {
+			Type:        schema.TypeSet,
+			Description: "Select the operating systems on which the monitoring rule should be applied.. Possible Values: `AIX`, `LINUX`, `WINDOWS`",
+			Optional:    true,
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				// operating_system was introduced in v286 as a required field, added code below to have successful results for old/new tenants.
+				if newValue == "0" || newValue == "" {
+					return true
+				}
+				return false
+			},
+			Elem: &schema.Schema{Type: schema.TypeString},
+		},
 		"rules": {
 			Type:        schema.TypeList,
 			Description: "Define process detection rules by selecting a process property and a condition. Each monitoring rule can have multiple detection rules associated with it.",
-			Optional:    true,
+			Optional:    true, // minobjects == 0
 			Elem:        &schema.Resource{Schema: new(DetectionConditions).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -67,29 +90,6 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "environment",
 			ForceNew:    true,
-		},
-		"minimum_processes": {
-			Type:        schema.TypeInt,
-			Description: "Specify a minimum number of processes matching the monitoring rule. If it's not satisfied, an alert will open.",
-			Optional:    true,
-			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-				// minimum_processes was introduced in v286 as a required field, added code below to have successful results for old/new tenants.
-				return newValue == "0"
-			},
-			// Default: 1,
-		},
-		"operating_system": {
-			Type:        schema.TypeSet,
-			Description: "Select the operating systems on which the monitoring rule should be applied.",
-			Optional:    true,
-			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-				// operating_system was introduced in v286 as a required field, added code below to have successful results for old/new tenants.
-				if newValue == "0" || newValue == "" {
-					return true
-				}
-				return false
-			},
-			Elem: &schema.Schema{Type: schema.TypeString},
 		},
 		"insert_after": {
 			Type:        schema.TypeString,
@@ -104,11 +104,11 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
 		"enabled":           me.Enabled,
 		"metadata":          me.Metadata,
+		"minimum_processes": me.MinimumProcesses,
 		"name":              me.Name,
+		"operating_system":  me.OperatingSystem,
 		"rules":             me.Rules,
 		"scope":             me.Scope,
-		"minimum_processes": me.MinimumProcesses,
-		"operating_system":  me.OperatingSystem,
 		"insert_after":      me.InsertAfter,
 	})
 }
@@ -117,11 +117,11 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	err := decoder.DecodeAll(map[string]any{
 		"enabled":           &me.Enabled,
 		"metadata":          &me.Metadata,
+		"minimum_processes": &me.MinimumProcesses,
 		"name":              &me.Name,
+		"operating_system":  &me.OperatingSystem,
 		"rules":             &me.Rules,
 		"scope":             &me.Scope,
-		"minimum_processes": &me.MinimumProcesses,
-		"operating_system":  &me.OperatingSystem,
 		"insert_after":      &me.InsertAfter,
 	})
 	// MinimumProcesses and OperatingSystem were introduced in v286 as required fields, added code below to have successful results for old/new tenants.

--- a/dynatrace/api/builtin/rum/web/capturecustomproperties/schema.json
+++ b/dynatrace/api/builtin/rum/web/capturecustomproperties/schema.json
@@ -15,6 +15,12 @@
 			"customValidatorId": "rumAppCaptureCustomPropertiesCaseInsensitiveValidator",
 			"skipAsyncValidation": false,
 			"type": "CUSTOM_VALIDATOR_REF"
+		},
+		{
+			"customMessage": "Field names must not contain the prefix 'event_properties.' or 'session_properties.'",
+			"customValidatorId": "rumAppCaptureCustomPropertiesPrefixValidator",
+			"skipAsyncValidation": false,
+			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"description": "Define specific properties to restrict event/session capturing, with options to allow by property name or allow all properties.",
@@ -43,6 +49,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "EARLY_ADOPTER",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -147,5 +154,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "0.3"
+	"version": "0.4"
 }

--- a/dynatrace/api/builtin/rum/web/capturecustomproperties/service.go
+++ b/dynatrace/api/builtin/rum/web/capturecustomproperties/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@
 package capturecustomproperties
 
 import (
-	capturecustomproperties "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/web/capturecustomproperties/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/web/capturecustomproperties/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.3"
+const SchemaVersion = "0.4"
 const SchemaID = "builtin:rum.web.capture-custom-properties"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*capturecustomproperties.Settings] {
-	return settings20.Service[*capturecustomproperties.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/rum/web/capturecustomproperties/settings/custom_property.go
+++ b/dynatrace/api/builtin/rum/web/capturecustomproperties/settings/custom_property.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2025 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,9 +45,9 @@ func (me *CustomProperties) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type CustomProperty struct {
-	CaseInsensitiveNamingEnabled bool          `json:"caseInsensitiveNamingEnabled,omitempty"` // Field name validation should be case-insensitive
-	FieldDataType                FieldDataType `json:"fieldDataType"`                          // Possible Values: `BOOLEAN`, `NUMBER`, `STRING`
-	FieldName                    string        `json:"fieldName"`                              // Field name
+	CaseInsensitiveNamingEnabled bool          `json:"caseInsensitiveNamingEnabled"` // Field name validation should be case-insensitive
+	FieldDataType                FieldDataType `json:"fieldDataType"`                // Datatype. Possible Values: `BOOLEAN`, `NUMBER`, `STRING`
+	FieldName                    string        `json:"fieldName"`                    // Field name
 }
 
 func (me *CustomProperty) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *CustomProperty) Schema() map[string]*schema.Schema {
 		},
 		"field_data_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `BOOLEAN`, `NUMBER`, `STRING`",
+			Description: "Datatype. Possible Values: `BOOLEAN`, `NUMBER`, `STRING`",
 			Required:    true,
 		},
 		"field_name": {


### PR DESCRIPTION
#### **Why** this PR?
Some APIs have changed with Dynatrace version 1.329. Therefore, the Terraform resources also need updating.

#### **What** has changed?
For most of the resources there are only documentation updates.
`dynatrace_disk_options`: new field `monitorTmpfs`. Default to `false`

#### How is it **tested**?
It's mostly about documentation.
Added the new property of `dynatrace_disk_options` to the example, which is tested.

#### How does it affect **users**?
They will see the updated documentation and can make use of the new property of `dynatrace_disk_options`.

**Issue:** CA-17601
