### PR TITLE
feat: resource updates for v330

### DIFF
--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/schema.json
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/schema.json
@@ -42,6 +42,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -951,7 +952,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": false,
+					"nullable": true,
 					"type": {
 						"$ref": "#/types/highGcActivityDetection"
 					}
@@ -2011,5 +2012,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.2.9"
+	"version": "1.3"
 }

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/service.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.2.9"
+const SchemaVersion = "1.3"
 const SchemaID = "builtin:anomaly-detection.infrastructure-hosts"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*hosts.Settings] {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/connection_lost_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/connection_lost_detection.go
@@ -18,26 +18,28 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type ConnectionLostDetection struct {
-	Enabled             bool                                `json:"enabled"`                       // Detect host or monitoring connection lost problems
-	OnGracefulShutdowns *ConnectionLostDetectionSensitivity `json:"onGracefulShutdowns,omitempty"` // Graceful host shutdowns
+	Enabled             bool                                `json:"enabled"`                       // This setting is enabled (`true`) or disabled (`false`)
+	OnGracefulShutdowns *ConnectionLostDetectionSensitivity `json:"onGracefulShutdowns,omitempty"` // Graceful host shutdowns. Possible Values: `ALERT_ON_GRACEFUL_SHUTDOWN`, `DONT_ALERT_ON_GRACEFUL_SHUTDOWN`
 }
 
 func (me *ConnectionLostDetection) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect host or monitoring connection lost problems",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 		"on_graceful_shutdowns": {
 			Type:        schema.TypeString,
-			Description: "Graceful host shutdowns. Possible values: `DONT_ALERT_ON_GRACEFUL_SHUTDOWN`, `ALERT_ON_GRACEFUL_SHUTDOWN`",
-			Optional:    true,
+			Description: "Graceful host shutdowns. Possible Values: `ALERT_ON_GRACEFUL_SHUTDOWN`, `DONT_ALERT_ON_GRACEFUL_SHUTDOWN`",
+			Optional:    true, // precondition
 		},
 	}
 }
@@ -47,6 +49,16 @@ func (me *ConnectionLostDetection) MarshalHCL(properties hcl.Properties) error {
 		"enabled":               me.Enabled,
 		"on_graceful_shutdowns": me.OnGracefulShutdowns,
 	})
+}
+
+func (me *ConnectionLostDetection) HandlePreconditions() error {
+	if (me.OnGracefulShutdowns == nil) && (me.Enabled) {
+		return fmt.Errorf("'on_graceful_shutdowns' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.OnGracefulShutdowns != nil) && (!me.Enabled) {
+		return fmt.Errorf("'on_graceful_shutdowns' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *ConnectionLostDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/enums.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/enums.go
@@ -23,8 +23,8 @@ var ConnectionLostDetectionSensitivities = struct {
 	AlertOnGracefulShutdown     ConnectionLostDetectionSensitivity
 	DontAlertOnGracefulShutdown ConnectionLostDetectionSensitivity
 }{
-	ConnectionLostDetectionSensitivity("ALERT_ON_GRACEFUL_SHUTDOWN"),
-	ConnectionLostDetectionSensitivity("DONT_ALERT_ON_GRACEFUL_SHUTDOWN"),
+	"ALERT_ON_GRACEFUL_SHUTDOWN",
+	"DONT_ALERT_ON_GRACEFUL_SHUTDOWN",
 }
 
 type DetectionMode string
@@ -33,6 +33,6 @@ var DetectionModes = struct {
 	Auto   DetectionMode
 	Custom DetectionMode
 }{
-	DetectionMode("auto"),
-	DetectionMode("custom"),
+	"auto",
+	"custom",
 }

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/event_thresholds.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/event_thresholds.go
@@ -24,7 +24,7 @@ import (
 
 type EventThresholds struct {
 	DealertingEvaluationWindow int `json:"dealertingEvaluationWindow"` // The number of **10-second samples** that form the sliding evaluation window for dealerting.
-	DealertingSamples          int `json:"dealertingSamples"`          // The number of **10-second samples** within the evaluation window that must be lower the threshold to close an event
+	DealertingSamples          int `json:"dealertingSamples"`          // The number of **10-second samples** within the evaluation window that must be lower than the threshold to close an event
 	ViolatingEvaluationWindow  int `json:"violatingEvaluationWindow"`  // The number of **10-second samples** that form the sliding evaluation window to detect violating samples.
 	ViolatingSamples           int `json:"violatingSamples"`           // The number of **10-second samples** within the evaluation window that must exceed the threshold to trigger an event
 }
@@ -38,7 +38,7 @@ func (me *EventThresholds) Schema() map[string]*schema.Schema {
 		},
 		"dealerting_samples": {
 			Type:        schema.TypeInt,
-			Description: "The number of **10-second samples** within the evaluation window that must be lower the threshold to close an event",
+			Description: "The number of **10-second samples** within the evaluation window that must be lower than the threshold to close an event",
 			Required:    true,
 		},
 		"violating_evaluation_window": {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_cpu_saturation_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_cpu_saturation_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type HighCpuSaturationDetection struct {
 	CustomThresholds *HighCpuSaturationDetectionThresholds `json:"customThresholds,omitempty"`
-	DetectionMode    *DetectionMode                        `json:"detectionMode,omitempty"` // Detection mode for CPU saturation
-	Enabled          bool                                  `json:"enabled"`                 // Detect CPU saturation on host
+	DetectionMode    *DetectionMode                        `json:"detectionMode,omitempty"` // Detection mode for CPU saturation. Possible Values: `auto`, `custom`
+	Enabled          bool                                  `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *HighCpuSaturationDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *HighCpuSaturationDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(HighCpuSaturationDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for CPU saturation",
-			Optional:    true,
+			Description: "Detection mode for CPU saturation. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect CPU saturation on host",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *HighCpuSaturationDetection) MarshalHCL(properties hcl.Properties) erro
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *HighCpuSaturationDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *HighCpuSaturationDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_gc_activity_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_gc_activity_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type HighGcActivityDetection struct {
 	CustomThresholds *HighGcActivityDetectionThresholds `json:"customThresholds,omitempty"` // Alert if the GC time **or** the GC suspension is exceeded
-	DetectionMode    *DetectionMode                     `json:"detectionMode,omitempty"`    // Detection mode for high GC activity
-	Enabled          bool                               `json:"enabled"`                    // You may also configure high GC activity alerting for .NET processes on [extensions events page](/#settings/anomalydetection/extensionevents).
+	DetectionMode    *DetectionMode                     `json:"detectionMode,omitempty"`    // Detection mode for high GC activity. Possible Values: `auto`, `custom`
+	Enabled          bool                               `json:"enabled"`                    // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *HighGcActivityDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *HighGcActivityDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "Alert if the GC time **or** the GC suspension is exceeded",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(HighGcActivityDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for high GC activity",
-			Optional:    true,
+			Description: "Detection mode for high GC activity. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "You may also configure high GC activity alerting for .NET processes on [extensions events page](/#settings/anomalydetection/extensionevents).",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *HighGcActivityDetection) MarshalHCL(properties hcl.Properties) error {
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *HighGcActivityDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *HighGcActivityDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_memory_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_memory_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type HighMemoryDetection struct {
 	CustomThresholds *HighMemoryDetectionThresholds `json:"customThresholds,omitempty"` // Alert if **both** the memory usage and the memory page fault rate thresholds are exceeded on Windows or on Unix systems
-	DetectionMode    *DetectionMode                 `json:"detectionMode,omitempty"`    // Detection mode for high memory usage
-	Enabled          bool                           `json:"enabled"`                    // Detect high memory usage on host
+	DetectionMode    *DetectionMode                 `json:"detectionMode,omitempty"`    // Detection mode for high memory usage. Possible Values: `auto`, `custom`
+	Enabled          bool                           `json:"enabled"`                    // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *HighMemoryDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *HighMemoryDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "Alert if **both** the memory usage and the memory page fault rate thresholds are exceeded on Windows or on Unix systems",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(HighMemoryDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for high memory usage",
-			Optional:    true,
+			Description: "Detection mode for high memory usage. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect high memory usage on host",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *HighMemoryDetection) MarshalHCL(properties hcl.Properties) error {
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *HighMemoryDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *HighMemoryDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_network_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_network_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type HighNetworkDetection struct {
 	CustomThresholds *HighNetworkDetectionThresholds `json:"customThresholds,omitempty"`
-	DetectionMode    *DetectionMode                  `json:"detectionMode,omitempty"` // Detection mode for high network utilization
-	Enabled          bool                            `json:"enabled"`                 // Detect high network utilization
+	DetectionMode    *DetectionMode                  `json:"detectionMode,omitempty"` // Detection mode for high network utilization. Possible Values: `auto`, `custom`
+	Enabled          bool                            `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *HighNetworkDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *HighNetworkDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(HighNetworkDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for high network utilization",
-			Optional:    true,
+			Description: "Detection mode for high network utilization. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect high network utilization",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *HighNetworkDetection) MarshalHCL(properties hcl.Properties) error {
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *HighNetworkDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *HighNetworkDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_system_load_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_system_load_detection.go
@@ -18,13 +18,15 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type HighSystemLoadDetection struct {
 	CustomThresholds *HighSystemLoadDetectionThresholds `json:"customThresholds,omitempty"`
-	DetectionMode    *DetectionMode                     `json:"detectionMode,omitempty"` // Possible Values: `Auto`, `Custom`
+	DetectionMode    *DetectionMode                     `json:"detectionMode,omitempty"` // Detection mode for High System Load. Possible Values: `auto`, `custom`
 	Enabled          bool                               `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
 }
 
@@ -33,16 +35,15 @@ func (me *HighSystemLoadDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Optional:    true,
-
-			Elem:     &schema.Resource{Schema: new(HighSystemLoadDetectionThresholds).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(HighSystemLoadDetectionThresholds).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Auto`, `Custom`",
-			Optional:    true,
+			Description: "Detection mode for High System Load. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
@@ -58,6 +59,22 @@ func (me *HighSystemLoadDetection) MarshalHCL(properties hcl.Properties) error {
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *HighSystemLoadDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *HighSystemLoadDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_system_load_detection_thresholds.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/high_system_load_detection_thresholds.go
@@ -24,7 +24,7 @@ import (
 
 type HighSystemLoadDetectionThresholds struct {
 	EventThresholds *EventThresholds `json:"eventThresholds"`
-	SystemLoad      float64          `json:"systemLoad"` // Alert if the System Load / Logical cpu core is higher than this threshold for the defined amount of samples
+	SystemLoad      float64          `json:"systemLoad"` // Alert if the System Load divided by the number of logical CPU cores is higher than this threshold for the defined amount of samples.
 }
 
 func (me *HighSystemLoadDetectionThresholds) Schema() map[string]*schema.Schema {
@@ -33,14 +33,13 @@ func (me *HighSystemLoadDetectionThresholds) Schema() map[string]*schema.Schema 
 			Type:        schema.TypeList,
 			Description: "no documentation available",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(EventThresholds).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(EventThresholds).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"system_load": {
 			Type:        schema.TypeFloat,
-			Description: "Alert if the System Load / Logical cpu core is higher than this threshold for the defined amount of samples",
+			Description: "Alert if the System Load divided by the number of logical CPU cores is higher than this threshold for the defined amount of samples.",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/host.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/host.go
@@ -25,7 +25,7 @@ import (
 type Host struct {
 	ConnectionLostDetection    *ConnectionLostDetection    `json:"connectionLostDetection"`
 	HighCpuSaturationDetection *HighCpuSaturationDetection `json:"highCpuSaturationDetection"`
-	HighGcActivityDetection    *HighGcActivityDetection    `json:"highGcActivityDetection"`
+	HighGcActivityDetection    *HighGcActivityDetection    `json:"highGcActivityDetection,omitempty"`
 	HighMemoryDetection        *HighMemoryDetection        `json:"highMemoryDetection"`
 	HighSystemLoadDetection    *HighSystemLoadDetection    `json:"highSystemLoadDetection"`
 	OutOfMemoryDetection       *OutOfMemoryDetection       `json:"outOfMemoryDetection"`
@@ -53,7 +53,7 @@ func (me *Host) Schema() map[string]*schema.Schema {
 		"high_gc_activity_detection": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    true,
+			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(HighGcActivityDetection).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/network_dropped_packets_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/network_dropped_packets_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type NetworkDroppedPacketsDetection struct {
 	CustomThresholds *NetworkDroppedPacketsDetectionThresholds `json:"customThresholds,omitempty"` // Alert if the dropped packet percentage is higher than the specified threshold **and** the total packets rate is higher than the defined threshold for the defined amount of samples
-	DetectionMode    *DetectionMode                            `json:"detectionMode,omitempty"`    // Detection mode for high number of dropped packets
-	Enabled          bool                                      `json:"enabled"`                    // Detect high number of dropped packets
+	DetectionMode    *DetectionMode                            `json:"detectionMode,omitempty"`    // Detection mode for high number of dropped packets. Possible Values: `auto`, `custom`
+	Enabled          bool                                      `json:"enabled"`                    // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *NetworkDroppedPacketsDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *NetworkDroppedPacketsDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "Alert if the dropped packet percentage is higher than the specified threshold **and** the total packets rate is higher than the defined threshold for the defined amount of samples",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(NetworkDroppedPacketsDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for high number of dropped packets",
-			Optional:    true,
+			Description: "Detection mode for high number of dropped packets. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect high number of dropped packets",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *NetworkDroppedPacketsDetection) MarshalHCL(properties hcl.Properties) 
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *NetworkDroppedPacketsDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *NetworkDroppedPacketsDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/network_errors_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/network_errors_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type NetworkErrorsDetection struct {
 	CustomThresholds *NetworkErrorsDetectionThresholds `json:"customThresholds,omitempty"` // Alert if the receive/transmit error packet percentage is higher than the specified threshold **and** the total packets rate is higher than the defined threshold for the defined amount of samples
-	DetectionMode    *DetectionMode                    `json:"detectionMode,omitempty"`    // Detection mode for high number of network errors
-	Enabled          bool                              `json:"enabled"`                    // Detect high number of network errors
+	DetectionMode    *DetectionMode                    `json:"detectionMode,omitempty"`    // Detection mode for high number of network errors. Possible Values: `auto`, `custom`
+	Enabled          bool                              `json:"enabled"`                    // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *NetworkErrorsDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *NetworkErrorsDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "Alert if the receive/transmit error packet percentage is higher than the specified threshold **and** the total packets rate is higher than the defined threshold for the defined amount of samples",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(NetworkErrorsDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for high number of network errors",
-			Optional:    true,
+			Description: "Detection mode for high number of network errors. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect high number of network errors",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *NetworkErrorsDetection) MarshalHCL(properties hcl.Properties) error {
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *NetworkErrorsDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *NetworkErrorsDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/network_high_retransmission_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/network_high_retransmission_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type NetworkHighRetransmissionDetection struct {
 	CustomThresholds *NetworkHighRetransmissionDetectionThresholds `json:"customThresholds,omitempty"` // Alert if the retransmission rate is higher than the specified threshold **and** the number of retransmitted packets is higher than the defined threshold for the defined amount of samples
-	DetectionMode    *DetectionMode                                `json:"detectionMode,omitempty"`    // Detection mode for high retransmission rate
-	Enabled          bool                                          `json:"enabled"`                    // Detect high retransmission rate
+	DetectionMode    *DetectionMode                                `json:"detectionMode,omitempty"`    // Detection mode for high retransmission rate. Possible Values: `auto`, `custom`
+	Enabled          bool                                          `json:"enabled"`                    // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *NetworkHighRetransmissionDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *NetworkHighRetransmissionDetection) Schema() map[string]*schema.Schema
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "Alert if the retransmission rate is higher than the specified threshold **and** the number of retransmitted packets is higher than the defined threshold for the defined amount of samples",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(NetworkHighRetransmissionDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for high retransmission rate",
-			Optional:    true,
+			Description: "Detection mode for high retransmission rate. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect high retransmission rate",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *NetworkHighRetransmissionDetection) MarshalHCL(properties hcl.Properti
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *NetworkHighRetransmissionDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *NetworkHighRetransmissionDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/network_tcp_problems_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/network_tcp_problems_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type NetworkTcpProblemsDetection struct {
 	CustomThresholds *NetworkTcpProblemsDetectionThresholds `json:"customThresholds,omitempty"` // Alert if the percentage of new connection failures is higher than the specified threshold **and** the number of failed connections is higher than the defined threshold for the defined amount of samples
-	DetectionMode    *DetectionMode                         `json:"detectionMode,omitempty"`    // Detection mode for TCP connectivity problems
-	Enabled          bool                                   `json:"enabled"`                    // Detect TCP connectivity problems for process
+	DetectionMode    *DetectionMode                         `json:"detectionMode,omitempty"`    // Detection mode for TCP connectivity problems. Possible Values: `auto`, `custom`
+	Enabled          bool                                   `json:"enabled"`                    // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *NetworkTcpProblemsDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *NetworkTcpProblemsDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "Alert if the percentage of new connection failures is higher than the specified threshold **and** the number of failed connections is higher than the defined threshold for the defined amount of samples",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(NetworkTcpProblemsDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for TCP connectivity problems",
-			Optional:    true,
+			Description: "Detection mode for TCP connectivity problems. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect TCP connectivity problems for process",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *NetworkTcpProblemsDetection) MarshalHCL(properties hcl.Properties) err
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *NetworkTcpProblemsDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *NetworkTcpProblemsDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/out_of_memory_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/out_of_memory_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type OutOfMemoryDetection struct {
 	CustomThresholds *OutOfMemoryDetectionThresholds `json:"customThresholds,omitempty"`
-	DetectionMode    *DetectionMode                  `json:"detectionMode,omitempty"` // Detection mode for Java out of memory problem
-	Enabled          bool                            `json:"enabled"`                 // Detect Java out of memory problem
+	DetectionMode    *DetectionMode                  `json:"detectionMode,omitempty"` // Detection mode for Java out of memory problem. Possible Values: `auto`, `custom`
+	Enabled          bool                            `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *OutOfMemoryDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *OutOfMemoryDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(OutOfMemoryDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for Java out of memory problem",
-			Optional:    true,
+			Description: "Detection mode for Java out of memory problem. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect Java out of memory problem",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *OutOfMemoryDetection) MarshalHCL(properties hcl.Properties) error {
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *OutOfMemoryDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *OutOfMemoryDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/out_of_threads_detection.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/out_of_threads_detection.go
@@ -18,14 +18,16 @@
 package hosts
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type OutOfThreadsDetection struct {
 	CustomThresholds *OutOfThreadsDetectionThresholds `json:"customThresholds,omitempty"`
-	DetectionMode    *DetectionMode                   `json:"detectionMode,omitempty"` // Detection mode for Java out of threads problem
-	Enabled          bool                             `json:"enabled"`                 // Detect Java out of threads problem
+	DetectionMode    *DetectionMode                   `json:"detectionMode,omitempty"` // Detection mode for Java out of threads problem. Possible Values: `auto`, `custom`
+	Enabled          bool                             `json:"enabled"`                 // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *OutOfThreadsDetection) Schema() map[string]*schema.Schema {
@@ -33,19 +35,19 @@ func (me *OutOfThreadsDetection) Schema() map[string]*schema.Schema {
 		"custom_thresholds": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Optional:    true,
+			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(OutOfThreadsDetectionThresholds).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
 		"detection_mode": {
 			Type:        schema.TypeString,
-			Description: "Detection mode for Java out of threads problem",
-			Optional:    true,
+			Description: "Detection mode for Java out of threads problem. Possible Values: `auto`, `custom`",
+			Optional:    true, // precondition
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
-			Description: "Detect Java out of threads problem",
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
 		},
 	}
@@ -57,6 +59,22 @@ func (me *OutOfThreadsDetection) MarshalHCL(properties hcl.Properties) error {
 		"detection_mode":    me.DetectionMode,
 		"enabled":           me.Enabled,
 	})
+}
+
+func (me *OutOfThreadsDetection) HandlePreconditions() error {
+	if (me.CustomThresholds == nil) && (me.Enabled && (me.DetectionMode != nil && (string(*me.DetectionMode) == "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must be specified if 'enabled' is set to '%v' and 'detection_mode' is set to '%v'", me.Enabled, me.DetectionMode)
+	}
+	if (me.CustomThresholds != nil) && (!me.Enabled || (me.DetectionMode == nil || (me.DetectionMode != nil && string(*me.DetectionMode) != "custom"))) {
+		return fmt.Errorf("'custom_thresholds' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode == nil) && (me.Enabled) {
+		return fmt.Errorf("'detection_mode' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.DetectionMode != nil) && (!me.Enabled) {
+		return fmt.Errorf("'detection_mode' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *OutOfThreadsDetection) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/strict_event_thresholds.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/settings/strict_event_thresholds.go
@@ -24,7 +24,7 @@ import (
 
 type StrictEventThresholds struct {
 	DealertingEvaluationWindow int `json:"dealertingEvaluationWindow"` // The number of **10-second samples** that form the sliding evaluation window for dealerting.
-	DealertingSamples          int `json:"dealertingSamples"`          // The number of **10-second samples** within the evaluation window that must be lower the threshold to close an event
+	DealertingSamples          int `json:"dealertingSamples"`          // The number of **10-second samples** within the evaluation window that must be lower than the threshold to close an event
 	ViolatingEvaluationWindow  int `json:"violatingEvaluationWindow"`  // The number of **10-second samples** that form the sliding evaluation window to detect violating samples.
 	ViolatingSamples           int `json:"violatingSamples"`           // The number of **10-second samples** within the evaluation window that must exceed the threshold to trigger an event
 }
@@ -38,7 +38,7 @@ func (me *StrictEventThresholds) Schema() map[string]*schema.Schema {
 		},
 		"dealerting_samples": {
 			Type:        schema.TypeInt,
-			Description: "The number of **10-second samples** within the evaluation window that must be lower the threshold to close an event",
+			Description: "The number of **10-second samples** within the evaluation window that must be lower than the threshold to close an event",
 			Required:    true,
 		},
 		"violating_evaluation_window": {

--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/schema.json
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/schema.json
@@ -1,329 +1,330 @@
 {
-  "dynatrace": "1",
-  "schemaId": "builtin:appsec.runtime-vulnerability-detection",
-  "displayName": "Vulnerability Analytics: General settings",
-  "description": "Automated [Runtime Vulnerability Analytics](https://dt-url.net/c010iio) helps you quickly and completely understand each detected vulnerability in your environment and how to remediate it, allowing you to prioritize which vulnerabilities to fix first. Note: Enabling Third-party or Code-level Vulnerability Analytics consumes Application Security units. For details, see the [Application Security Monitoring documentation](https://dt-url.net/wq031ql).",
-  "documentation": "",
-  "schemaGroups": [
-    "group:appsec.vulnerability-analytics",
-    "group:appsec"
-  ],
-  "version": "3.12",
-  "multiObject": false,
-  "maxObjects": 1,
-  "allowedScopes": [
-    "environment"
-  ],
-  "enums": {
-    "MonitoringModeTPV": {
-      "displayName": "MonitoringModeTPV",
-      "description": "",
-      "documentation": "",
-      "items": [
-        {
-          "value": "MONITORING_OFF",
-          "displayName": "Do not monitor",
-          "description": "Third-party vulnerabilities will not be monitored"
-        },
-        {
-          "value": "MONITORING_ON",
-          "displayName": "Monitor",
-          "description": "Third-party vulnerabilities will be monitored"
-        }
-      ],
-      "type": "enum"
-    },
-    "MonitoringMode": {
-      "displayName": "MonitoringMode",
-      "description": "",
-      "documentation": "",
-      "items": [
-        {
-          "value": "MONITORING_OFF",
-          "displayName": "Do not monitor",
-          "description": "Code-level vulnerabilities will be ignored "
-        },
-        {
-          "value": "MONITORING_ON",
-          "displayName": "Monitor",
-          "description": "Code-level vulnerabilities will be recorded"
-        }
-      ],
-      "type": "enum"
-    }
-  },
-  "types": {
-    "Technology": {
-      "version": "0",
-      "versionInfo": "",
-      "displayName": "Technology",
-      "summaryPattern": "",
-      "description": "",
-      "documentation": "",
-      "properties": {
-        "enableDotNet": {
-          "displayName": ".NET",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enableDotNetRuntime": {
-          "displayName": ".NET runtimes",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "precondition": {
-            "type": "EQUALS",
-            "property": "enableDotNet",
-            "expectedValue": true
-          },
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enableGo": {
-          "displayName": "Go",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enableJava": {
-          "displayName": "Java",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enableJavaRuntime": {
-          "displayName": "Java runtimes",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "precondition": {
-            "type": "EQUALS",
-            "property": "enableJava",
-            "expectedValue": true
-          },
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enableKubernetes": {
-          "displayName": "Kubernetes",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enableNodeJs": {
-          "displayName": "Node.js",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enableNodeJsRuntime": {
-          "displayName": "Node.js runtimes",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "precondition": {
-            "type": "EQUALS",
-            "property": "enableNodeJs",
-            "expectedValue": true
-          },
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enablePython": {
-          "displayName": "Python",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enablePythonRuntime": {
-          "displayName": "Python runtimes",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "precondition": {
-            "type": "EQUALS",
-            "property": "enablePython",
-            "expectedValue": true
-          },
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        },
-        "enablePhp": {
-          "displayName": "PHP",
-          "description": "",
-          "documentation": "",
-          "type": "boolean",
-          "nullable": false,
-          "maxObjects": 1,
-          "modificationPolicy": "DEFAULT",
-          "default": true
-        }
-      },
-      "type": "object"
-    }
-  },
-  "properties": {
-    "enableRuntimeVulnerabilityDetection": {
-      "displayName": "Enable Third-party Vulnerability Analytics",
-      "description": "",
-      "documentation": "",
-      "type": "boolean",
-      "nullable": false,
-      "maxObjects": 1,
-      "modificationPolicy": "DEFAULT",
-      "default": false
-    },
-    "enableResourceAttributeRules": {
-      "displayName": "Enable new monitoring rules",
-      "description": "When new monitoring rules are enabled, classic rules are disabled. To re-enable classic rules, disable the new monitoring rules.",
-      "documentation": "",
-      "type": "boolean",
-      "nullable": true,
-      "metadata": {
-        "featureFlag": "com.compuware.EnableCaspResourceAttributesSettingsToggle.feature",
-        "maturity": "GENERAL_AVAILABILITY"
-      },
-      "maxObjects": 1,
-      "modificationPolicy": "DEFAULT"
-    },
-    "globalMonitoringModeTPV": {
-      "displayName": "Global third-party vulnerability detection control",
-      "description": "Global third-party vulnerability detection control defines the default for all processes.",
-      "documentation": "",
-      "type": {
-        "$ref": "#/enums/MonitoringModeTPV"
-      },
-      "nullable": false,
-      "metadata": {
-        "sortItems": "disabled"
-      },
-      "maxObjects": 1,
-      "modificationPolicy": "DEFAULT",
-      "default": "MONITORING_ON"
-    },
-    "technologies": {
-      "displayName": "Technologies",
-      "description": "Vulnerability Analytics can be enabled/disabled per supported technology.",
-      "documentation": "",
-      "type": {
-        "$ref": "#/types/Technology"
-      },
-      "nullable": false,
-      "maxObjects": 1,
-      "modificationPolicy": "DEFAULT"
-    },
-    "enableCodeLevelVulnerabilityDetection": {
-      "displayName": "Enable Code-level Vulnerability Analytics",
-      "description": "",
-      "documentation": "",
-      "type": "boolean",
-      "nullable": false,
-      "maxObjects": 1,
-      "modificationPolicy": "DEFAULT",
-      "default": false
-    },
-    "globalMonitoringModeJava": {
-      "displayName": "Global Java code-level vulnerability detection control",
-      "description": "Global Java code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
-      "documentation": "Code-level vulnerability detection for Java has been recently released as early access version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \"Java code-level vulnerability evaluation\" to get started.",
-      "type": {
-        "$ref": "#/enums/MonitoringMode"
-      },
-      "nullable": false,
-      "metadata": {
-        "sortItems": "disabled"
-      },
-      "maxObjects": 1,
-      "modificationPolicy": "DEFAULT",
-      "default": "MONITORING_ON"
-    },
-    "globalMonitoringModeDotNet": {
-      "displayName": "Global .NET code-level vulnerability detection control",
-      "description": "Global .NET code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
-      "documentation": "Code-level vulnerability detection for .NET has been recently released as a preview version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \".NET code-level vulnerability evaluation\" to get started.",
-      "type": {
-        "$ref": "#/enums/MonitoringMode"
-      },
-      "nullable": false,
-      "metadata": {
-        "sortItems": "disabled"
-      },
-      "maxObjects": 1,
-      "modificationPolicy": "DEFAULT",
-      "default": "MONITORING_OFF"
-    },
-    "globalMonitoringModeGo": {
-      "displayName": "Global Go code-level vulnerability detection control",
-      "description": "Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
-      "documentation": "Code-level vulnerability detection for Go has been recently released as a preview version. It has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \"Go code-level vulnerability evaluation\" to get started.",
-      "type": {
-        "$ref": "#/enums/MonitoringMode"
-      },
-      "nullable": false,
-      "metadata": {
-        "sortItems": "disabled"
-      },
-      "maxObjects": 1,
-      "modificationPolicy": "DEFAULT",
-      "default": "MONITORING_OFF"
-    }
-  },
-  "uiCustomization": {
-    "tabs": {
-      "groups": [
-        {
-          "displayName": "Third-party Vulnerability Analytics",
-          "properties": [
-            "enableRuntimeVulnerabilityDetection",
-            "enableResourceAttributeRules",
-            "globalMonitoringModeTPV",
-            "technologies"
-          ]
-        },
-        {
-          "displayName": "Code-level Vulnerability Analytics",
-          "properties": [
-            "enableCodeLevelVulnerabilityDetection",
-            "globalMonitoringModeJava",
-            "globalMonitoringModeDotNet",
-            "globalMonitoringModeGo",
-            "globalMonitoringModeNodeJs"
-          ]
-        }
-      ]
-    }
-  }
+	"allowedScopes": [
+		"environment"
+	],
+	"description": "Automated [Runtime Vulnerability Analytics](https://dt-url.net/c010iio) helps you quickly and completely understand each detected vulnerability in your environment and how to remediate it, allowing you to prioritize which vulnerabilities to fix first. Note: Enabling Third-party or Code-level Vulnerability Analytics consumes Application Security units. For details, see the [Application Security Monitoring documentation](https://dt-url.net/wq031ql).",
+	"displayName": "Vulnerability Analytics: General settings",
+	"documentation": "",
+	"dynatrace": "1",
+	"enums": {
+		"MonitoringMode": {
+			"description": "",
+			"displayName": "MonitoringMode",
+			"documentation": "",
+			"items": [
+				{
+					"description": "Code-level vulnerabilities will be ignored ",
+					"displayName": "Do not monitor",
+					"value": "MONITORING_OFF"
+				},
+				{
+					"description": "Code-level vulnerabilities will be recorded",
+					"displayName": "Monitor",
+					"value": "MONITORING_ON"
+				}
+			],
+			"type": "enum"
+		},
+		"MonitoringModeTPV": {
+			"description": "",
+			"displayName": "MonitoringModeTPV",
+			"documentation": "",
+			"items": [
+				{
+					"description": "Third-party vulnerabilities will not be monitored",
+					"displayName": "Do not monitor",
+					"value": "MONITORING_OFF"
+				},
+				{
+					"description": "Third-party vulnerabilities will be monitored",
+					"displayName": "Monitor",
+					"value": "MONITORING_ON"
+				}
+			],
+			"type": "enum"
+		}
+	},
+	"maturity": "GENERAL_AVAILABILITY",
+	"maxObjects": 1,
+	"multiObject": false,
+	"properties": {
+		"enableCodeLevelVulnerabilityDetection": {
+			"default": false,
+			"description": "",
+			"displayName": "Enable Code-level Vulnerability Analytics",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "boolean"
+		},
+		"enableResourceAttributeRules": {
+			"description": "When new monitoring rules are enabled, classic rules are disabled. To re-enable classic rules, disable the new monitoring rules.",
+			"displayName": "Enable new monitoring rules",
+			"documentation": "",
+			"maxObjects": 1,
+			"metadata": {
+				"featureFlag": "com.compuware.EnableCaspResourceAttributesSettingsToggle.feature",
+				"maturity": "GENERAL_AVAILABILITY"
+			},
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": "boolean"
+		},
+		"enableRuntimeVulnerabilityDetection": {
+			"default": false,
+			"description": "",
+			"displayName": "Enable Third-party Vulnerability Analytics",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "boolean"
+		},
+		"globalMonitoringModeDotNet": {
+			"default": "MONITORING_OFF",
+			"description": "Global .NET code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
+			"displayName": "Global .NET code-level vulnerability detection control",
+			"documentation": "Code-level vulnerability detection for .NET has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \".NET code-level vulnerability evaluation\" to get started.",
+			"maxObjects": 1,
+			"metadata": {
+				"sortItems": "disabled"
+			},
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/MonitoringMode"
+			}
+		},
+		"globalMonitoringModeGo": {
+			"default": "MONITORING_OFF",
+			"description": "Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
+			"displayName": "Global Go code-level vulnerability detection control",
+			"documentation": "Code-level vulnerability detection for Go has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \"Go code-level vulnerability evaluation\" to get started.",
+			"maxObjects": 1,
+			"metadata": {
+				"sortItems": "disabled"
+			},
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/MonitoringMode"
+			}
+		},
+		"globalMonitoringModeJava": {
+			"default": "MONITORING_ON",
+			"description": "Global Java code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
+			"displayName": "Global Java code-level vulnerability detection control",
+			"documentation": "Code-level vulnerability detection for Java has been designed to carry a production-ready performance footprint. The overhead is depending on your application, but should be negligible in most cases. You have to enable the OneAgent feature \"Java code-level vulnerability evaluation\" to get started.",
+			"maxObjects": 1,
+			"metadata": {
+				"sortItems": "disabled"
+			},
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/MonitoringMode"
+			}
+		},
+		"globalMonitoringModeTPV": {
+			"default": "MONITORING_ON",
+			"description": "Global third-party vulnerability detection control defines the default for all processes.",
+			"displayName": "Global third-party vulnerability detection control",
+			"documentation": "",
+			"maxObjects": 1,
+			"metadata": {
+				"sortItems": "disabled"
+			},
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/MonitoringModeTPV"
+			}
+		},
+		"technologies": {
+			"description": "Vulnerability Analytics can be enabled/disabled per supported technology.",
+			"displayName": "Technologies",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/types/Technology"
+			}
+		}
+	},
+	"schemaGroups": [
+		"group:appsec.vulnerability-analytics",
+		"group:appsec"
+	],
+	"schemaId": "builtin:appsec.runtime-vulnerability-detection",
+	"types": {
+		"Technology": {
+			"description": "",
+			"displayName": "Technology",
+			"documentation": "",
+			"properties": {
+				"enableDotNet": {
+					"default": true,
+					"description": "",
+					"displayName": ".NET",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"enableDotNetRuntime": {
+					"default": true,
+					"description": "",
+					"displayName": ".NET runtimes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "enableDotNet",
+						"type": "EQUALS"
+					},
+					"type": "boolean"
+				},
+				"enableGo": {
+					"default": true,
+					"description": "",
+					"displayName": "Go",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"enableJava": {
+					"default": true,
+					"description": "",
+					"displayName": "Java",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"enableJavaRuntime": {
+					"default": true,
+					"description": "",
+					"displayName": "Java runtimes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "enableJava",
+						"type": "EQUALS"
+					},
+					"type": "boolean"
+				},
+				"enableKubernetes": {
+					"default": true,
+					"description": "",
+					"displayName": "Kubernetes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"enableNodeJs": {
+					"default": true,
+					"description": "",
+					"displayName": "Node.js",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"enableNodeJsRuntime": {
+					"default": true,
+					"description": "",
+					"displayName": "Node.js runtimes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "enableNodeJs",
+						"type": "EQUALS"
+					},
+					"type": "boolean"
+				},
+				"enablePhp": {
+					"default": true,
+					"description": "",
+					"displayName": "PHP",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"enablePython": {
+					"default": true,
+					"description": "",
+					"displayName": "Python",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"enablePythonRuntime": {
+					"default": true,
+					"description": "",
+					"displayName": "Python runtimes",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": true,
+						"property": "enablePython",
+						"type": "EQUALS"
+					},
+					"type": "boolean"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		}
+	},
+	"uiCustomization": {
+		"tabs": {
+			"groups": [
+				{
+					"displayName": "Third-party Vulnerability Analytics",
+					"properties": [
+						"enableRuntimeVulnerabilityDetection",
+						"enableResourceAttributeRules",
+						"globalMonitoringModeTPV",
+						"technologies"
+					]
+				},
+				{
+					"displayName": "Code-level Vulnerability Analytics",
+					"properties": [
+						"enableCodeLevelVulnerabilityDetection",
+						"globalMonitoringModeJava",
+						"globalMonitoringModeDotNet",
+						"globalMonitoringModeGo",
+						"globalMonitoringModeNodeJs"
+					]
+				}
+			]
+		}
+	},
+	"version": "3.12.1"
 }

--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/service.go
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/service.go
@@ -18,15 +18,15 @@
 package runtimevulnerabilitydetection
 
 import (
-	runtimevulnerabilitydetection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "3.12"
+const SchemaVersion = "3.12.1"
 const SchemaID = "builtin:appsec.runtime-vulnerability-detection"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*runtimevulnerabilitydetection.Settings] {
-	return settings20.Service[*runtimevulnerabilitydetection.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings/enums.go
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings/enums.go
@@ -26,3 +26,13 @@ var MonitoringModes = struct {
 	"MONITORING_OFF",
 	"MONITORING_ON",
 }
+
+type MonitoringModeTpv string
+
+var MonitoringModeTpvs = struct {
+	MonitoringOff MonitoringModeTpv
+	MonitoringOn  MonitoringModeTpv
+}{
+	"MONITORING_OFF",
+	"MONITORING_ON",
+}

--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings/settings.go
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings/settings.go
@@ -23,14 +23,14 @@ import (
 )
 
 type Settings struct {
-	EnableCodeLevelVulnerabilityDetection bool            `json:"enableCodeLevelVulnerabilityDetection"`  // Enable Code-level Vulnerability Analytics
-	EnableResourceAttributeRules          *bool           `json:"enableResourceAttributeRules,omitempty"` // When new monitoring rules are enabled, classic rules are disabled. To re-enable classic rules, disable the new monitoring rules.
-	EnableRuntimeVulnerabilityDetection   bool            `json:"enableRuntimeVulnerabilityDetection"`    // Enable Third-party Vulnerability Analytics
-	GlobalMonitoringModeDotNet            MonitoringMode  `json:"globalMonitoringModeDotNet"`             // (v1.290) Global .NET code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes. Possible Values: `MONITORING_OFF`, `MONITORING_ON`
-	GlobalMonitoringModeGo                *MonitoringMode `json:"globalMonitoringModeGo,omitempty"`       // Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.
-	GlobalMonitoringModeJava              MonitoringMode  `json:"globalMonitoringModeJava"`               // Global Java code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes. Possible Values: `MONITORING_OFF`, `MONITORING_ON`
-	GlobalMonitoringModeTPV               MonitoringMode  `json:"globalMonitoringModeTPV"`                // Global third-party vulnerability detection control defines the default for all processes. Possible Values: `MONITORING_OFF`, `MONITORING_ON`
-	Technologies                          *Technology     `json:"technologies"`                           // Vulnerability Analytics can be enabled/disabled per supported technology.
+	EnableCodeLevelVulnerabilityDetection bool              `json:"enableCodeLevelVulnerabilityDetection"`  // Enable Code-level Vulnerability Analytics
+	EnableResourceAttributeRules          *bool             `json:"enableResourceAttributeRules,omitempty"` // When new monitoring rules are enabled, classic rules are disabled. To re-enable classic rules, disable the new monitoring rules.
+	EnableRuntimeVulnerabilityDetection   bool              `json:"enableRuntimeVulnerabilityDetection"`    // Enable Third-party Vulnerability Analytics
+	GlobalMonitoringModeDotNet            MonitoringMode    `json:"globalMonitoringModeDotNet"`             // Global .NET code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.. Possible Values: `MONITORING_OFF`, `MONITORING_ON`
+	GlobalMonitoringModeGo                MonitoringMode    `json:"globalMonitoringModeGo"`                 // Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.. Possible Values: `MONITORING_OFF`, `MONITORING_ON`
+	GlobalMonitoringModeJava              MonitoringMode    `json:"globalMonitoringModeJava"`               // Global Java code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.. Possible Values: `MONITORING_OFF`, `MONITORING_ON`
+	GlobalMonitoringModeTPV               MonitoringModeTpv `json:"globalMonitoringModeTPV"`                // Global third-party vulnerability detection control defines the default for all processes.. Possible Values: `MONITORING_OFF`, `MONITORING_ON`
+	Technologies                          *Technology       `json:"technologies"`                           // Vulnerability Analytics can be enabled/disabled per supported technology.
 }
 
 func (me *Settings) Name() string {
@@ -56,24 +56,24 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"global_monitoring_mode_dot_net": {
 			Type:        schema.TypeString,
-			Description: "(v1.290) Global .NET code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes. Possible Values: `MONITORING_OFF`, `MONITORING_ON`",
+			Description: "Global .NET code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.. Possible Values: `MONITORING_OFF`, `MONITORING_ON`",
 			Optional:    true, // nullable
 			Default:     "MONITORING_OFF",
 		},
 		"global_monitoring_mode_go": {
 			Type:        schema.TypeString,
-			Description: "Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.",
+			Description: "Global Go code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.. Possible Values: `MONITORING_OFF`, `MONITORING_ON`",
 			Optional:    true, // nullable
 			Default:     "MONITORING_OFF",
 		},
 		"global_monitoring_mode_java": {
 			Type:        schema.TypeString,
-			Description: "Global Java code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes. Possible Values: `MONITORING_OFF`, `MONITORING_ON`",
+			Description: "Global Java code-level vulnerability detection control defines the default for all process groups. You can use monitoring rules to override the default for certain processes.. Possible Values: `MONITORING_OFF`, `MONITORING_ON`",
 			Required:    true,
 		},
 		"global_monitoring_mode_tpv": {
 			Type:        schema.TypeString,
-			Description: "Global third-party vulnerability detection control defines the default for all processes. Possible Values: `MONITORING_OFF`, `MONITORING_ON`",
+			Description: "Global third-party vulnerability detection control defines the default for all processes.. Possible Values: `MONITORING_OFF`, `MONITORING_ON`",
 			Optional:    true,
 			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 				// global_monitoring_mode_tpv was introduced in v289 as a required field, added code below to have successful results for old/new tenants.

--- a/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/schema.json
+++ b/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/schema.json
@@ -7,6 +7,7 @@
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -55,7 +56,7 @@
 								"type": "LENGTH"
 							},
 							{
-								"customValidatorId": "functionproxy.functionproxy.svc.cluster.local/internal/settings-validation/v0.1/validate-property/allowed-hostname",
+								"customValidatorId": "functionproxy.functionproxy.svc.cluster.local:8080/internal/settings-validation/v0.1/validate-property/allowed-hostname",
 								"skipAsyncValidation": false,
 								"type": "CUSTOM_VALIDATOR_REF"
 							}
@@ -83,5 +84,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.0.3"
+	"version": "1.0.4"
 }

--- a/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/service.go
+++ b/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/service.go
@@ -18,15 +18,15 @@
 package allowedoutboundconnections
 
 import (
-	allowedoutboundconnections "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.3"
+const SchemaVersion = "1.0.4"
 const SchemaID = "builtin:dt-javascript-runtime.allowed-outbound-connections"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*allowedoutboundconnections.Settings] {
-	return settings20.Service[*allowedoutboundconnections.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/settings/allowed_hosts_list.go
+++ b/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/settings/allowed_hosts_list.go
@@ -22,22 +22,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// AllowedHostsList. Specifies allowed hosts and if the allow list should be enforced.
+// AllowedHostsList. Specifies allowed hosts and if the allowlist should be enforced.
 type AllowedHostsList struct {
-	Enforced bool     `json:"enforced"`           // If enabled, the Dynatrace JavaScript runtime will only be able to connect to the specified hosts.
-	HostList []string `json:"hostList,omitempty"` // The Dynatrace JavaScript runtime will only be to connect to these hosts.
+	Enforced bool     `json:"enforced"`           // If enabled, the Dynatrace JavaScript Runtime will only be able to connect to the specified hosts.
+	HostList []string `json:"hostList,omitempty"` // A host that app backends should be able to connect to.
 }
 
 func (me *AllowedHostsList) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"enforced": {
 			Type:        schema.TypeBool,
-			Description: "If enabled, the Dynatrace JavaScript runtime will only be able to connect to the specified hosts.",
+			Description: "If enabled, the Dynatrace JavaScript Runtime will only be able to connect to the specified hosts.",
 			Required:    true,
 		},
 		"host_list": {
 			Type:        schema.TypeSet,
-			Description: "The Dynatrace JavaScript runtime will only be to connect to these hosts.",
+			Description: "A host that app backends should be able to connect to.",
 			Optional:    true, // precondition & minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},

--- a/dynatrace/api/builtin/endpointdetectionrules/schema.json
+++ b/dynatrace/api/builtin/endpointdetectionrules/schema.json
@@ -27,6 +27,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1000,
 	"metadata": {
 		"addItemButton": "Add rule",
@@ -216,5 +217,5 @@
 			]
 		}
 	},
-	"version": "1.0.1"
+	"version": "1.0.2"
 }

--- a/dynatrace/api/builtin/endpointdetectionrules/service.go
+++ b/dynatrace/api/builtin/endpointdetectionrules/service.go
@@ -15,18 +15,18 @@
 * limitations under the License.
  */
 
-package ednpointdetectionrules
+package endpointdetectionrules
 
 import (
-	ednpointdetectionrules "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/endpointdetectionrules/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/endpointdetectionrules/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.1"
+const SchemaVersion = "1.0.2"
 const SchemaID = "builtin:endpoint-detection-rules"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*ednpointdetectionrules.Settings] {
-	return settings20.Service[*ednpointdetectionrules.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/endpointdetectionrules/service_test.go
+++ b/dynatrace/api/builtin/endpointdetectionrules/service_test.go
@@ -17,7 +17,7 @@
 * limitations under the License.
  */
 
-package ednpointdetectionrules_test
+package endpointdetectionrules_test
 
 import (
 	"testing"

--- a/dynatrace/api/builtin/endpointdetectionrules/settings/rule.go
+++ b/dynatrace/api/builtin/endpointdetectionrules/settings/rule.go
@@ -28,7 +28,7 @@ type Rule struct {
 	Condition            *string         `json:"condition,omitempty"` // Limits the scope of the endpoint detection rule using [DQL matcher](https://dt-url.net/l603wby) conditions on span and resource attributes.. A rule is applied only if the condition matches, otherwise the ruleset evaluation continues.\n\nIf empty, the condition will always match.
 	Description          *string         `json:"description,omitempty"`
 	EndpointNameTemplate *string         `json:"endpointNameTemplate,omitempty"` // Specify attribute placeholders in curly braces, e.g. {http.route} or {rpc.method}.. Attribute value placeholders should be specified in curly braces, e.g. {http.route}, {rpc.method}. All attributes used in the placeholder are required for the rule to apply. If any of them is missing, the rule will not be applied and ruleset evaluation continues.\n\nIf the resolved endpoint name on a given span is empty, the request will be ignored.
-	IfConditionMatches   ActionToPerform `json:"ifConditionMatches"`             // Possible Values: `DETECT_REQUEST_ON_ENDPOINT`, `SUPPRESS_REQUEST`
+	IfConditionMatches   ActionToPerform `json:"ifConditionMatches"`             // If condition matches. Possible Values: `DETECT_REQUEST_ON_ENDPOINT`, `SUPPRESS_REQUEST`
 	RuleName             string          `json:"ruleName"`                       // Rule name
 }
 
@@ -51,7 +51,7 @@ func (me *Rule) Schema() map[string]*schema.Schema {
 		},
 		"if_condition_matches": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `DETECT_REQUEST_ON_ENDPOINT`, `SUPPRESS_REQUEST`",
+			Description: "If condition matches. Possible Values: `DETECT_REQUEST_ON_ENDPOINT`, `SUPPRESS_REQUEST`",
 			Required:    true,
 		},
 		"rule_name": {
@@ -75,6 +75,9 @@ func (me *Rule) MarshalHCL(properties hcl.Properties) error {
 func (me *Rule) HandlePreconditions() error {
 	if (me.EndpointNameTemplate == nil) && (string(me.IfConditionMatches) == "DETECT_REQUEST_ON_ENDPOINT") {
 		return fmt.Errorf("'endpoint_name_template' must be specified if 'if_condition_matches' is set to '%v'", me.IfConditionMatches)
+	}
+	if (me.EndpointNameTemplate != nil) && (string(me.IfConditionMatches) != "DETECT_REQUEST_ON_ENDPOINT") {
+		return fmt.Errorf("'endpoint_name_template' must not be specified if 'if_condition_matches' is set to '%v'", me.IfConditionMatches)
 	}
 	return nil
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/schema.json
@@ -79,8 +79,8 @@
 			"type": "enum"
 		}
 	},
-	"maturity": "EARLY_ADOPTER",
-	"maxObjects": 500,
+	"maturity": "GENERAL_AVAILABILITY",
+	"maxObjects": 3000,
 	"metadata": {
 		"$ref": "#/types/Metadata"
 	},
@@ -276,5 +276,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "0.0.21"
+	"version": "0.0.23"
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/service.go
@@ -24,8 +24,8 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
+const SchemaVersion = "0.0.23"
 const SchemaID = "builtin:hyperscaler-authentication.connections.aws"
-const SchemaVersion = "0.0.21"
 
 // An update should only happen when the role ARN is added. Otherwise, all attributes and subresources
 // are flagged as "forceNew", meaning instead of an update, the resource is destroyed and created from scratch

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/schema.json
@@ -79,8 +79,8 @@
 			"type": "enum"
 		}
 	},
-	"maturity": "EARLY_ADOPTER",
-	"maxObjects": 500,
+	"maturity": "GENERAL_AVAILABILITY",
+	"maxObjects": 3000,
 	"metadata": {
 		"$ref": "#/types/Metadata"
 	},
@@ -337,5 +337,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "0.0.11"
+	"version": "0.0.13"
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/service.go
@@ -31,7 +31,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.0.11"
+const SchemaVersion = "0.0.13"
 const SchemaID = "builtin:hyperscaler-authentication.connections.azure"
 const DefaultTimeout = 2 * time.Minute
 

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/schema.json
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/schema.json
@@ -461,11 +461,6 @@
 					"displayName": "Entry boundary",
 					"id": "entryBoundary",
 					"propertyRef": "entry-boundary/pattern"
-				},
-				{
-					"displayName": "JSON Configuration",
-					"id": "jsonConf",
-					"propertyRef": "json-configuration/formatDetection"
 				}
 			],
 			"emptyState": {
@@ -473,5 +468,5 @@
 			}
 		}
 	},
-	"version": "1.0.18"
+	"version": "1.0.19"
 }

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/service.go
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/service.go
@@ -18,15 +18,15 @@
 package timestampconfiguration
 
 import (
-	timestampconfiguration "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/logmonitoring/timestampconfiguration/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.18"
+const SchemaVersion = "1.0.19"
 const SchemaID = "builtin:logmonitoring.timestamp-configuration"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*timestampconfiguration.Settings] {
-	return settings20.Service[*timestampconfiguration.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/schema.json
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/schema.json
@@ -104,7 +104,8 @@
 			"type": "enum"
 		}
 	},
-	"maxObjects": 100,
+	"maturity": "GENERAL_AVAILABILITY",
+	"maxObjects": 500,
 	"metadata": {
 		"addItemButton": "Add relationship definition",
 		"itemDisplayName": "New relationship"
@@ -505,5 +506,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.1"
+	"version": "1.2"
 }

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/service.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/service.go
@@ -28,7 +28,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.1"
+const SchemaVersion = "1.2"
 const SchemaID = "builtin:monitoredentities.generic.relation"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*relation.Settings] {

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/settings/enums.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/settings/enums.go
@@ -44,9 +44,9 @@ var Normalizations = struct {
 	Tolowercase   Normalization
 	Touppercase   Normalization
 }{
-	"Leavetextas_is",
-	"Tolowercase",
-	"Touppercase",
+	"Leave text as-is",
+	"To lower case",
+	"To upper case",
 }
 
 type RelationType string

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/settings/mapping_rule.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/settings/mapping_rule.go
@@ -46,9 +46,9 @@ func (me *MappingRules) UnmarshalHCL(decoder hcl.Decoder) error {
 
 type MappingRule struct {
 	DestinationProperty       string        `json:"destinationProperty"`       // The case-sensitive name of a property of the destination type.
-	DestinationTransformation Normalization `json:"destinationTransformation"` // Possible Values: `Leavetextas_is`, `Tolowercase`, `Touppercase`
+	DestinationTransformation Normalization `json:"destinationTransformation"` // Normalize text or leave it as-is?. Possible Values: `Leave text as-is`, `To lower case`, `To upper case`
 	SourceProperty            string        `json:"sourceProperty"`            // The case-sensitive name of a property of the source type.
-	SourceTransformation      Normalization `json:"sourceTransformation"`      // Possible Values: `Leavetextas_is`, `Tolowercase`, `Touppercase`
+	SourceTransformation      Normalization `json:"sourceTransformation"`      // Normalize text or leave it as-is?. Possible Values: `Leave text as-is`, `To lower case`, `To upper case`
 }
 
 func (me *MappingRule) Schema() map[string]*schema.Schema {
@@ -60,7 +60,7 @@ func (me *MappingRule) Schema() map[string]*schema.Schema {
 		},
 		"destination_transformation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Leavetextas_is`, `Tolowercase`, `Touppercase`",
+			Description: "Normalize text or leave it as-is?. Possible Values: `Leave text as-is`, `To lower case`, `To upper case`",
 			Required:    true,
 		},
 		"source_property": {
@@ -70,7 +70,7 @@ func (me *MappingRule) Schema() map[string]*schema.Schema {
 		},
 		"source_transformation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `Leavetextas_is`, `Tolowercase`, `Touppercase`",
+			Description: "Normalize text or leave it as-is?. Possible Values: `Leave text as-is`, `To lower case`, `To upper case`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/settings/settings.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/settings/settings.go
@@ -32,7 +32,7 @@ type Settings struct {
 	Sources        SourceFilters `json:"sources"`            // Specify all sources which should be evaluated for this relationship rule. The relationship is only created when any of the filters match.
 	ToRole         *string       `json:"toRole,omitempty"`   // Specify a role for the destination entity. If both source and destination type are the same, referring different roles will allow identification of a relationships direction. If role is left blank, any role of the destination type is considered for the relationship.
 	ToType         string        `json:"toType"`             // Define an entity type as the destination of the relationship. You can choose the same type as the source type. In this case you also may assign different roles for source and destination for having directed relationships.
-	TypeOfRelation RelationType  `json:"typeOfRelation"`     // Possible Values: `CALLS`, `CHILD_OF`, `INSTANCE_OF`, `PART_OF`, `RUNS_ON`, `SAME_AS`
+	TypeOfRelation RelationType  `json:"typeOfRelation"`     // Type of the relationship between the Source Type and the Destination Type. Possible Values: `CALLS`, `CHILD_OF`, `INSTANCE_OF`, `PART_OF`, `RUNS_ON`, `SAME_AS`
 }
 
 func (me *Settings) Name() string {
@@ -54,7 +54,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"from_role": {
 			Type:        schema.TypeString,
 			Description: "Specify a role for the source entity. If both source and destination type are the same, referring different roles will allow identification of a relationships direction. If role is left blank, any role of the source type is considered for the relationship.",
-			Optional:    true,
+			Optional:    true, // nullable
 		},
 		"from_type": {
 			Type:        schema.TypeString,
@@ -65,15 +65,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "Specify all sources which should be evaluated for this relationship rule. The relationship is only created when any of the filters match.",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(SourceFilters).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(SourceFilters).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"to_role": {
 			Type:        schema.TypeString,
 			Description: "Specify a role for the destination entity. If both source and destination type are the same, referring different roles will allow identification of a relationships direction. If role is left blank, any role of the destination type is considered for the relationship.",
-			Optional:    true,
+			Optional:    true, // nullable
 		},
 		"to_type": {
 			Type:        schema.TypeString,
@@ -82,7 +81,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"type_of_relation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `CALLS`, `CHILD_OF`, `INSTANCE_OF`, `PART_OF`, `RUNS_ON`, `SAME_AS`",
+			Description: "Type of the relationship between the Source Type and the Destination Type. Possible Values: `CALLS`, `CHILD_OF`, `INSTANCE_OF`, `PART_OF`, `RUNS_ON`, `SAME_AS`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/settings/source_filter.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/settings/source_filter.go
@@ -18,6 +18,9 @@
 package relation
 
 import (
+	"fmt"
+	"slices"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -48,7 +51,7 @@ func (me *SourceFilters) UnmarshalHCL(decoder hcl.Decoder) error {
 type SourceFilter struct {
 	Condition    *string          `json:"condition,omitempty"`    // Specify a filter that needs to match in order for the extraction to happen.. Two different filters are supported: `$eq(value)` will ensure that the source matches exactly 'value', while `$prefix(value)` will ensure that the source begins with exactly 'value'.\nIf your value contains the characters '(', ')' or '\\~', you need to escape them by adding a '\\~' in front of them.
 	MappingRules MappingRules     `json:"mappingRules,omitempty"` // Specify all properties which should be compared. If all mapping rules match a relationship between entities will be created.
-	SourceType   IngestDataSource `json:"sourceType"`             // Possible Values: `BusinessEvents`, `Entities`, `Events`, `Logs`, `Metrics`, `Spans`, `Topology`
+	SourceType   IngestDataSource `json:"sourceType"`             // Specify the source type of the filter to identify which data source should be evaluated.. Possible Values: `Business Events`, `Entities`, `Events`, `Logs`, `Metrics`, `Spans`, `Topology`
 }
 
 func (me *SourceFilter) Schema() map[string]*schema.Schema {
@@ -56,20 +59,19 @@ func (me *SourceFilter) Schema() map[string]*schema.Schema {
 		"condition": {
 			Type:        schema.TypeString,
 			Description: "Specify a filter that needs to match in order for the extraction to happen.. Two different filters are supported: `$eq(value)` will ensure that the source matches exactly 'value', while `$prefix(value)` will ensure that the source begins with exactly 'value'.\nIf your value contains the characters '(', ')' or '\\~', you need to escape them by adding a '\\~' in front of them.",
-			Optional:    true,
+			Optional:    true, // precondition
 		},
 		"mapping_rules": {
 			Type:        schema.TypeList,
 			Description: "Specify all properties which should be compared. If all mapping rules match a relationship between entities will be created.",
-			Optional:    true,
-
-			Elem:     &schema.Resource{Schema: new(MappingRules).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(MappingRules).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `BusinessEvents`, `Entities`, `Events`, `Logs`, `Metrics`, `Spans`, `Topology`",
+			Description: "Specify the source type of the filter to identify which data source should be evaluated.. Possible Values: `Business Events`, `Entities`, `Events`, `Logs`, `Metrics`, `Spans`, `Topology`",
 			Required:    true,
 		},
 	}
@@ -81,6 +83,17 @@ func (me *SourceFilter) MarshalHCL(properties hcl.Properties) error {
 		"mapping_rules": me.MappingRules,
 		"source_type":   me.SourceType,
 	})
+}
+
+func (me *SourceFilter) HandlePreconditions() error {
+	if (me.Condition == nil) && (!slices.Contains([]string{"Logs", "Spans", "Entities", "Topology", "Business Events"}, string(me.SourceType))) {
+		return fmt.Errorf("'condition' must be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	if (me.Condition != nil) && (slices.Contains([]string{"Logs", "Spans", "Entities", "Topology", "Business Events"}, string(me.SourceType))) {
+		return fmt.Errorf("'condition' must not be specified if 'source_type' is set to '%v'", me.SourceType)
+	}
+	// ---- MappingRules MappingRules -> {"expectedValues":["Entities"],"property":"sourceType","type":"IN"}
+	return nil
 }
 
 func (me *SourceFilter) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.bizevents.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.bizevents.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
@@ -105,7 +105,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.bizevents.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.davis.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
@@ -105,7 +105,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.davis.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.davis.problems.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.davis.problems.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
@@ -105,7 +105,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.davis.problems.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/routing/schema.json
@@ -105,7 +105,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.events.sdlc.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
@@ -105,7 +105,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.events.sdlc.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.events.security.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.events.security.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.logs.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.logs.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
@@ -105,7 +105,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.logs.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.metrics.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.metrics.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.security.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.security.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.spans.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.spans.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
@@ -105,7 +105,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.spans.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.system.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.user.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
@@ -493,7 +493,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +523,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +602,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -834,11 +837,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1240,7 +1238,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1314,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1542,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1860,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2023,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2186,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2275,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2355,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2472,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2783,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3121,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3156,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.usersessions.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
@@ -81,6 +81,22 @@
 			],
 			"type": "enum"
 		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
+				}
+			],
+			"type": "enum"
+		},
 		"Measurement": {
 			"description": "",
 			"displayName": "measurement",
@@ -201,6 +217,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +279,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +333,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +402,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +542,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +572,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +651,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -829,11 +886,6 @@
 			"properties": {
 				"defaultValue": {
 					"constraints": [
-						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
 						{
 							"maxLength": 500,
 							"minLength": 1,
@@ -1235,7 +1287,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1363,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1591,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +1909,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2072,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2235,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2324,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2404,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2521,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2832,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3109,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3144,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.usersessions.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +123,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
@@ -105,7 +105,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +182,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.43"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.43"
 const SchemaID = "builtin:openpipeline.usersessions.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/opentelemetrymetrics/schema.json
+++ b/dynatrace/api/builtin/opentelemetrymetrics/schema.json
@@ -8,6 +8,7 @@
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
@@ -201,5 +202,5 @@
 			]
 		}
 	},
-	"version": "1.5"
+	"version": "1.6"
 }

--- a/dynatrace/api/builtin/opentelemetrymetrics/service.go
+++ b/dynatrace/api/builtin/opentelemetrymetrics/service.go
@@ -33,7 +33,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.5"
+const SchemaVersion = "1.6"
 const SchemaID = "builtin:opentelemetry-metrics"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*opentelemetrymetrics.Settings] {

--- a/dynatrace/api/builtin/opentelemetrymetrics/settings/settings.go
+++ b/dynatrace/api/builtin/opentelemetrymetrics/settings/settings.go
@@ -24,11 +24,11 @@ import (
 )
 
 type Settings struct {
-	AdditionalAttributes                   AdditionalAttributeItems `json:"additionalAttributes,omitempty"`         // When enabled, the attributes defined in the list below will be added as dimensions to ingested OTLP metrics if they are present in the OpenTelemetry resource or in the instrumentation scope.\n\n**Notes:**\n\n* Modifying this setting (renaming, disabling or removing attributes) will cause the metric to change. This may have an impact on existing dashboards, events and alerts that make use of these dimensions. In this case, they will need to be updated manually.\n\n* Dynatrace does not recommend changing/removing the attributes starting with \"dt.\". Dynatrace leverages these attributes to [Enrich metrics](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/enrich-metrics).
-	AdditionalAttributesToDimensionEnabled *bool                    `json:"additionalAttributesToDimensionEnabled"` // Add the resource and scope attributes configured below as dimensions
-	MeterNameToDimensionEnabled            *bool                    `json:"meterNameToDimensionEnabled"`            // When enabled, the Meter name (also referred to as InstrumentationScope or InstrumentationLibrary in OpenTelemetry SDKs) and version will be added as dimensions (`otel.scope.name` and `otel.scope.version`) to ingested OTLP metrics.\n\n**Note:** Modifying this setting will cause the metric to change. This may have an impact on existing dashboards, events and alerts that make use of these dimensions. In this case, they will need to be updated manually.
+	AdditionalAttributes                   AdditionalAttributeItems `json:"additionalAttributes,omitempty"`         // When enabled, the attributes defined in the list below will be added as dimensions to ingested OTLP metrics if they are present in the OpenTelemetry resource or in the instrumentation scope.\n\n**Notes:**\n\n- Attributes **must** be added in their **original format**, as exported to Dynatrace by the telemetry source. For example, if the attribute is in `PascalCase`, the same case must be used when adding the attribute to the list.\n\n- Dynatrace does not recommend changing/removing the attributes starting with \"dt.\". Dynatrace leverages these attributes to [Enrich metrics](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/enrich-metrics).
+	AdditionalAttributesToDimensionEnabled *bool                    `json:"additionalAttributesToDimensionEnabled"` // Add the resource and scope attributes configured below as dimensions (Metrics Classic)
+	MeterNameToDimensionEnabled            *bool                    `json:"meterNameToDimensionEnabled"`            // When enabled, the Meter name (also referred to as InstrumentationScope or InstrumentationLibrary in OpenTelemetry SDKs) and version will be added as dimensions (`otel.scope.name` and `otel.scope.version`) to ingested OTLP metrics.
 	Scope                                  *string                  `json:"-" scope:"scope"`                        // The scope of this setting (environment-default). Omit this property if you want to cover the whole environment.
-	ToDropAttributes                       DropAttributeItems       `json:"toDropAttributes,omitempty"`             // The attributes defined in the list below will be dropped from all ingested OTLP metrics.\n\nUpon ingest, the *Allow list: resource and scope attributes* above is applied first. Then, the *Deny list: all attributes* below is applied. The deny list therefore applies to all attributes from all sources (data points, scope and resource).\n\n**Notes:**\n\n* Modifying this setting (adding, renaming, disabling or removing attributes) will cause the metric to change. This may have an impact on existing dashboards, events and alerts that make use of these dimensions. In this case, they will need to be updated manually.\n\n* Dynatrace does not recommend including attributes starting with \"dt.\" to the deny list. Dynatrace leverages these attributes to [Enrich metrics](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/enrich-metrics).
+	ToDropAttributes                       DropAttributeItems       `json:"toDropAttributes,omitempty"`             // The attributes defined in the list below will be dropped from all ingested OTLP metrics.\n\n**Notes:**\n\n- Attributes **must** be added in their **original format**, as exported to Dynatrace by the telemetry source. For example, if the attribute is in `PascalCase`, the same case must be used when adding the attribute to the list.\n\n- Wildcards are only supported in Metrics powered by Grail.\n\n- Dynatrace does not recommend including attributes starting with \"dt.\" to the deny list. Dynatrace leverages these attributes to [Enrich metrics](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/enrich-metrics).
 	Mode                                   Mode                     `json:"-"`
 }
 
@@ -44,7 +44,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"additional_attributes": {
 			Type:        schema.TypeList,
-			Description: "When enabled, the attributes defined in the list below will be added as dimensions to ingested OTLP metrics if they are present in the OpenTelemetry resource or in the instrumentation scope.\n\n**Notes:**\n\n* Modifying this setting (renaming, disabling or removing attributes) will cause the metric to change. This may have an impact on existing dashboards, events and alerts that make use of these dimensions. In this case, they will need to be updated manually.\n\n* Dynatrace does not recommend changing/removing the attributes starting with \"dt.\". Dynatrace leverages these attributes to [Enrich metrics](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/enrich-metrics).",
+			Description: "When enabled, the attributes defined in the list below will be added as dimensions to ingested OTLP metrics if they are present in the OpenTelemetry resource or in the instrumentation scope.\n\n**Notes:**\n\n- Attributes **must** be added in their **original format**, as exported to Dynatrace by the telemetry source. For example, if the attribute is in `PascalCase`, the same case must be used when adding the attribute to the list.\n\n- Dynatrace does not recommend changing/removing the attributes starting with \"dt.\". Dynatrace leverages these attributes to [Enrich metrics](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/enrich-metrics).",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Resource{Schema: new(AdditionalAttributeItems).Schema()},
 			MinItems:    1,
@@ -52,13 +52,13 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"additional_attributes_to_dimension_enabled": {
 			Type:        schema.TypeBool,
-			Description: "Add the resource and scope attributes configured below as dimensions",
+			Description: "Add the resource and scope attributes configured below as dimensions (Metrics Classic)",
 			Optional:    true,
 			Computed:    true,
 		},
 		"meter_name_to_dimension_enabled": {
 			Type:        schema.TypeBool,
-			Description: "When enabled, the Meter name (also referred to as InstrumentationScope or InstrumentationLibrary in OpenTelemetry SDKs) and version will be added as dimensions (`otel.scope.name` and `otel.scope.version`) to ingested OTLP metrics.\n\n**Note:** Modifying this setting will cause the metric to change. This may have an impact on existing dashboards, events and alerts that make use of these dimensions. In this case, they will need to be updated manually",
+			Description: "When enabled, the Meter name (also referred to as InstrumentationScope or InstrumentationLibrary in OpenTelemetry SDKs) and version will be added as dimensions (`otel.scope.name` and `otel.scope.version`) to ingested OTLP metrics.",
 			Optional:    true,
 			Computed:    true,
 		},
@@ -79,7 +79,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"to_drop_attributes": {
 			Type:        schema.TypeList,
-			Description: "The attributes defined in the list below will be dropped from all ingested OTLP metrics.\n\nUpon ingest, the *Allow list: resource and scope attributes* above is applied first. Then, the *Deny list: all attributes* below is applied. The deny list therefore applies to all attributes from all sources (data points, scope and resource).\n\n**Notes:**\n\n* Modifying this setting (adding, renaming, disabling or removing attributes) will cause the metric to change. This may have an impact on existing dashboards, events and alerts that make use of these dimensions. In this case, they will need to be updated manually.\n\n* Dynatrace does not recommend including attributes starting with \"dt.\" to the deny list. Dynatrace leverages these attributes to [Enrich metrics](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/enrich-metrics).",
+			Description: "The attributes defined in the list below will be dropped from all ingested OTLP metrics.\n\n**Notes:**\n\n- Attributes **must** be added in their **original format**, as exported to Dynatrace by the telemetry source. For example, if the attribute is in `PascalCase`, the same case must be used when adding the attribute to the list.\n\n- Wildcards are only supported in Metrics powered by Grail.\n\n- Dynatrace does not recommend including attributes starting with \"dt.\" to the deny list. Dynatrace leverages these attributes to [Enrich metrics](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/enrich-metrics).",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Resource{Schema: new(DropAttributeItems).Schema()},
 			MinItems:    1,

--- a/dynatrace/api/builtin/rum/mobile/enablement/schema.json
+++ b/dynatrace/api/builtin/rum/mobile/enablement/schema.json
@@ -28,9 +28,25 @@
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
+		"experienceAnalytics": {
+			"description": "",
+			"displayName": "User Interactions",
+			"documentation": "",
+			"maxObjects": 1,
+			"metadata": {
+				"featureFlag": "com.compuware.mrumff.experience-analytics.feature",
+				"maturity": "EARLY_ADOPTER"
+			},
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/experienceAnalytics"
+			}
+		},
 		"rum": {
 			"description": "Capture and analyze all user actions within your application. Enable [Real User Monitoring (RUM)](https://dt-url.net/1n2b0prq) to monitor and improve your application's performance, identify errors, and gain insight into your user's behavior and experience.",
 			"displayName": "Real User Monitoring",
@@ -67,12 +83,12 @@
 			"properties": {
 				"enabled": {
 					"default": false,
-					"description": "As part of the new RUM experience preview, Experience Analytics captures all interactions within your application. Check our documentation for more details: https://docs.dynatrace.com/docs/whats-new/preview-releases",
-					"displayName": "Enable Experience Analytics",
+					"description": "As part of the new RUM experience preview, User Interactions capture all interactions within your application.",
+					"displayName": "Enable User Interactions",
 					"documentation": "",
 					"maxObjects": 1,
 					"metadata": {
-						"maturity": "PREVIEW"
+						"maturity": "EARLY_ADOPTER"
 					},
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
@@ -135,10 +151,6 @@
 					"displayName": "Enable New Real User Monitoring Experience",
 					"documentation": "",
 					"maxObjects": 1,
-					"metadata": {
-						"featureFlag": "com.compuware.apm.webuiff.rum-settings-show-enable-monitoring-on-3rd-gen-switch.resemo3g.feature",
-						"maturity": "PREVIEW"
-					},
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
 					"precondition": {
@@ -211,5 +223,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "2.4.4"
+	"version": "2.6"
 }

--- a/dynatrace/api/builtin/rum/mobile/enablement/service.go
+++ b/dynatrace/api/builtin/rum/mobile/enablement/service.go
@@ -18,15 +18,15 @@
 package enablement
 
 import (
-	enablement "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/mobile/enablement/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/mobile/enablement/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "2.4.4"
+const SchemaVersion = "2.6"
 const SchemaID = "builtin:rum.mobile.enablement"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*enablement.Settings] {
-	return settings20.Service[*enablement.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/rum/mobile/enablement/settings/experience_analytics.go
+++ b/dynatrace/api/builtin/rum/mobile/enablement/settings/experience_analytics.go
@@ -1,0 +1,49 @@
+/**
+* @license
+* Copyright 2020 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package enablement
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ExperienceAnalytics struct {
+	Enabled bool `json:"enabled"` // This setting is enabled (`true`) or disabled (`false`)
+}
+
+func (me *ExperienceAnalytics) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"enabled": {
+			Type:        schema.TypeBool,
+			Description: "This setting is enabled (`true`) or disabled (`false`)",
+			Required:    true,
+		},
+	}
+}
+
+func (me *ExperienceAnalytics) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"enabled": me.Enabled,
+	})
+}
+
+func (me *ExperienceAnalytics) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"enabled": &me.Enabled,
+	})
+}

--- a/dynatrace/api/builtin/rum/mobile/enablement/settings/rum.go
+++ b/dynatrace/api/builtin/rum/mobile/enablement/settings/rum.go
@@ -26,7 +26,7 @@ import (
 type Rum struct {
 	CostAndTrafficControl int   `json:"costAndTrafficControl"`    // Percentage of user sessions captured and analyzed. By default, Dynatrace captures all user actions and user sessions for analysis. This approach ensures complete insight into your application’s performance and customer experience. You can optionally reduce the granularity of user-action and user-session analysis by capturing a lower percentage of user sessions. While this approach can reduce monitoring costs, it also results in lower visibility into how your customers are using your applications. For example, a setting of 10% results in Dynatrace analyzing only every tenth user session.
 	Enabled               bool  `json:"enabled"`                  // This setting is enabled (`true`) or disabled (`false`)
-	EnabledOnGrail        *bool `json:"enabledOnGrail,omitempty"` // Please be aware that only mobile agents with version **8.303 or higher** can ingest Grail events
+	EnabledOnGrail        *bool `json:"enabledOnGrail,omitempty"` // Please be aware that only mobile agents with version **8.309 or higher** can ingest Grail events
 }
 
 func (me *Rum) Schema() map[string]*schema.Schema {
@@ -43,7 +43,7 @@ func (me *Rum) Schema() map[string]*schema.Schema {
 		},
 		"enabled_on_grail": {
 			Type:        schema.TypeBool,
-			Description: "Please be aware that only mobile agents with version **8.303 or higher** can ingest Grail events",
+			Description: "Please be aware that only mobile agents with version **8.309 or higher** can ingest Grail events",
 			Optional:    true, // nullable & precondition
 		},
 	}

--- a/dynatrace/api/builtin/rum/mobile/enablement/settings/settings.go
+++ b/dynatrace/api/builtin/rum/mobile/enablement/settings/settings.go
@@ -27,9 +27,10 @@ func (me *Settings) Name() string {
 }
 
 type Settings struct {
-	ApplicationID *string        `json:"-" scope:"applicationId"` // The scope of this settings. If the settings should cover the whole environment, just don't specify any scope.
-	Rum           *Rum           `json:"rum"`                     // (Field has overlap with `dynatrace_mobile_application`) Capture and analyze all user actions within your application. Enable [Real User Monitoring (RUM)](https://dt-url.net/1n2b0prq) to monitor and improve your application's performance, identify errors, and gain insight into your user's behavior and experience.
-	SessionReplay *SessionReplay `json:"sessionReplay"`           // (Field has overlap with `dynatrace_mobile_application`) [Session Replay on crashes](https://dt-url.net/session-replay) gives you additional context for crash analysis in the form of video-like screen recordings that replay user actions immediately preceding a detected crash, while providing [best-in-class security and data protection](https://dt-url.net/b303zxj).
+	ApplicationID       *string              `json:"-" scope:"applicationId"`       // The scope of this settings. If the settings should cover the whole environment, just don't specify any scope.
+	ExperienceAnalytics *ExperienceAnalytics `json:"experienceAnalytics,omitempty"` // User Interactions
+	Rum                 *Rum                 `json:"rum"`                           // Capture and analyze all user actions within your application. Enable [Real User Monitoring (RUM)](https://dt-url.net/1n2b0prq) to monitor and improve your application's performance, identify errors, and gain insight into your user's behavior and experience.
+	SessionReplay       *SessionReplay       `json:"sessionReplay"`                 // [Session Replay](https://dt-url.net/session-replay) captures all user interactions within your application and replays them in a movie-like experience while providing [best-in-class security and data protection](https://dt-url.net/b303zxj).
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -41,6 +42,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Default:     "environment",
 			ForceNew:    true,
 		},
+		"experience_analytics": {
+			Type:        schema.TypeList,
+			Description: "User Interactions",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(ExperienceAnalytics).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"rum": {
 			Type:        schema.TypeList,
 			Description: "(Field has overlap with `dynatrace_mobile_application`) Capture and analyze all user actions within your application. Enable [Real User Monitoring (RUM)](https://dt-url.net/1n2b0prq) to monitor and improve your application's performance, identify errors, and gain insight into your user's behavior and experience.",
@@ -51,7 +60,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"session_replay": {
 			Type:        schema.TypeList,
-			Description: "(Field has overlap with `dynatrace_mobile_application`) [Session Replay on crashes](https://dt-url.net/session-replay) gives you additional context for crash analysis in the form of video-like screen recordings that replay user actions immediately preceding a detected crash, while providing [best-in-class security and data protection](https://dt-url.net/b303zxj).",
+			Description: "(Field has overlap with `dynatrace_mobile_application`) [Session Replay](https://dt-url.net/session-replay) captures all user interactions within your application and replays them in a movie-like experience while providing [best-in-class security and data protection](https://dt-url.net/b303zxj).",
 			Required:    true,
 			Elem:        &schema.Resource{Schema: new(SessionReplay).Schema()},
 			MinItems:    1,
@@ -62,16 +71,18 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"application_id": me.ApplicationID,
-		"rum":            me.Rum,
-		"session_replay": me.SessionReplay,
+		"application_id":       me.ApplicationID,
+		"experience_analytics": me.ExperienceAnalytics,
+		"rum":                  me.Rum,
+		"session_replay":       me.SessionReplay,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"application_id": &me.ApplicationID,
-		"rum":            &me.Rum,
-		"session_replay": &me.SessionReplay,
+		"application_id":       &me.ApplicationID,
+		"experience_analytics": &me.ExperienceAnalytics,
+		"rum":                  &me.Rum,
+		"session_replay":       &me.SessionReplay,
 	})
 }

--- a/dynatrace/api/builtin/rum/web/enablement/schema.json
+++ b/dynatrace/api/builtin/rum/web/enablement/schema.json
@@ -29,17 +29,18 @@
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
 		"experienceAnalytics": {
 			"description": "",
-			"displayName": "Experience Analytics",
+			"displayName": "User Interactions",
 			"documentation": "",
 			"maxObjects": 1,
 			"metadata": {
 				"featureFlag": "com.compuware.apm.webuiff.rum-settings-web-show-experience-analytics.reeaw.feature",
-				"maturity": "PREVIEW"
+				"maturity": "EARLY_ADOPTER"
 			},
 			"modificationPolicy": "DEFAULT",
 			"nullable": true,
@@ -84,12 +85,12 @@
 			"properties": {
 				"enabled": {
 					"default": false,
-					"description": "As part of the new RUM experience preview, Experience Analytics captures all interactions within your application. Check our documentation for more details: https://docs.dynatrace.com/docs/whats-new/preview-releases",
-					"displayName": "Enable Experience Analytics",
+					"description": "As part of the new RUM experience preview, User Interactions capture all interactions within your application.",
+					"displayName": "Enable User Interactions",
 					"documentation": "",
 					"maxObjects": 1,
 					"metadata": {
-						"maturity": "PREVIEW"
+						"maturity": "EARLY_ADOPTER"
 					},
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
@@ -152,10 +153,6 @@
 					"displayName": "Enable New Real User Monitoring Experience",
 					"documentation": "",
 					"maxObjects": 1,
-					"metadata": {
-						"featureFlag": "com.compuware.apm.webuiff.rum-settings-show-enable-monitoring-on-3rd-gen-switch.resemo3g.feature",
-						"maturity": "PREVIEW"
-					},
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
 					"precondition": {
@@ -237,5 +234,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.4.3"
+	"version": "1.6"
 }

--- a/dynatrace/api/builtin/rum/web/enablement/service.go
+++ b/dynatrace/api/builtin/rum/web/enablement/service.go
@@ -18,15 +18,15 @@
 package enablement
 
 import (
-	enablement "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/web/enablement/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/web/enablement/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.4.3"
+const SchemaVersion = "1.6"
 const SchemaID = "builtin:rum.web.enablement"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*enablement.Settings] {
-	return settings20.Service[*enablement.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/rum/web/enablement/settings/rum.go
+++ b/dynatrace/api/builtin/rum/web/enablement/settings/rum.go
@@ -24,9 +24,9 @@ import (
 )
 
 type Rum struct {
-	CostAndTrafficControl int   `json:"costAndTrafficControl"`    // (Field has overlap with `dynatrace_web_application`) Percentage of user sessions captured and analyzed
-	Enabled               bool  `json:"enabled"`                  // (Field has overlap with `dynatrace_web_application`) This setting is enabled (`true`) or disabled (`false`)
-	EnabledOnGrail        *bool `json:"enabledOnGrail,omitempty"` // Enable Real User Monitoring powered by Grail
+	CostAndTrafficControl int   `json:"costAndTrafficControl"`    // Percentage of user sessions captured and analyzed
+	Enabled               bool  `json:"enabled"`                  // This setting is enabled (`true`) or disabled (`false`)
+	EnabledOnGrail        *bool `json:"enabledOnGrail,omitempty"` // Enable New Real User Monitoring Experience
 }
 
 func (me *Rum) Schema() map[string]*schema.Schema {

--- a/dynatrace/api/builtin/rum/web/enablement/settings/session_replay.go
+++ b/dynatrace/api/builtin/rum/web/enablement/settings/session_replay.go
@@ -23,15 +23,15 @@ import (
 )
 
 type SessionReplay struct {
-	CostAndTrafficControl int  `json:"costAndTrafficControl"` // (Field has overlap with `dynatrace_web_application`) [Percentage of user sessions recorded with Session Replay](https://dt-url.net/sr-cost-traffic-control). For example, if you have 50% for RUM and 50% for Session Replay, it results in 25% of sessions recorded with Session Replay.
-	Enabled               bool `json:"enabled"`               // (Field has overlap with `dynatrace_web_application`) This setting is enabled (`true`) or disabled (`false`)
+	CostAndTrafficControl int  `json:"costAndTrafficControl"` // [Percentage of user sessions recorded with Session Replay Classic](https://dt-url.net/sr-cost-traffic-control). For example, if you have 50% for RUM and 50% for Session Replay Classic, it results in 25% of sessions recorded with Session Replay Classic.
+	Enabled               bool `json:"enabled"`               // This setting is enabled (`true`) or disabled (`false`)
 }
 
 func (me *SessionReplay) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"cost_and_traffic_control": {
 			Type:        schema.TypeInt,
-			Description: "(Field has overlap with `dynatrace_web_application`) [Percentage of user sessions recorded with Session Replay](https://dt-url.net/sr-cost-traffic-control). For example, if you have 50% for RUM and 50% for Session Replay, it results in 25% of sessions recorded with Session Replay.",
+			Description: "(Field has overlap with `dynatrace_web_application`) [Percentage of user sessions recorded with Session Replay Classic](https://dt-url.net/sr-cost-traffic-control). For example, if you have 50% for RUM and 50% for Session Replay Classic, it results in 25% of sessions recorded with Session Replay Classic.",
 			Required:    true,
 		},
 		"enabled": {

--- a/dynatrace/api/builtin/rum/web/enablement/settings/settings.go
+++ b/dynatrace/api/builtin/rum/web/enablement/settings/settings.go
@@ -24,7 +24,7 @@ import (
 
 type Settings struct {
 	ApplicationID       *string              `json:"-" scope:"applicationId"`       // The scope of this settings. If the settings should cover the whole environment, just don't specify any scope.
-	ExperienceAnalytics *ExperienceAnalytics `json:"experienceAnalytics,omitempty"` // Experience Analytics
+	ExperienceAnalytics *ExperienceAnalytics `json:"experienceAnalytics,omitempty"` // User Interactions
 	Rum                 *Rum                 `json:"rum"`                           // Capture and analyze all user actions within your application. Enable [Real User Monitoring (RUM)](https://dt-url.net/1n2b0prq) to monitor and improve your application's performance, identify errors, and gain insight into your user's behavior and experience.
 	SessionReplay       *SessionReplay       `json:"sessionReplay"`                 // [Session Replay](https://dt-url.net/session-replay) captures all user interactions within your application and replays them in a movie-like experience while providing [best-in-class security and data protection](https://dt-url.net/b303zxj).
 }
@@ -44,7 +44,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"experience_analytics": {
 			Type:        schema.TypeList,
-			Description: "Experience Analytics",
+			Description: "User Interactions",
 			Optional:    true, // nullable
 			Elem:        &schema.Resource{Schema: new(ExperienceAnalytics).Schema()},
 			MinItems:    1,
@@ -54,19 +54,17 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "Capture and analyze all user actions within your application. Enable [Real User Monitoring (RUM)](https://dt-url.net/1n2b0prq) to monitor and improve your application's performance, identify errors, and gain insight into your user's behavior and experience.",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(Rum).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(Rum).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"session_replay": {
 			Type:        schema.TypeList,
 			Description: "[Session Replay](https://dt-url.net/session-replay) captures all user interactions within your application and replays them in a movie-like experience while providing [best-in-class security and data protection](https://dt-url.net/b303zxj).",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(SessionReplay).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(SessionReplay).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 	}
 }


### PR DESCRIPTION
#### **Why** this PR?
Some APIs have changed with Dynatrace version 1.329. Therefore, the Terraform resources also need updating.

#### **What** has changed?
For most of the resources there are only documentation updates.
`dynatrace_mobile_app_enablement`: new optional field `experienceAnalytics`.
`dynatrace_openpipeline_v2_*_ingestsources`: The `eventType` of `BizeventAttributes` and `SdlcEventAttributes` is now required
`dynatrace_openpipeline_v2_*_pipelines`: The `eventType` of `BizeventAttributes` and `SdlcEventAttributes` is now required. New optional fields `group_role` and `routing`.
`dynatrace_host_anomalies_v2`: host `gc` (`highGcActivityDetection`) is now optional
Some missing preconditions were added (property A conflicts with property B, etc.) for `dynatrace_host_anomalies_v2`, `dynatrace_endpoint_detection_rules` and `dynatrace_generic_relationships`,  


#### How is it **tested**?
It's mostly about documentation.

#### How does it affect **users**?
They will see the updated documentation, will have breaking changes due to the openpipeline updates (new required fields) and can make use of the new properties mentioned above.

**Issue:** CA-17857
