### PR TITLE
test(iam): Adds dynatrace_iam_user & dynatrace_iam_group E2E tests

### DIFF
--- a/dynatrace/api/iam/groups/service_test.go
+++ b/dynatrace/api/iam/groups/service_test.go
@@ -1,0 +1,66 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package groups_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccUsers(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	accountID := os.Getenv("DT_ACCOUNT_ID")
+	//fallback to DYNATRACE_ACCOUNT_ID
+	if accountID == "" {
+		accountID = os.Getenv("DYNATRACE_ACCOUNT_ID")
+	}
+	t.Setenv("TF_VAR_ACCOUNT_ID", accountID)
+
+	groupName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_GROUP_NAME", groupName)
+
+	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
+	configUpdate, _ := api.ReadTfConfig(t, "testdata/update.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("Updating description, permissions, and federated attributes of group works", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCreate}, // creates group
+				{Config: configUpdate}, // updates group fields
+			},
+		}
+		resource.Test(t, testCase)
+	})
+}

--- a/dynatrace/api/iam/groups/testdata/create.tf
+++ b/dynatrace/api/iam/groups/testdata/create.tf
@@ -1,0 +1,10 @@
+variable "GROUP_NAME" {
+  description = "The name of the group."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "my-group" {
+  name = var.GROUP_NAME
+  description = "A group created for e2e testing."
+  federated_attribute_values = ["some-value"]
+}

--- a/dynatrace/api/iam/groups/testdata/update.tf
+++ b/dynatrace/api/iam/groups/testdata/update.tf
@@ -1,0 +1,21 @@
+variable "GROUP_NAME" {
+  description = "The name of the group."
+  type        = string
+}
+
+variable "ACCOUNT_ID" {
+  description = "The ID of the Dynatrace account."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "my-group" {
+  name = var.GROUP_NAME
+  description = "A group created for e2e testing with specific permissions."
+  permissions {
+    permission {
+      name  = "account-viewer"
+      type  = "account"
+      scope = var.ACCOUNT_ID
+    }
+  }
+}

--- a/dynatrace/api/iam/users/service_test.go
+++ b/dynatrace/api/iam/users/service_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package users_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccUsers(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	emailAddress := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha) + "@dynatrace.com"
+	t.Setenv("TF_VAR_USER_EMAIL", emailAddress)
+	groupName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_GROUP_NAME", groupName)
+
+	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
+	configUpdate, _ := api.ReadTfConfig(t, "testdata/update.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("Removal of group works", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCreate}, // creates user with group
+				{Config: configUpdate}, // removes group from user
+			},
+		}
+		resource.Test(t, testCase)
+	})
+}

--- a/dynatrace/api/iam/users/testdata/create.tf
+++ b/dynatrace/api/iam/users/testdata/create.tf
@@ -1,0 +1,28 @@
+variable "USER_EMAIL" {
+    description = "The email of the Dynatrace IAM user."
+    type        = string
+}
+
+// Every user always belongs to at least "Default group with all users"
+data "dynatrace_iam_group" "all_users_group" {
+  name = "Default group with all users"
+}
+
+variable "GROUP_NAME" {
+  description = "The name of the group."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "my_group" {
+  name          = var.GROUP_NAME
+
+  lifecycle {
+    ignore_changes = [permissions]
+  }
+}
+
+resource "dynatrace_iam_user" "my_user" {
+  email  = var.USER_EMAIL
+  groups = [data.dynatrace_iam_group.all_users_group.id, dynatrace_iam_group.my_group.id]
+}
+

--- a/dynatrace/api/iam/users/testdata/update.tf
+++ b/dynatrace/api/iam/users/testdata/update.tf
@@ -1,0 +1,14 @@
+variable "USER_EMAIL" {
+  description = "The email of the Dynatrace IAM user."
+  type        = string
+}
+
+// Every user always belongs to at least "Default group with all users"
+data "dynatrace_iam_group" "all_users_group" {
+  name = "Default group with all users"
+}
+
+resource "dynatrace_iam_user" "my_user" {
+  email  = var.USER_EMAIL
+  groups = [data.dynatrace_iam_group.all_users_group.id]
+}


### PR DESCRIPTION
#### **Why** this PR?
We need E2E tests for IAM resources

#### **What** has changed?
E2E tests have been added for 
- `dynatrace_iam_user`
- `dynatrace_iam_group`

#### **How** does it do it?
##### `dynatrace_iam_user`:
Two steps:
1. A user with a group is created
2. The user is updated, i.e. the user is removed from the group.
##### `dynatrace_iam_group`:
Two steps:
1. A simple group is created
2. This updates the description, federated attributes and permissions of the group

#### How is it **tested**?
This is the test.

#### How does it affect **users**?
It doesn't.

**Issue:** CA-17713
