### PR TITLE
fix: add fixed waiting time for synthetic monitor updates

### DIFF
--- a/dynatrace/api/v1/config/synthetic/monitors/http/service.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service.go
@@ -19,8 +19,10 @@ package http
 
 import (
 	"context"
+	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	monitors2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/synthetic/monitors"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
@@ -59,7 +61,12 @@ func (me *service) Create(ctx context.Context, v *http.SyntheticMonitor) (*api.S
 	if v.NoScript != nil && *v.NoScript && v.Script == nil {
 		v.Script = GetTempScript()
 	}
-	return me.service.Create(ctx, v)
+	stub, err := me.service.Create(ctx, v)
+	if err != nil {
+		return nil, err
+	}
+	time.Sleep(monitors2.TimeForUpdateConsistency)
+	return stub, nil
 }
 
 func (me *service) Update(ctx context.Context, id string, v *http.SyntheticMonitor) error {
@@ -70,7 +77,11 @@ func (me *service) Update(ctx context.Context, id string, v *http.SyntheticMonit
 		}
 		v.Script = monitorSettings.Script
 	}
-	return me.service.Update(ctx, id, v)
+	if err := me.service.Update(ctx, id, v); err != nil {
+		return err
+	}
+	time.Sleep(monitors2.TimeForUpdateConsistency)
+	return nil
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {

--- a/dynatrace/api/v2/synthetic/monitors/service.go
+++ b/dynatrace/api/v2/synthetic/monitors/service.go
@@ -32,8 +32,8 @@ import (
 const SchemaID = "v2:synthetic:monitors:network"
 const BasePath = "/api/v2/synthetic/monitors"
 
-var defaultCreateConfirm = 8
-var createConfirm = settings.GetIntEnv("DYNATRACE_CREATE_CONFIRM_SYNTHETIC_MONITORS_V2", defaultCreateConfirm, 1, 50)
+// TimeForUpdateConsistency Time to wait after create/update operations to allow for consistency in subsequent GET operations
+var TimeForUpdateConsistency = 5 * time.Second
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*monitors.Settings] {
 	return &service{credentials: credentials}
@@ -54,41 +54,7 @@ func (me *service) Create(ctx context.Context, v *monitors.Settings) (*api.Stub,
 		return nil, err
 	}
 
-	// The code below validates that the resource is fully created and available
-	// First loop: There could be a small delay until the API returns a successful GET after create
-	// Second loop: Tag configuration takes a while to propagate across the cluster
-	successes := 0
-	for {
-		if err = client.Get(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(resp.EntityId)), 200).Finish(); err == nil {
-			successes = successes + 1
-			if successes >= createConfirm {
-				break
-			}
-			time.Sleep(time.Millisecond * 100)
-		} else {
-			successes = 0
-			time.Sleep(time.Millisecond * 500)
-		}
-	}
-
-	if len(v.Tags) > 0 {
-		successes = 0
-		for {
-			validateMonitor := monitors.Settings{}
-			if err = client.Get(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(resp.EntityId)), 200).Finish(&validateMonitor); err == nil {
-				if len(v.Tags) == len(validateMonitor.Tags) {
-					successes = successes + 1
-					if successes >= createConfirm {
-						break
-					}
-				} else {
-					successes = 0
-				}
-				time.Sleep(time.Millisecond * 100)
-			}
-		}
-	}
-
+	time.Sleep(TimeForUpdateConsistency)
 	return &api.Stub{ID: resp.EntityId, Name: v.Name}, nil
 }
 
@@ -132,7 +98,7 @@ func (me *service) Update(ctx context.Context, id string, v *monitors.Settings) 
 	if err != nil {
 		return err
 	}
-	time.Sleep(3 * time.Second) // GET after update is eventually consistent
+	time.Sleep(TimeForUpdateConsistency)
 	return nil
 }
 


### PR DESCRIPTION
#### **Why** this PR?
Synthetic monitors are eventually consistent, not only for creation but also for updates. Meaning a GET after a create or an update may lead to an incomplete result (some properties are updated, and some aren't)

#### **What** has changed?
The state is now properly set after the update for `dynatrace_network_monitor` and `dynatrace_http_monitor`.

#### **How** does it do it?
By adding a 5-second sleep duration after the update. It has gotten worse last week, and 3 seconds aren't enough anymore.

#### How is it **tested**?
The test should not be flaky anymore

#### How does it affect **users**?
They're less likely to run into `terraform plan` updates after `terraform apply` for `dynatrace_network_monitor` and `dynatrace_http_monitor`.

**Issue:**
