### PR TITLE
fix: prevent potential OAuth context cancelled errors

### DIFF
--- a/dynatrace/api/documents/directshares/service.go
+++ b/dynatrace/api/documents/directshares/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 
 	directshares "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/directshares/settings"
-	httplog "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/monaco/pkg/client/auth"
 	directshare "github.com/dynatrace-oss/terraform-provider-dynatrace/monaco/pkg/client/document/directshares"
 )
@@ -41,7 +40,7 @@ type service struct {
 }
 
 func (me *service) client(ctx context.Context) *directshare.Client {
-	httplog.InstallRoundTripper()
+	rest.PreRequest()
 	httpClient := auth.NewOAuthClient(ctx, auth.OauthCredentials{
 		ClientID:     me.credentials.OAuth.ClientID,
 		ClientSecret: me.credentials.OAuth.ClientSecret,

--- a/dynatrace/rest/logging/http_listener.go
+++ b/dynatrace/rest/logging/http_listener.go
@@ -27,8 +27,9 @@ import (
 	"strings"
 	"sync"
 
-	crest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/google/uuid"
+
+	crest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
 var DYNATRACE_HTTP_OAUTH = (os.Getenv("DYNATRACE_HTTP_OAUTH") == "true")
@@ -95,20 +96,6 @@ func HTTPListener(prefix string) *crest.HTTPListener {
 			logRequest(ctx, response.ID, response.Request)
 			logResponse(ctx, response.ID, response.Response)
 		},
-	}
-}
-
-var lock sync.Mutex
-
-func InstallRoundTripper() {
-	lock.Lock()
-	defer lock.Unlock()
-	if _, ok := http.DefaultClient.Transport.(*RoundTripper); !ok {
-		if http.DefaultClient.Transport == nil {
-			http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultTransport}
-		} else {
-			http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultClient.Transport}
-		}
 	}
 }
 

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -42,8 +42,6 @@ var eligiblePlatformRequests = map[string]string{
 
 type platform_request request
 
-var platformClientCache = map[string]*rest.Client{}
-
 var platformClientCacheMutex sync.Mutex
 var NoPlatformCredentialsErr = errors.New("neither oauth credentials nor platform token present")
 
@@ -92,9 +90,6 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 	platformClientCacheMutex.Lock()
 	defer platformClientCacheMutex.Unlock()
 
-	if client, found := platformClientCache[platformURL]; found {
-		return client, nil
-	}
 	PreRequest()
 
 	var client *rest.Client
@@ -109,7 +104,6 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 	if err != nil {
 		return nil, err
 	}
-	platformClientCache[platformURL] = client
 
 	return client, err
 }

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
@@ -42,7 +41,6 @@ var eligiblePlatformRequests = map[string]string{
 
 type platform_request request
 
-var platformClientCacheMutex sync.Mutex
 var NoPlatformCredentialsErr = errors.New("neither oauth credentials nor platform token present")
 
 func configureCommonRestClient(restClient *rest.Client) (*rest.Client, error) {
@@ -87,9 +85,6 @@ func CreatePlatformTokenClient(u string, credentials *Credentials) (*rest.Client
 }
 
 func CreatePlatformClient(ctx context.Context, platformURL string, credentials *Credentials) (*rest.Client, error) {
-	platformClientCacheMutex.Lock()
-	defer platformClientCacheMutex.Unlock()
-
 	PreRequest()
 
 	var client *rest.Client

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -28,13 +28,14 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/google/uuid"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
+var preRequestMutex sync.Mutex
 var DYNATRACE_HTTP_LEGACY = (os.Getenv("DYNATRACE_HTTP_LEGACY") == "true")
 var DYNATRACE_HTTP_OAUTH_PREFERENCE = (os.Getenv("DYNATRACE_HTTP_OAUTH_PREFERENCE") == "true")
 
@@ -70,7 +71,15 @@ func (me request) evalClassicURL() string {
 }
 
 func PreRequest() {
-	logging.InstallRoundTripper()
+	preRequestMutex.Lock()
+	defer preRequestMutex.Unlock()
+	if _, ok := http.DefaultClient.Transport.(*RoundTripper); !ok {
+		if http.DefaultClient.Transport == nil {
+			http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultTransport}
+		} else {
+			http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultClient.Transport}
+		}
+	}
 	if strings.TrimSpace(os.Getenv("DYNATRACE_HTTP_INSECURE")) == "true" {
 		if transport, ok := http.DefaultTransport.(*http.Transport); ok {
 			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}


### PR DESCRIPTION
#### **Why** this PR?
Under certain conditions, platform resources (requests) errored with context cancelled.
example error
`Post "https://something.apps.dynatrace.com/platform/automation/v1/workflows?adminAccess=true": Post "https://sso.dynatrace.com/sso/oauth2/token": context canceled`

#### **What** has changed?
Long-running `terraform apply` runs should not lead to context canceled errors anymore.
This will lead to more token requests, but resolves the context issue.

#### **How** does it do it?
By simply removing the client cache we are using.
The issue here was that the first resource that creates a client and saves it to the cache is also caching its context, which is used for OAuth token requests. Terraform is probably cancelling the context of some resources, cleanup-related, and with the cache, a cancelled context was still used for OAuth requests.

#### How is it **tested**?
Current E2E tests cover it

#### How does it affect **users**?
context cancelled errors should not show up anymore, unless there is a resource that runs longer than 20 minutes (Terraform default defined timeout per resource)

#### Steps to reproduce
If the cache is present, you can easily trigger the error by having two platform resources, like segments, and adding a `time_sleep` of 5 minutes in between them via `depends_on`. `segment1->sleep_5_min->segment2`

**Issue:** CA-17913
