### PR TITLE
fix: `dynatrace_iam_policy_bindings_v2` incorrect policy binding update

### DIFF
--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -120,7 +120,7 @@ type BindingsResponse struct {
 	} `json:"policyBindings"`
 }
 
-func (me *BindingServiceClient) getGroupPolicyBindingIDs(ctx context.Context, id string) ([]string, error) {
+func (me *BindingServiceClient) getGroupPolicyBindingUUIDs(ctx context.Context, id string) ([]string, error) {
 	groupID, levelType, levelID, err := splitID(id)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 	}
 	client := iam.NewIAMClient(me)
 
-	policyIDs, err := me.getGroupPolicyBindingIDs(ctx, id)
+	policyIDs, err := me.getGroupPolicyBindingUUIDs(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 
 	client := iam.NewIAMClient(me)
 
-	deployedBindings, err := me.getGroupPolicyBindingIDs(ctx, id)
+	deployedBindings, err := me.getGroupPolicyBindingUUIDs(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	policyIDs, err := me.getGroupPolicyBindingIDs(ctx, id)
+	policyIDs, err := me.getGroupPolicyBindingUUIDs(ctx, id)
 	policyUUIDs := map[string]string{}
 	for _, policy := range policyIDs {
 		policyUUID, _, _, err := policies.SplitID(policy, levelType, levelID)

--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -120,6 +120,23 @@ type BindingsResponse struct {
 	} `json:"policyBindings"`
 }
 
+func (me *BindingServiceClient) getGroupPolicyBindingIDs(ctx context.Context, id string) ([]string, error) {
+	groupID, levelType, levelID, err := splitID(id)
+	if err != nil {
+		return nil, err
+	}
+	client := iam.NewIAMClient(me)
+
+	type groupPolicyBindings struct {
+		PolicyUuids []string `json:"policyUuids"`
+	}
+	var policyBindings groupPolicyBindings
+	if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/groups/%s", me.endpointURL, levelType, levelID, groupID), 200, false, &policyBindings); err != nil {
+		return nil, err
+	}
+	return policyBindings.PolicyUuids, nil
+}
+
 func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.PolicyBinding) error {
 	stateConfig := getStateConfig(ctx)
 	groupID, levelType, levelID, err := splitID(id)
@@ -128,10 +145,8 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 	}
 	client := iam.NewIAMClient(me)
 
-	policyUUIDStruct := struct {
-		PolicyUuids []string `json:"policyUuids"`
-	}{}
-	if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/groups/%s", me.endpointURL, levelType, levelID, groupID), 200, false, &policyUUIDStruct); err != nil {
+	policyIDs, err := me.getGroupPolicyBindingIDs(ctx, id)
+	if err != nil {
 		return err
 	}
 	if levelType == "account" {
@@ -142,7 +157,7 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 	v.GroupID = groupID
 	policies := []*bindings.Policy{}
 
-	for _, policyID := range policyUUIDStruct.PolicyUuids {
+	for _, policyID := range policyIDs {
 		var bindingsResponse BindingsResponse
 		if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyID, groupID), 200, false, &bindingsResponse); err != nil {
 			return err
@@ -203,8 +218,12 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 
 	policiesList := append([]*bindings.Policy{}, v.Policies...)
 
-	for _, policy := range policiesList {
-		policyUUID, _, _, _ := policies.SplitID(policy.ID, levelType, levelID)
+	policyBindings, err := me.getGroupPolicyBindingIDs(ctx, id)
+	if err != nil {
+		return err
+	}
+	for _, policyID := range policyBindings {
+		policyUUID, _, _, _ := policies.SplitID(policyID, levelType, levelID)
 		if _, err = client.DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyUUID, groupID), []int{204, 400, 404}, false); err != nil {
 			return err
 		}

--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -208,6 +208,12 @@ func (me *BindingServiceClient) resolvePolicies(ctx context.Context, uuid string
 	return results, nil
 }
 
+type bindingPayload = struct {
+	Parameters map[string]string `json:"parameters"`
+	Metadata   map[string]string `json:"metadata"`
+	Boundaries []string          `json:"boundaries"`
+}
+
 func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindings.PolicyBinding) error {
 	groupID, levelType, levelID, err := splitID(id)
 	if err != nil {
@@ -216,35 +222,51 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 
 	client := iam.NewIAMClient(me)
 
-	policiesList := append([]*bindings.Policy{}, v.Policies...)
-
-	policyBindings, err := me.getGroupPolicyBindingIDs(ctx, id)
+	deployedBindings, err := me.getGroupPolicyBindingIDs(ctx, id)
 	if err != nil {
 		return err
 	}
-	for _, policyID := range policyBindings {
-		policyUUID, _, _, _ := policies.SplitID(policyID, levelType, levelID)
-		if _, err = client.DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyUUID, groupID), []int{204, 400, 404}, false); err != nil {
-			return err
+	existingPolicyBindings := map[string]struct{}{}
+	for _, desiredPolicy := range deployedBindings {
+		existingPolicyBindings[desiredPolicy] = struct{}{}
+	}
+	desiredPolicyBindings := map[string]*bindings.Policy{}
+	for _, desiredPolicy := range v.Policies {
+		policyUUID, _, _, _ := policies.SplitID(desiredPolicy.ID, levelType, levelID)
+		desiredPolicyBindings[policyUUID] = desiredPolicy
+	}
+
+	// update/delete
+	for existingPolicyID := range existingPolicyBindings {
+		if desiredPolicy, ok := desiredPolicyBindings[existingPolicyID]; ok {
+			// policy found that matches desired - update
+			payload := bindingPayload{
+				Parameters: desiredPolicy.Parameters,
+				Metadata:   desiredPolicy.Metadata,
+				Boundaries: desiredPolicy.Boundaries,
+			}
+			if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, existingPolicyID, groupID), payload, 204, false); err != nil {
+				return err
+			}
+		} else {
+			// There is an existing policy binding that is not desired anymore - delete
+			if _, err = client.DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, existingPolicyID, groupID), []int{204, 400, 404}, false); err != nil {
+				return err
+			}
 		}
 	}
-	for _, policy := range policiesList {
-		policyUUID, _, _, _ := policies.SplitID(policy.ID, levelType, levelID)
-		payload := struct {
-			Parameters map[string]string `json:"parameters"`
-			Metadata   map[string]string `json:"metadata"`
-			Boundaries []string          `json:"boundaries"`
-		}{
-			Parameters: policy.Parameters,
-			Metadata:   policy.Metadata,
-			Boundaries: policy.Boundaries,
-		}
-		retries := 0
-		for retries < 10 {
+
+	// If not found in existing bindings, create
+	for policyUUID, desiredPolicy := range desiredPolicyBindings {
+		if _, ok := existingPolicyBindings[policyUUID]; !ok {
+			payload := bindingPayload{
+				Parameters: desiredPolicy.Parameters,
+				Metadata:   desiredPolicy.Metadata,
+				Boundaries: desiredPolicy.Boundaries,
+			}
 			if _, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyUUID, groupID), payload, 204, false); err != nil {
 				return err
 			}
-			break
 		}
 	}
 
@@ -380,13 +402,10 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	var binding bindings.PolicyBinding
-	if err = me.Get(ctx, id, &binding); err != nil {
-		return err
-	}
+	policyIDs, err := me.getGroupPolicyBindingIDs(ctx, id)
 	policyUUIDs := map[string]string{}
-	for _, policy := range binding.Policies {
-		policyUUID, _, _, err := policies.SplitID(policy.ID, levelType, levelID)
+	for _, policy := range policyIDs {
+		policyUUID, _, _, err := policies.SplitID(policy, levelType, levelID)
 		if err != nil {
 			return err
 		}

--- a/dynatrace/api/iam/v2bindings/service_test.go
+++ b/dynatrace/api/iam/v2bindings/service_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2bindings_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccV2Bindings(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	t.Setenv("TF_VAR_ACCOUNT_ID", os.Getenv("DT_ACCOUNT_ID"))
+	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
+	configUpdate, _ := api.ReadTfConfig(t, "testdata/update.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("Removal of policies works", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCreate},
+				{Config: configUpdate}, // removes one policy, adds a new policy and updates an existing policy
+			},
+		}
+		resource.Test(t, testCase)
+	})
+}

--- a/dynatrace/api/iam/v2bindings/service_test.go
+++ b/dynatrace/api/iam/v2bindings/service_test.go
@@ -33,7 +33,12 @@ func TestAccV2Bindings(t *testing.T) {
 		return
 	}
 
-	t.Setenv("TF_VAR_ACCOUNT_ID", os.Getenv("DT_ACCOUNT_ID"))
+	accountID := os.Getenv("DT_ACCOUNT_ID")
+	//fallback to DYNATRACE_ACCOUNT_ID
+	if accountID == "" {
+		accountID = os.Getenv("DYNATRACE_ACCOUNT_ID")
+	}
+	t.Setenv("TF_VAR_ACCOUNT_ID", accountID)
 	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
 	configUpdate, _ := api.ReadTfConfig(t, "testdata/update.tf")
 

--- a/dynatrace/api/iam/v2bindings/testdata/create.tf
+++ b/dynatrace/api/iam/v2bindings/testdata/create.tf
@@ -1,0 +1,40 @@
+variable "ACCOUNT_ID" {
+  description = "The ID of the Dynatrace account."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "my_group" {
+  name          = "#name#"
+  lifecycle {
+    ignore_changes = [permissions]
+  }
+}
+
+resource "dynatrace_iam_policy" "policy" {
+  name            = "#name#"
+  account = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:objects:read;"
+}
+
+resource "dynatrace_iam_policy" "acc_policy" {
+  name            = "#name#-2"
+  account     = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:schemas:read;"
+}
+
+resource "dynatrace_iam_policy_bindings_v2" "acc_bindings" {
+  group       = dynatrace_iam_group.my_group.id
+  account     = var.ACCOUNT_ID
+  policy {
+    id = dynatrace_iam_policy.policy.id
+  }
+  policy {
+    id = dynatrace_iam_policy.acc_policy.id
+    parameters = {
+      "prop-b" : "value-b"
+    }
+    metadata = {
+      "prop-b" : "value-c"
+    }
+  }
+}

--- a/dynatrace/api/iam/v2bindings/testdata/update.tf
+++ b/dynatrace/api/iam/v2bindings/testdata/update.tf
@@ -1,0 +1,46 @@
+variable "ACCOUNT_ID" {
+  description = "The ID of the Dynatrace account."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "my_group" {
+  name          = "#name#"
+  lifecycle {
+    ignore_changes = [permissions]
+  }
+}
+
+resource "dynatrace_iam_policy" "policy" {
+  name            = "#name#"
+  account = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:objects:read;"
+}
+
+resource "dynatrace_iam_policy" "acc_policy" {
+  name            = "#name#-2"
+  account     = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:schemas:read;"
+}
+
+resource "dynatrace_iam_policy" "new_policy" {
+  name            = "#name#-3"
+  account = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:objects:write;"
+}
+
+resource "dynatrace_iam_policy_bindings_v2" "acc_bindings" {
+  group       = dynatrace_iam_group.my_group.id
+  account     = var.ACCOUNT_ID
+  policy {
+    id = dynatrace_iam_policy.new_policy.id
+  }
+  policy {
+    id = dynatrace_iam_policy.acc_policy.id
+    parameters = {
+      "prop-b" : "value-b-edit"
+    }
+    metadata = {
+      "prop-b" : "value-c-edit"
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
If a policy is removed in the `dynatrace_iam_policy_bindings_v2` resource, an update won’t have any effect. It will show that the policy will be removed in the plan, but it won’t actually be removed.

#### **What** has changed?
Policy bindings can now be removed.

#### **How** does it do it?
By not deleting/updating only existing bindings defined in the resource but also comparing them against the deployed ones, so that non-existent ones in the resource are actually deleted.

#### How is it **tested**?
A new test was added that covers updating a binding with a new policy, a removed policy, and a modified policy.

#### How does it affect **users**?
Updating existing bindings via removing policies is now working.

**Issue:** CA-17779