### PR TITLE
test(permission): Adds dynatrace_iam_permission E2E test

### DIFF
--- a/dynatrace/api/iam/permissions/service_test.go
+++ b/dynatrace/api/iam/permissions/service_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package permissions_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccPermissions(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	accountID := os.Getenv("DT_ACCOUNT_ID")
+	//fallback to DYNATRACE_ACCOUNT_ID
+	if accountID == "" {
+		accountID = os.Getenv("DYNATRACE_ACCOUNT_ID")
+	}
+	t.Setenv("TF_VAR_ACCOUNT_ID", accountID)
+
+	groupName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_GROUP_NAME", groupName)
+
+	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("Create group with permission", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCreate}, // creates group and permission
+			},
+		}
+		resource.Test(t, testCase)
+	})
+}

--- a/dynatrace/api/iam/permissions/testdata/create.tf
+++ b/dynatrace/api/iam/permissions/testdata/create.tf
@@ -1,0 +1,25 @@
+variable "ACCOUNT_ID" {
+  description = "The ID of the Dynatrace account."
+  type        = string
+}
+
+variable "GROUP_NAME" {
+  description = "The name of the group."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "my-group" {
+  name = var.GROUP_NAME
+  description = "A group created for e2e testing."
+  federated_attribute_values = ["some-value"]
+
+  lifecycle {
+    ignore_changes = [permissions]
+  }
+}
+
+resource "dynatrace_iam_permission" "perm_a" {
+  name            = "account-viewer"
+  group           = dynatrace_iam_group.my-group.id
+  account = var.ACCOUNT_ID
+}


### PR DESCRIPTION
#### **Why** this PR?
We need E2E tests for IAM resources

#### **What** has changed?
E2E tests have been added for `dynatrace_iam_permission`

#### **How** does it do it?
Two steps:
1. A group is created and then a `dynatrace_iam_permission` resource is created which grants some permission to said group.
2. The permission resource is removed again.

#### How is it **tested**?
This is the test.

#### How does it affect **users**?
It doesn't.

**Issue:** CA-17713
