### PR TITLE
fix: not working request attribute fields

### DIFF
--- a/dynatrace/api/v1/config/requestattributes/settings/data_source.go
+++ b/dynatrace/api/v1/config/requestattributes/settings/data_source.go
@@ -399,7 +399,7 @@ func (me *DataSource) MarshalJSON() ([]byte, error) {
 	if err := m.Marshal("cicsTransactionCallType", me.CICSTransactionCallType); err != nil {
 		return nil, err
 	}
-	if err := m.Marshal("iibNodeTypeCondition", me.IIBMethodNodeCondition); err != nil {
+	if err := m.Marshal("iibNodeTypeCondition", me.IIBNodeTypeCondition); err != nil {
 		return nil, err
 	}
 	if err := m.Marshal("imsTransactionCallType", me.IMSTransactionCallType); err != nil {
@@ -461,7 +461,7 @@ func (me *DataSource) UnmarshalJSON(data []byte) error {
 	if err := m.Unmarshal("cicsTransactionCallType", &me.CICSTransactionCallType); err != nil {
 		return err
 	}
-	if err := m.Unmarshal("iibNodeTypeCondition", &me.IIBMethodNodeCondition); err != nil {
+	if err := m.Unmarshal("iibNodeTypeCondition", &me.IIBNodeTypeCondition); err != nil {
 		return err
 	}
 	if err := m.Unmarshal("imsTransactionCallType", &me.IMSTransactionCallType); err != nil {

--- a/dynatrace/api/v1/config/requestattributes/settings/data_source.go
+++ b/dynatrace/api/v1/config/requestattributes/settings/data_source.go
@@ -225,19 +225,19 @@ func (me *DataSource) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Encode("iib_node_type", me.IIBNodeType); err != nil {
 		return err
 	}
-	if err := properties.Encode("cics_transaction_call_type", me.IIBNodeType); err != nil {
+	if err := properties.Encode("cics_transaction_call_type", me.CICSTransactionCallType); err != nil {
 		return err
 	}
-	if err := properties.Encode("iib_node_type_condition", me.IIBNodeType); err != nil {
+	if err := properties.Encode("iib_node_type_condition", me.IIBNodeTypeCondition); err != nil {
 		return err
 	}
-	if err := properties.Encode("ims_transaction_call_type", me.IIBNodeType); err != nil {
+	if err := properties.Encode("ims_transaction_call_type", me.IMSTransactionCallType); err != nil {
 		return err
 	}
-	if err := properties.Encode("server_variable_technology", me.IIBNodeType); err != nil {
+	if err := properties.Encode("server_variable_technology", me.ServerVariableTechnology); err != nil {
 		return err
 	}
-	if err := properties.Encode("span_attribute_key", me.IIBNodeType); err != nil {
+	if err := properties.Encode("span_attribute_key", me.SpanAttributeKey); err != nil {
 		return err
 	}
 	return nil
@@ -396,19 +396,19 @@ func (me *DataSource) MarshalJSON() ([]byte, error) {
 	if err := m.Marshal("iibNodeType", me.IIBNodeType); err != nil {
 		return nil, err
 	}
-	if err := m.Marshal("cics_transaction_call_type", me.CICSTransactionCallType); err != nil {
+	if err := m.Marshal("cicsTransactionCallType", me.CICSTransactionCallType); err != nil {
 		return nil, err
 	}
-	if err := m.Marshal("iib_node_type_condition", me.IIBMethodNodeCondition); err != nil {
+	if err := m.Marshal("iibNodeTypeCondition", me.IIBMethodNodeCondition); err != nil {
 		return nil, err
 	}
-	if err := m.Marshal("ims_transaction_call_type", me.IMSTransactionCallType); err != nil {
+	if err := m.Marshal("imsTransactionCallType", me.IMSTransactionCallType); err != nil {
 		return nil, err
 	}
-	if err := m.Marshal("server_variable_technology", me.ServerVariableTechnology); err != nil {
+	if err := m.Marshal("serverVariableTechnology", me.ServerVariableTechnology); err != nil {
 		return nil, err
 	}
-	if err := m.Marshal("span_attribute_key", me.SpanAttributeKey); err != nil {
+	if err := m.Marshal("spanAttributeKey", me.SpanAttributeKey); err != nil {
 		return nil, err
 	}
 	return json.Marshal(m)
@@ -458,19 +458,19 @@ func (me *DataSource) UnmarshalJSON(data []byte) error {
 	if err := m.Unmarshal("iibNodeType", &me.IIBNodeType); err != nil {
 		return err
 	}
-	if err := m.Unmarshal("cics_transaction_call_type", &me.CICSTransactionCallType); err != nil {
+	if err := m.Unmarshal("cicsTransactionCallType", &me.CICSTransactionCallType); err != nil {
 		return err
 	}
-	if err := m.Unmarshal("iib_node_type_condition", &me.IIBMethodNodeCondition); err != nil {
+	if err := m.Unmarshal("iibNodeTypeCondition", &me.IIBMethodNodeCondition); err != nil {
 		return err
 	}
-	if err := m.Unmarshal("ims_transaction_call_type", &me.IMSTransactionCallType); err != nil {
+	if err := m.Unmarshal("imsTransactionCallType", &me.IMSTransactionCallType); err != nil {
 		return err
 	}
-	if err := m.Unmarshal("server_variable_technology", &me.ServerVariableTechnology); err != nil {
+	if err := m.Unmarshal("serverVariableTechnology", &me.ServerVariableTechnology); err != nil {
 		return err
 	}
-	if err := m.Unmarshal("span_attribute_key", &me.SpanAttributeKey); err != nil {
+	if err := m.Unmarshal("spanAttributeKey", &me.SpanAttributeKey); err != nil {
 		return err
 	}
 

--- a/dynatrace/api/v1/config/requestattributes/settings/request_attribute.go
+++ b/dynatrace/api/v1/config/requestattributes/settings/request_attribute.go
@@ -72,6 +72,7 @@ func (me *RequestAttribute) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "The data type of the request attribute",
 			Required:    true,
+			ForceNew:    true,
 		},
 		"normalization": {
 			Type:        schema.TypeString,

--- a/dynatrace/api/v1/config/requestattributes/testdata/terraform/example_b.tf
+++ b/dynatrace/api/v1/config/requestattributes/testdata/terraform/example_b.tf
@@ -1,0 +1,16 @@
+resource "dynatrace_request_attribute" "attribute" {
+  name         = "#name#"
+  enabled      = true
+  aggregation  = "FIRST"
+  confidential = false
+
+  data_type                  = "INTEGER"
+  normalization              = "ORIGINAL"
+  skip_personal_data_masking = false
+  data_sources {
+    enabled = true
+    source = "SERVER_VARIABLE"
+    server_variable_technology = "ASP_NET"
+    parameter_name             = "param"
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
Some fields in `dynatrace_request_attribute` didn't work as expected.
Affected fields: cics_transaction_call_type, iib_node_type_condition, ims_transaction_call_type, server_variable_technology, span_attribute_key

#### **What** has changed?
Applying and planning now correctly returns the affected fields.

#### **How** does it do it?
The fields are now correctly mapped to and from the API (HCL to JSON and vice versa)

#### How is it **tested**?
A new example has been added that makes use of some other properties.

#### How does it affect **users**?
They can now properly use the fields cics_transaction_call_type, iib_node_type_condition, ims_transaction_call_type, server_variable_technology and span_attribute_key of a data source

**Issue:** NOISSUE (found during CA-17770)
