### PR TITLE
fix(document): `dynatrace_direct_shares` supports documents with custom IDs

### DIFF
--- a/dynatrace/api/documents/directshares/settings/directshare.go
+++ b/dynatrace/api/documents/directshares/settings/directshare.go
@@ -77,7 +77,7 @@ func (me *DirectShare) Schema() map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			Description:      "Document ID",
 			Required:         true,
-			ValidateDiagFunc: Validate(ValidateUUID, ValidateMaxLength(200)),
+			ValidateDiagFunc: Validate(ValidateMaxLength(200)),
 		},
 		"access": {
 			Type:             schema.TypeString,

--- a/dynatrace/api/documents/directshares/testdata/terraform/example-custom-id.tf
+++ b/dynatrace/api/documents/directshares/testdata/terraform/example-custom-id.tf
@@ -1,0 +1,42 @@
+resource "dynatrace_iam_group" "this" {
+  name = "#name#"
+}
+
+resource "dynatrace_document" "this" {
+  custom_id = "#name#"
+  type      = "dashboard"
+  name      = "#name#"
+  content = jsonencode(
+    {
+      "version" : 1,
+      "variables" : [],
+      "tiles" : {
+        "0" : {
+          "type" : "markdown",
+          "title" : "",
+          "content" : "Dashboard content"
+        }
+      },
+      "layouts" : {
+        "0" : {
+          "x" : 0,
+          "y" : 0,
+          "w" : 24,
+          "h" : 14
+        }
+      }
+    }
+  )
+}
+
+resource "dynatrace_direct_shares" "this" {
+  document_id = dynatrace_document.this.id
+  access      = "read"
+
+  recipients {
+    recipient {
+      id   = dynatrace_iam_group.this.id
+      type = "group"
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
The `dynatrace_direct_shares` had a validator requiring the specified `document_id` to be a UUID. As documents now support custom IDs that must not be UUIDs, this requirement is no longer valid.

#### **What** has changed and **how** does it do it?
The validator requiring `document_id` to be a UUID is removed.

#### How is it **tested**?
An explicit test creating a direct share for a document with a (non-UUID) custom ID is added.

#### How does it affect **users**?
Users can now share documents with custom IDs.

**Issue:** CA-17840
