### PR TITLE
feat: support advanced monitor settings for `dynatrace_http_monitor`

### DIFF
--- a/dynatrace/api/v1/config/synthetic/monitors/http/settings/customProperty.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/settings/customProperty.go
@@ -1,0 +1,90 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type CustomProperties []*CustomProperty
+
+func (me *CustomProperties) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"custom_property": {
+			Type:        schema.TypeSet,
+			Description: "Custom properties for the monitor",
+			Required:    true,
+			MinItems:    1,
+			Elem:        &schema.Resource{Schema: new(CustomProperty).Schema()},
+		},
+	}
+}
+
+func (me CustomProperties) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("custom_property", me)
+}
+
+func (me *CustomProperties) UnmarshalHCL(decoder hcl.Decoder) error {
+	if err := decoder.DecodeSlice("custom_property", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	customProperties := CustomProperties{}
+	for _, property := range *me {
+		if property.Name != "" || property.Value != "" {
+			customProperties = append(customProperties, property)
+		}
+	}
+	*me = customProperties
+	return nil
+}
+
+type CustomProperty struct {
+	Name  string `json:"name"`  // The name of the custom property
+	Value string `json:"value"` // The value of the custom property
+}
+
+func (me *CustomProperty) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Description: "The name of the custom property. Possible values: `hmRequestTimeoutInMs`, `hmConnectTimeoutInMs`, `hmMaxHeaderSizeInBytes`, `hmMonitorExecutionTimeoutInMs`, `hmScriptExecutionTimeoutInMs`, `hmMaxRequestBodySizeInBytes`, `hmMaxCustomScriptSizeInBytes`, `hmMaxResponseBodySizeInBytes`, `hmMaxResponseBodySizeToCustomScriptInBytes`, `hmDnsQueryTimeoutInMs`",
+			Required:    true,
+		},
+		"value": {
+			Type:        schema.TypeString,
+			Description: "The value of the custom property",
+			Required:    true,
+		},
+	}
+}
+
+func (me *CustomProperty) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"name":  me.Name,
+		"value": me.Value,
+	})
+}
+
+func (me *CustomProperty) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"name":  &me.Name,
+		"value": &me.Value,
+	})
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/http/settings/script.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/settings/script.go
@@ -24,8 +24,9 @@ import (
 )
 
 type Script struct {
-	Version  string   `json:"version"`  // Script version—use the `1.0` value here
-	Requests Requests `json:"requests"` // A list of HTTP requests to be performed by the monitor.\n\nThe requests are executed in the order in which they appear in the script
+	Version          string           `json:"version"`  // Script version—use the `1.0` value here
+	Requests         Requests         `json:"requests"` // A list of HTTP requests to be performed by the monitor.\n\nThe requests are executed in the order in which they appear in the script
+	CustomProperties CustomProperties `json:"customProperties,omitempty"`
 }
 
 func (me *Script) GetVersion() string {
@@ -41,6 +42,14 @@ func (me *Script) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			Elem:        &schema.Resource{Schema: new(Request).Schema()},
 		},
+		"custom_properties": {
+			Type:        schema.TypeList,
+			Description: "[Preview only](https://docs.dynatrace.com/docs/whats-new/preview-releases). A set of custom properties assigned to the monitor. More information can be found [here](https://docs.dynatrace.com/docs/observe/digital-experience/synthetic-monitoring/http-monitors-classic/advanced-http-monitor-settings-classic).",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: new(CustomProperties).Schema(),
+			},
+		},
 	}
 }
 
@@ -48,11 +57,17 @@ func (me *Script) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Encode("request", me.Requests); err != nil {
 		return err
 	}
+	if err := properties.Encode("custom_properties", me.CustomProperties); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (me *Script) UnmarshalHCL(decoder hcl.Decoder) error {
 	me.Version = me.GetVersion()
+	if err := decoder.Decode("custom_properties", &me.CustomProperties); err != nil {
+		return err
+	}
 	if result, ok := decoder.GetOk("request.#"); ok {
 		me.Requests = Requests{}
 		for idx := 0; idx < result.(int); idx++ {

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_advanced.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_advanced.tf
@@ -1,0 +1,68 @@
+resource "dynatrace_http_monitor" "advanced" {
+  name      = "#name#"
+  frequency = 1
+  locations = ["GEOLOCATION-F3E06A526BE3B4C4"]
+  anomaly_detection {
+    loading_time_thresholds {
+    }
+    outage_handling {
+      global_outage = true
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  script {
+    request {
+      description     = "getOffice365ActiveUserCounts"
+      method          = "GET"
+      url             = "https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserCounts(period='D7')"
+      configuration {
+        accept_any_certificate = true
+        follow_redirects       = true
+      }
+    }
+    custom_properties {
+      custom_property {
+        name = "hmRequestTimeoutInMs"
+        value = "5000"
+      }
+      custom_property {
+        name = "hmConnectTimeoutInMs"
+        value = "5000"
+      }
+      custom_property {
+        name = "hmMaxHeaderSizeInBytes"
+        value = "10240"
+      }
+      custom_property {
+        name = "hmMonitorExecutionTimeoutInMs"
+        value = "10000"
+      }
+      custom_property {
+        name = "hmScriptExecutionTimeoutInMs"
+        value = "5000"
+      }
+      custom_property {
+        name = "hmMaxRequestBodySizeInBytes"
+        value = "10240"
+      }
+      custom_property {
+        name = "hmMaxCustomScriptSizeInBytes"
+        value = "10240"
+      }
+      custom_property {
+        name = "hmMaxResponseBodySizeInBytes"
+        value = "51200"
+      }
+      custom_property {
+        name = "hmMaxResponseBodySizeToCustomScriptInBytes"
+        value = "10240"
+      }
+      custom_property {
+        name = "hmDnsQueryTimeoutInMs"
+        value = "5000"
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
It's not possible to set certain preview-only properties. Therefore, we should support the advanced settings of HTTP monitors.

#### **What** has changed?
The advanced settings for HTTP monitors can now be set/changed.

#### **How** does it do it?
New field `custom_properties` for `dynatrace_http_monitor` added, which is a key-value pair of certain configs.

#### How is it **tested**?
New test/example added.

#### How does it affect **users**?
Preview users can now make use of the advanced settings of HTTP monitors.

**Issue:** CA-17717