### PR TITLE
fix: Correct `group` field description for `dynatrace_iam_policy_bindings` and `dynatrace_iam_policy_bindings_v2`

### DIFF
--- a/dynatrace/api/iam/bindings/settings/policy_binding.go
+++ b/dynatrace/api/iam/bindings/settings/policy_binding.go
@@ -39,7 +39,7 @@ func (me *PolicyBinding) Schema() map[string]*schema.Schema {
 		"group": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The name of the policy",
+			Description: "The UUID of the group to which the policy applies",
 			ForceNew:    true,
 		},
 		"account": {

--- a/dynatrace/api/iam/v2bindings/settings/policy_binding.go
+++ b/dynatrace/api/iam/v2bindings/settings/policy_binding.go
@@ -39,7 +39,7 @@ func (me *PolicyBinding) Schema() map[string]*schema.Schema {
 		"group": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The name of the policy",
+			Description: "The UUID of the group to which the policy applies",
 			ForceNew:    true,
 		},
 		"account": {


### PR DESCRIPTION
#### **Why** this PR?
The description for the `group` field in the `dynatrace_iam_policy_bindings` and `dynatrace_iam_policy_bindings_v2` resources was incorrect.

#### **What** has changed and **how** does it do it?
The description now states that the `group` is the UUID of the group to which the policy applies.

#### How is it **tested**?
NA

#### How does it affect **users**?
Yes - documentation is correct.

**Issue:**
NA
