### PR TITLE
test(iam): Adds tests for policy, boundary, and binding resources

### DIFF
--- a/dynatrace/api/iam/bindings/service_test.go
+++ b/dynatrace/api/iam/bindings/service_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bindings_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccBindings(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	accountID := os.Getenv("DT_ACCOUNT_ID")
+	//fallback to DYNATRACE_ACCOUNT_ID
+	if accountID == "" {
+		accountID = os.Getenv("DYNATRACE_ACCOUNT_ID")
+	}
+	t.Setenv("TF_VAR_ACCOUNT_ID", accountID)
+
+	groupName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_GROUP_NAME", groupName)
+	policyNameOne := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_POLICY_NAME_1", policyNameOne)
+	policyNameTwo := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_POLICY_NAME_2", policyNameTwo)
+
+	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
+	configUpdate, _ := api.ReadTfConfig(t, "testdata/update.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("Create binding and update it", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCreate}, // creates binding which binds policy-1 to group
+				{Config: configUpdate}, // Removes policy-1 from binding and adds policy-2 instead
+			},
+		}
+		resource.Test(t, testCase)
+	})
+}

--- a/dynatrace/api/iam/bindings/testdata/create.tf
+++ b/dynatrace/api/iam/bindings/testdata/create.tf
@@ -1,0 +1,32 @@
+variable "ACCOUNT_ID" {
+  description = "The ID of the Dynatrace account."
+  type        = string
+}
+
+variable "GROUP_NAME" {
+  description = "The name of the group."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "group" {
+  name = var.GROUP_NAME
+}
+
+variable "POLICY_NAME_1" {
+  description = "The name of the first policy."
+  type        = string
+}
+
+resource "dynatrace_iam_policy" "policy-1" {
+  name            = var.POLICY_NAME_1
+  account         = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:objects:read, settings:schemas:read WHERE settings:schemaId = \"some-schema-id\";"
+}
+
+resource "dynatrace_iam_policy_bindings" "bindings" {
+  group       = dynatrace_iam_group.group.id
+  account     = var.ACCOUNT_ID
+  policies    = [dynatrace_iam_policy.policy-1.id]
+}
+
+

--- a/dynatrace/api/iam/bindings/testdata/update.tf
+++ b/dynatrace/api/iam/bindings/testdata/update.tf
@@ -1,0 +1,32 @@
+variable "ACCOUNT_ID" {
+  description = "The ID of the Dynatrace account."
+  type        = string
+}
+
+variable "GROUP_NAME" {
+  description = "The name of the group."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "group" {
+  name = var.GROUP_NAME
+}
+
+variable "POLICY_NAME_2" {
+  description = "The name of the second policy."
+  type        = string
+}
+
+resource "dynatrace_iam_policy" "policy-2" {
+  name            = var.POLICY_NAME_2
+  account         = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:objects:read, settings:schemas:read WHERE settings:schemaId = \"another-schema-id\";"
+}
+
+resource "dynatrace_iam_policy_bindings" "bindings" {
+  group       = dynatrace_iam_group.group.id
+  account     = var.ACCOUNT_ID
+  policies    = [dynatrace_iam_policy.policy-2.id]
+}
+
+

--- a/dynatrace/api/iam/boundaries/service_test.go
+++ b/dynatrace/api/iam/boundaries/service_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package boundaries_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccBoundaries(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	boundaryName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_BOUNDARY_NAME", boundaryName)
+
+	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
+	configUpdate, _ := api.ReadTfConfig(t, "testdata/update.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("Create boundary and update it", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCreate}, // creates boundary
+				{Config: configUpdate}, // Updates boundary
+			},
+		}
+		resource.Test(t, testCase)
+	})
+}

--- a/dynatrace/api/iam/boundaries/testdata/create.tf
+++ b/dynatrace/api/iam/boundaries/testdata/create.tf
@@ -1,0 +1,9 @@
+variable "BOUNDARY_NAME" {
+  description = "The name of the policy boundary."
+  type        = string
+}
+
+resource "dynatrace_iam_policy_boundary" "boundary" {
+  name  = var.BOUNDARY_NAME
+  query = "environment:management-zone startsWith \"[Foo]\";"
+}

--- a/dynatrace/api/iam/boundaries/testdata/update.tf
+++ b/dynatrace/api/iam/boundaries/testdata/update.tf
@@ -1,0 +1,9 @@
+variable "BOUNDARY_NAME" {
+  description = "The name of the policy boundary."
+  type        = string
+}
+
+resource "dynatrace_iam_policy_boundary" "boundary" {
+  name  = var.BOUNDARY_NAME
+  query = "environment:management-zone startsWith \"[Bar]\";"
+}

--- a/dynatrace/api/iam/policies/service_test.go
+++ b/dynatrace/api/iam/policies/service_test.go
@@ -1,0 +1,66 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package policies_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccPolicies(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	accountID := os.Getenv("DT_ACCOUNT_ID")
+	//fallback to DYNATRACE_ACCOUNT_ID
+	if accountID == "" {
+		accountID = os.Getenv("DYNATRACE_ACCOUNT_ID")
+	}
+	t.Setenv("TF_VAR_ACCOUNT_ID", accountID)
+
+	policyName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_POLICY_NAME", policyName)
+
+	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
+	configUpdate, _ := api.ReadTfConfig(t, "testdata/update.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("Create account policy and update account policy", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCreate}, // creates policy
+				{Config: configUpdate}, // updates policy
+			},
+		}
+		resource.Test(t, testCase)
+	})
+}

--- a/dynatrace/api/iam/policies/testdata/create.tf
+++ b/dynatrace/api/iam/policies/testdata/create.tf
@@ -1,0 +1,15 @@
+variable "ACCOUNT_ID" {
+  description = "The ID of the Dynatrace account."
+  type        = string
+}
+
+variable "POLICY_NAME" {
+  description = "The name of the policy."
+  type        = string
+}
+
+resource "dynatrace_iam_policy" "policy" {
+  name            = var.POLICY_NAME
+  account         = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:objects:read, settings:schemas:read WHERE settings:schemaId = \"string\";"
+}

--- a/dynatrace/api/iam/policies/testdata/update.tf
+++ b/dynatrace/api/iam/policies/testdata/update.tf
@@ -1,0 +1,15 @@
+variable "ACCOUNT_ID" {
+  description = "The ID of the Dynatrace account."
+  type        = string
+}
+
+variable "POLICY_NAME" {
+  description = "The name of the policy."
+  type        = string
+}
+
+resource "dynatrace_iam_policy" "policy" {
+  name            = var.POLICY_NAME
+  account         = var.ACCOUNT_ID
+  statement_query = "ALLOW settings:objects:read, settings:schemas:read WHERE settings:schemaId = \"other-string\";"
+}


### PR DESCRIPTION
#### **Why** this PR?
We need E2E tests for IAM resources

#### **What** has changed?
E2E tests have been added for 
- `dynatrace_iam_policy`
- `dynatrace_iam_policy_boundary`
- `dynatrace_iam_policy_bindings`

#### **How** does it do it?
For each resource there is a `create.tf` and an `update.tf` file.
So the respective resource is created and afterwards updated.

##### Limitation
I only included account policies. 
I did not want to assume an environment via env var for environment policies.

#### How is it **tested**?
This is the test.

#### How does it affect **users**?
It doesn't.

**Issue:** CA-17713
