### PR TITLE
test(serviceuser): Adds dynatrace_iam_service_user E2E test

### DIFF
--- a/dynatrace/api/iam/serviceusers/service_e2e_test.go
+++ b/dynatrace/api/iam/serviceusers/service_e2e_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package serviceusers_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccServiceUsers(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	groupName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_GROUP_NAME", groupName)
+	serviceUserName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	t.Setenv("TF_VAR_SERVICE_USER_NAME", serviceUserName)
+
+	configCreate, _ := api.ReadTfConfig(t, "testdata/create.tf")
+	configUpdate, _ := api.ReadTfConfig(t, "testdata/update.tf")
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	t.Run("Updating description and groups of service user", func(t *testing.T) {
+		testCase := resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{Config: configCreate}, // creates service user with group
+				{Config: configUpdate}, // updates description, removes group
+			},
+		}
+		resource.Test(t, testCase)
+	})
+}

--- a/dynatrace/api/iam/serviceusers/testdata/create.tf
+++ b/dynatrace/api/iam/serviceusers/testdata/create.tf
@@ -1,0 +1,20 @@
+variable "GROUP_NAME" {
+  description = "The name of the group."
+  type        = string
+}
+
+resource "dynatrace_iam_group" "my-group" {
+  name = var.GROUP_NAME
+  description = "A group created for e2e testing."
+}
+
+variable "SERVICE_USER_NAME" {
+  description = "The name of the service user."
+  type        = string
+}
+
+resource "dynatrace_iam_service_user" "test_service_user" {
+  name        = var.SERVICE_USER_NAME
+  description = "a service user for testing purposes"
+  groups      = [  dynatrace_iam_group.my-group.id ]
+}

--- a/dynatrace/api/iam/serviceusers/testdata/update.tf
+++ b/dynatrace/api/iam/serviceusers/testdata/update.tf
@@ -1,0 +1,10 @@
+variable "SERVICE_USER_NAME" {
+  description = "The name of the service user."
+  type        = string
+}
+
+resource "dynatrace_iam_service_user" "test_service_user" {
+  name        = var.SERVICE_USER_NAME
+  description = "an updated description"
+  groups      = []
+}


### PR DESCRIPTION
#### **Why** this PR?
We need E2E tests for IAM resources

#### **What** has changed?
E2E tests have been added for `dynatrace_iam_service_user`

#### **How** does it do it?
I added a `create.tf` and an `update.tf` file, so the service user resource is created and afterwards updated.

#### How is it **tested**?
This is the test.

#### How does it affect **users**?
It doesn't.

**Issue:** CA-17713
