### PR TITLE
test: refactor E2E dependencies (Part 1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,7 @@ jobs:
           DT_CLIENT_ID: ${{ secrets.DT_CLIENT_ID }}
           DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
+          TF_VAR_PROCESS_GROUP_ID: ${{ secrets.PROCESS_GROUP_ID }}
         run: go test -tags=integration -v -p 1 ${{ matrix.config.path }}
 
   sonar_scan:

--- a/dynatrace/api/builtin/alerting/connectivityalerts/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/alerting/connectivityalerts/testdata/terraform/example_a.tf
@@ -1,4 +1,8 @@
-resource "dynatrace_connectivity_alerts" "PROCESS_GROUP-1234567890000000" {
+variable "PROCESS_GROUP_ID" {
+  type = string
+}
+
+resource "dynatrace_connectivity_alerts" "alert" {
   connectivity_alerts = false
-  process_group_id    = "PROCESS_GROUP-1234567890000000"
+  process_group_id    = var.PROCESS_GROUP_ID
 }

--- a/dynatrace/api/builtin/anomalydetection/rum/mobile/crashrate/testdata/terraform-mobile-app/example_a.tf
+++ b/dynatrace/api/builtin/anomalydetection/rum/mobile/crashrate/testdata/terraform-mobile-app/example_a.tf
@@ -1,5 +1,9 @@
-resource "dynatrace_mobile_app_crash_rate" "#name#" {
-  application_id = "MOBILE_APPLICATION-1234567890000000"
+data "dynatrace_mobile_application" "application" {
+  name = "Application"
+}
+
+resource "dynatrace_mobile_app_crash_rate" "crash_rate" {
+  application_id = data.dynatrace_mobile_application.application.id
   crash_rate_increase {
     enabled        = true
     detection_mode = "fixed"

--- a/dynatrace/api/builtin/anomalydetection/rum/mobile/testdata/terraform-mobile-app/example_a.tf
+++ b/dynatrace/api/builtin/anomalydetection/rum/mobile/testdata/terraform-mobile-app/example_a.tf
@@ -1,5 +1,9 @@
-resource "dynatrace_mobile_app_anomalies" "#name#" {
-  scope = "MOBILE_APPLICATION-1234567890000000"
+data "dynatrace_mobile_application" "application" {
+  name = "Application"
+}
+
+resource "dynatrace_mobile_app_anomalies" "anomalies" {
+  scope = data.dynatrace_mobile_application.application.id
   error_rate_increase {
     enabled        = true
     detection_mode = "fixed"

--- a/dynatrace/api/builtin/availability/processgroupalerting/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/availability/processgroupalerting/testdata/terraform/example_a.tf
@@ -1,6 +1,10 @@
-resource "dynatrace_pg_alerting" "#name#" {
+variable "PROCESS_GROUP_ID" {
+  type = string
+}
+
+resource "dynatrace_pg_alerting" "alert" {
   enabled                    = true
   alerting_mode              = "ON_INSTANCE_COUNT_VIOLATION"
   minimum_instance_threshold = 5
-  process_group              = "PROCESS_GROUP-1234567890000000"
+  process_group              = var.PROCESS_GROUP_ID
 }

--- a/dynatrace/api/builtin/devobs/agentoptin/service_test.go
+++ b/dynatrace/api/builtin/devobs/agentoptin/service_test.go
@@ -21,10 +21,10 @@ package agentoptin_test
 
 import (
 	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
 )
 
 func TestAccDevObsAgentOptin(t *testing.T) {
-	// Temporarily disabled - not licensed and enabled on test tenant
-	// api.TestAcc(t)
-	t.Skip()
+	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/devobs/agentoptin/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/devobs/agentoptin/testdata/terraform/example_a.tf
@@ -1,4 +1,8 @@
-resource "dynatrace_devobs_agent_optin" "#name#" {
-  scope   = "PROCESS_GROUP-1234567890000000"
+variable "PROCESS_GROUP_ID" {
+  type = string
+}
+
+resource "dynatrace_devobs_agent_optin" "optin" {
+  scope   = var.PROCESS_GROUP_ID
   enabled = false
 }

--- a/dynatrace/api/builtin/host/processgroups/monitoringstate/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/host/processgroups/monitoringstate/testdata/terraform/example_a.tf
@@ -1,5 +1,9 @@
-resource "dynatrace_host_process_group_monitoring" "#name#" {
+variable "PROCESS_GROUP_ID" {
+  type = string
+}
+
+resource "dynatrace_host_process_group_monitoring" "monitoring" {
   host_id          = "HOST-1234567890000000"
   monitoring_state = "MONITORING_ON"
-  process_group    = "PROCESS_GROUP-1234567890000000"
+  process_group    = var.PROCESS_GROUP_ID
 }

--- a/dynatrace/api/builtin/processgroup/monitoring/state/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/processgroup/monitoring/state/testdata/terraform/example_a.tf
@@ -1,4 +1,8 @@
-resource "dynatrace_process_group_monitoring" "#name#" {
+variable "PROCESS_GROUP_ID" {
+  type = string
+}
+
+resource "dynatrace_process_group_monitoring" "monitoring" {
   monitoring_state = "MONITORING_ON"
-  process_group_id = "PROCESS_GROUP-1234567890000000"
+  process_group_id = var.PROCESS_GROUP_ID
 }

--- a/dynatrace/api/builtin/rum/mobile/requesterrors/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/rum/mobile/requesterrors/testdata/terraform/example_a.tf
@@ -1,5 +1,9 @@
-resource "dynatrace_mobile_app_request_errors" "#name#" {
-  scope = "MOBILE_APPLICATION-1234567890000000"
+data "dynatrace_mobile_application" "application" {
+  name = "Application"
+}
+
+resource "dynatrace_mobile_app_request_errors" "request_errors" {
+  scope = data.dynatrace_mobile_application.application.id
   error_rules {
     error_rule {
       error_codes = "409"

--- a/dynatrace/api/builtin/rum/processgroup/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/rum/processgroup/testdata/terraform/example_a.tf
@@ -1,4 +1,9 @@
-resource "dynatrace_process_group_rum" "#name#" {
+variable "PROCESS_GROUP_ID" {
+  type = string
+}
+
+
+resource "dynatrace_process_group_rum" "rum" {
   enable           = false
-  process_group_id = "PROCESS_GROUP-1234567890000000"
+  process_group_id = var.PROCESS_GROUP_ID
 }

--- a/dynatrace/api/builtin/synthetic/browser/performancethresholds/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/synthetic/browser/performancethresholds/testdata/terraform/example_a.tf
@@ -1,9 +1,63 @@
-resource "dynatrace_browser_monitor_performance" "#name#" {
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
+resource "dynatrace_browser_monitor" "monitor" {
+  name                   = "#name#"
+  frequency              = 15
+  locations              = [data.dynatrace_synthetic_location.location.id]
+  key_performance_metrics {
+    load_action_kpm = "VISUALLY_COMPLETE"
+    xhr_action_kpm  = "VISUALLY_COMPLETE"
+  }
+  anomaly_detection {
+    loading_time_thresholds {
+      enabled = true
+      thresholds {
+        threshold {
+          event_index   = 0
+          request_index = 0
+          type          = "TOTAL"
+          value_ms      = 10000
+        }
+      }
+    }
+    outage_handling {
+      global_outage = true
+      local_outage = false
+      retry_on_error = true
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  script {
+    type = "clickpath"
+    configuration {
+      bypass_csp = true
+      user_agent = "Mozilla"
+      device {
+        name        = "Desktop"
+        orientation = "landscape"
+      }
+    }
+    events {
+      event {
+        description = "my description"
+        navigate {
+          url = "https://www.example.com"
+        }
+      }
+    }
+  }
+}
+
+resource "dynatrace_browser_monitor_performance" "performance" {
   enabled = true
-  scope   = "SYNTHETIC_TEST-1234567890000000"
+  scope   = dynatrace_browser_monitor.monitor.id
   thresholds {
     threshold {
-      event     = "SYNTHETIC_TEST-1234567890000000"
+      event     = dynatrace_browser_monitor.monitor.id
       threshold = 10
     }
   }

--- a/dynatrace/api/v1/config/anomalies/processgroups/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/anomalies/processgroups/testdata/terraform/example_a.tf
@@ -1,5 +1,9 @@
-resource "dynatrace_pg_anomalies" "#name#" {
-  pg_id = "PROCESS_GROUP-AA665B81183B0D7A"
+variable "PROCESS_GROUP_ID" {
+  type = string
+}
+
+resource "dynatrace_pg_anomalies" "anomaly" {
+  pg_id = var.PROCESS_GROUP_ID
   availability {
     method            = "OFF"
     minimum_threshold = 0

--- a/dynatrace/api/v1/config/jsondashboards/testdata/terraform/example_a_json.tf
+++ b/dynatrace/api/v1/config/jsondashboards/testdata/terraform/example_a_json.tf
@@ -1,529 +1,476 @@
-resource "dynatrace_json_dashboard" "#name#" {
+resource "dynatrace_json_dashboard" "name" {
   contents = jsonencode(
     {
-      "dashboardMetadata" : {
-        "name" : "Azure Cognitive Services",
-        "shared" : true,
-        "owner" : "Dynatrace",
-        "tags" : [
-          "Azure"
+      "dashboardMetadata": {
+        "name": "Performance overview",
+        "shared": true,
+        "owner": "Dynatrace",
+        "tags": [
+          "performance"
         ],
-        "preset" : true
+        "preset": true,
+        "hasConsistentColors": false
       },
-      "tiles" : [
+      "tiles": [
         {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 342,
-            "left" : 38,
-            "width" : 342,
-            "height" : 304
+          "name": "Performance",
+          "tileType": "HEADER",
+          "configured": true,
+          "bounds": {
+            "top": 0,
+            "left": 38,
+            "width": 1026,
+            "height": 38
           },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Successful calls by service instance",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.successfulcalls",
-                  "aggregation" : "SUM",
-                  "type" : "LINE",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "0",
-                      "name" : "dt.entity.custom_device",
-                      "entityDimension" : true
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
-              ]
-            }
-          }
+          "tileFilter": {},
+          "isAutoRefreshDisabled": true
         },
         {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 342,
-            "left" : 722,
-            "width" : 342,
-            "height" : 304
+          "name": "Failure rate by service",
+          "tileType": "DATA_EXPLORER",
+          "configured": true,
+          "bounds": {
+            "top": 342,
+            "left": 38,
+            "width": 342,
+            "height": 304
           },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Latency by service instance",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.latency",
-                  "aggregation" : "AVG",
-                  "type" : "LINE",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "0",
-                      "name" : "dt.entity.custom_device",
-                      "values" : [],
-                      "entityDimension" : true
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 38,
-            "left" : 380,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Total errors",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TIMESERIES",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.totalerrors",
-                  "aggregation" : "SUM",
-                  "type" : "BAR",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "0",
-                      "name" : "dt.entity.custom_device",
-                      "values" : [],
-                      "entityDimension" : true
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 38,
-            "left" : 38,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Total calls",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TIMESERIES",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.blockedcalls",
-                  "aggregation" : "SUM",
-                  "type" : "BAR",
-                  "entityType" : "IOT",
-                  "dimensions" : [],
-                  "aggregationRate" : "TOTAL"
-                },
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.successfulcalls",
-                  "aggregation" : "SUM",
-                  "type" : "BAR",
-                  "entityType" : "IOT",
-                  "dimensions" : [],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
+          "tileFilter": {},
+          "isAutoRefreshDisabled": true,
+          "customName": "Successful calls by service instance",
+          "queries": [
+            {
+              "id": "A",
+              "metric": "builtin:service.errors.total.rate",
+              "spaceAggregation": "AUTO",
+              "timeAggregation": "DEFAULT",
+              "splitBy": [
+                "dt.entity.service"
               ],
-              "resultMetadata" : {
-                "nullext:cloud.azure.microsoft_cognitiveservices.accounts.blockedcalls|SUM|TOTAL|BAR|IOT" : {
-                  "lastModified" : 1595493591071,
-                  "customColor" : "#FF0000"
+              "sortBy": "DESC",
+              "sortByDimension": "",
+              "filterBy": {
+                "nestedFilters": [],
+                "criteria": []
+              },
+              "limit": 20,
+              "rate": "NONE",
+              "enabled": true
+            }
+          ],
+          "visualConfig": {
+            "type": "TOP_LIST",
+            "global": {
+              "hideLegend": false
+            },
+            "rules": [
+              {
+                "matcher": "A:",
+                "properties": {
+                  "color": "DEFAULT"
                 },
-                "nullext:cloud.azure.microsoft_cognitiveservices.accounts.totalerrors|SUM|TOTAL|LINE|IOT" : {
-                  "lastModified" : 1595343403084,
-                  "customColor" : "#4fd5e0"
-                },
-                "nullext:cloud.azure.microsoft_cognitiveservices.accounts.successfulcalls|SUM|TOTAL|BAR|IOT" : {
-                  "lastModified" : 1595493603433,
-                  "customColor" : "#4fd5e0"
-                }
+                "seriesOverrides": []
               }
+            ],
+            "axes": {
+              "xAxis": {
+                "visible": true
+              },
+              "yAxes": []
+            },
+            "heatmapSettings": {
+              "yAxis": "VALUE"
+            },
+            "singleValueSettings": {
+              "showSparkLine": true
+            },
+            "thresholds": [
+              {
+                "axisTarget": "LEFT",
+                "rules": [
+                  {
+                    "color": "#7dc540"
+                  },
+                  {
+                    "color": "#f5d30f"
+                  },
+                  {
+                    "color": "#dc172a"
+                  }
+                ],
+                "visible": true
+              }
+            ],
+            "tableSettings": {
+              "hiddenColumns": []
+            },
+            "graphChartSettings": {
+              "connectNulls": false
+            },
+            "honeycombSettings": {
+              "showHive": true,
+              "showLegend": true,
+              "showLabels": false
             }
-          }
+          },
+          "queriesSettings": {
+            "resolution": ""
+          },
+          "metricExpressions": [
+            "resolution=Inf&(builtin:service.errors.total.rate:splitBy(\"dt.entity.service\"):sort(value(auto,descending)):limit(20)):limit(100):names"
+          ]
         },
         {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 38,
-            "left" : 722,
-            "width" : 342,
-            "height" : 304
+          "name": "Total calls",
+          "tileType": "DATA_EXPLORER",
+          "configured": true,
+          "bounds": {
+            "top": 38,
+            "left": 38,
+            "width": 342,
+            "height": 304
           },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Client & server errors by operation",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.clienterrors",
-                  "aggregation" : "SUM",
-                  "type" : "BAR",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "2",
-                      "name" : "Operation name",
-                      "values" : []
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 646,
-            "left" : 38,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Successful calls by operation",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.successfulcalls",
-                  "aggregation" : "SUM",
-                  "type" : "LINE",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "2",
-                      "name" : "Operation name",
-                      "values" : []
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 646,
-            "left" : 380,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Blocked calls by operation",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.blockedcalls",
-                  "aggregation" : "SUM",
-                  "type" : "LINE",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "2",
-                      "name" : "Operation name",
-                      "values" : []
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 646,
-            "left" : 722,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Latency by operation",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.latency",
-                  "aggregation" : "AVG",
-                  "type" : "LINE",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "2",
-                      "name" : "Operation name",
-                      "values" : []
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 38,
-            "left" : 1064,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Data IN/OUT",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TIMESERIES",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.datain",
-                  "aggregation" : "SUM",
-                  "type" : "BAR",
-                  "entityType" : "IOT",
-                  "dimensions" : [],
-                  "aggregationRate" : "TOTAL"
-                },
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.dataout",
-                  "aggregation" : "SUM",
-                  "type" : "BAR",
-                  "entityType" : "IOT",
-                  "dimensions" : [],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
+          "tileFilter": {},
+          "isAutoRefreshDisabled": true,
+          "customName": "Total calls",
+          "queries": [
+            {
+              "id": "A",
+              "metric": "builtin:service.errors.total.successCount",
+              "spaceAggregation": "SUM",
+              "timeAggregation": "DEFAULT",
+              "splitBy": [
+                "dt.entity.service"
               ],
-              "resultMetadata" : {
-                "nullext:cloud.azure.microsoft_cognitiveservices.accounts.dataout|SUM|TOTAL|BAR|IOT" : {
-                  "lastModified" : 1595495569439,
-                  "customColor" : "#008cdb"
-                },
-                "nullext:cloud.azure.microsoft_cognitiveservices.accounts.datain|SUM|TOTAL|BAR|IOT" : {
-                  "lastModified" : 1595495567476,
-                  "customColor" : "#aeebf0"
-                },
-                "nullext:cloud.azure.microsoft_cognitiveservices.accounts.datain|SUM|TOTAL|BAR|IOT|IOT" : {
-                  "lastModified" : 1595494661543,
-                  "customColor" : "#008cdb"
-                }
-              }
-            }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 342,
-            "left" : 1064,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Data IN by operation",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.datain",
-                  "aggregation" : "SUM",
-                  "type" : "LINE",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "2",
-                      "name" : "Operation name",
-                      "values" : []
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
+              "sortBy": "DESC",
+              "sortByDimension": "",
+              "filterBy": {
+                "nestedFilters": [],
+                "criteria": []
+              },
+              "limit": 20,
+              "rate": "NONE",
+              "enabled": true
+            },
+            {
+              "id": "B",
+              "metric": "builtin:service.errors.fourxx.successCount",
+              "spaceAggregation": "SUM",
+              "timeAggregation": "DEFAULT",
+              "splitBy": [
+                "dt.entity.service"
               ],
-              "resultMetadata" : {
-                "nullext:cloud.azure.microsoft_cognitiveservices.accounts.dataout|SUM|TOTAL|LINE|IOT" : {
-                  "lastModified" : 1595344576968,
-                  "customColor" : "#ef651f"
-                }
-              }
-            }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 646,
-            "left" : 1064,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Data OUT by operation",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
-                {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.dataout",
-                  "aggregation" : "SUM",
-                  "type" : "LINE",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "2",
-                      "name" : "Operation name",
-                      "values" : []
-                    }
-                  ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
-                }
+              "sortBy": "DESC",
+              "sortByDimension": "",
+              "filterBy": {
+                "nestedFilters": [],
+                "criteria": []
+              },
+              "limit": 20,
+              "rate": "NONE",
+              "enabled": true
+            },
+            {
+              "id": "C",
+              "metric": "builtin:service.errors.fivexx.successCount",
+              "spaceAggregation": "SUM",
+              "timeAggregation": "DEFAULT",
+              "splitBy": [
+                "dt.entity.service"
               ],
-              "resultMetadata" : {
-                "nullÂ¦Operation nameÂ»ReadÂ»falseext:cloud.azure.microsoft_cognitiveservices.accounts.dataout|SUM|TOTAL|LINE|IOT" : {
-                  "lastModified" : 1595344576968,
-                  "customColor" : "#ef651f"
-                }
-              }
+              "sortBy": "DESC",
+              "sortByDimension": "",
+              "filterBy": {
+                "nestedFilters": [],
+                "criteria": []
+              },
+              "limit": 20,
+              "rate": "NONE",
+              "enabled": true
             }
-          }
-        },
-        {
-          "name" : "Custom chart",
-          "tileType" : "CUSTOM_CHARTING",
-          "configured" : true,
-          "bounds" : {
-            "top" : 342,
-            "left" : 380,
-            "width" : 342,
-            "height" : 304
-          },
-          "filterConfig" : {
-            "type" : "MIXED",
-            "customName" : "Blocked calls by service instance",
-            "defaultName" : "Custom chart",
-            "chartConfig" : {
-              "legendShown" : true,
-              "type" : "TOP_LIST",
-              "series" : [
+          ],
+          "visualConfig": {
+            "type": "STACKED_AREA",
+            "global": {
+              "hideLegend": false
+            },
+            "rules": [
+              {
+                "matcher": "A:",
+                "properties": {
+                  "color": "DEFAULT"
+                },
+                "seriesOverrides": []
+              },
+              {
+                "matcher": "B:",
+                "properties": {
+                  "color": "DEFAULT"
+                },
+                "seriesOverrides": []
+              },
+              {
+                "matcher": "C:",
+                "properties": {
+                  "color": "DEFAULT"
+                },
+                "seriesOverrides": []
+              }
+            ],
+            "axes": {
+              "xAxis": {
+                "displayName": "",
+                "visible": true
+              },
+              "yAxes": [
                 {
-                  "metric" : "ext:cloud.azure.microsoft_cognitiveservices.accounts.blockedcalls",
-                  "aggregation" : "SUM",
-                  "type" : "LINE",
-                  "entityType" : "IOT",
-                  "dimensions" : [
-                    {
-                      "id" : "0",
-                      "name" : "dt.entity.custom_device",
-                      "values" : [],
-                      "entityDimension" : true
-                    }
+                  "displayName": "",
+                  "visible": true,
+                  "min": "AUTO",
+                  "max": "AUTO",
+                  "position": "LEFT",
+                  "queryIds": [
+                    "A",
+                    "B",
+                    "C"
                   ],
-                  "sortColumn" : true,
-                  "aggregationRate" : "TOTAL"
+                  "defaultAxis": true
                 }
               ]
+            },
+            "heatmapSettings": {
+              "yAxis": "VALUE"
+            },
+            "singleValueSettings": {
+              "showSparkLine": true
+            },
+            "thresholds": [
+              {
+                "axisTarget": "LEFT",
+                "rules": [
+                  {
+                    "color": "#7dc540"
+                  },
+                  {
+                    "color": "#f5d30f"
+                  },
+                  {
+                    "color": "#dc172a"
+                  }
+                ],
+                "visible": true
+              }
+            ],
+            "tableSettings": {
+              "hiddenColumns": []
+            },
+            "graphChartSettings": {
+              "connectNulls": false
+            },
+            "honeycombSettings": {
+              "showHive": true,
+              "showLegend": true,
+              "showLabels": false
             }
-          }
+          },
+          "queriesSettings": {
+            "resolution": ""
+          },
+          "metricExpressions": [
+            "resolution=null&(builtin:service.errors.total.successCount:splitBy(\"dt.entity.service\"):sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:service.errors.fourxx.successCount:splitBy(\"dt.entity.service\"):sum:sort(value(sum,descending)):limit(20)):limit(100):names,(builtin:service.errors.fivexx.successCount:splitBy(\"dt.entity.service\"):sum:sort(value(sum,descending)):limit(20)):limit(100):names"
+          ]
         },
         {
-          "name" : "Performance ",
-          "tileType" : "HEADER",
-          "configured" : true,
-          "bounds" : {
-            "top" : 0,
-            "left" : 38,
-            "width" : 1026,
-            "height" : 38
-          }
+          "name": "Total errors",
+          "tileType": "DATA_EXPLORER",
+          "configured": true,
+          "bounds": {
+            "top": 38,
+            "left": 380,
+            "width": 342,
+            "height": 304
+          },
+          "tileFilter": {},
+          "isAutoRefreshDisabled": true,
+          "customName": "Total errors",
+          "queries": [
+            {
+              "id": "A",
+              "metric": "builtin:service.errors.total.count",
+              "spaceAggregation": "SUM",
+              "timeAggregation": "DEFAULT",
+              "splitBy": [],
+              "sortBy": "DESC",
+              "sortByDimension": "",
+              "filterBy": {
+                "nestedFilters": [],
+                "criteria": []
+              },
+              "limit": 20,
+              "rate": "NONE",
+              "enabled": true
+            }
+          ],
+          "visualConfig": {
+            "type": "SINGLE_VALUE",
+            "global": {
+              "hideLegend": false
+            },
+            "rules": [
+              {
+                "matcher": "A:",
+                "properties": {
+                  "color": "DEFAULT"
+                },
+                "seriesOverrides": []
+              }
+            ],
+            "axes": {
+              "xAxis": {
+                "visible": true
+              },
+              "yAxes": []
+            },
+            "heatmapSettings": {
+              "yAxis": "VALUE"
+            },
+            "singleValueSettings": {
+              "showTrend": false,
+              "showSparkLine": true,
+              "linkTileColorToThreshold": false
+            },
+            "thresholds": [
+              {
+                "axisTarget": "LEFT",
+                "rules": [
+                  {
+                    "color": "#7dc540"
+                  },
+                  {
+                    "color": "#f5d30f"
+                  },
+                  {
+                    "color": "#dc172a"
+                  }
+                ],
+                "visible": true
+              }
+            ],
+            "tableSettings": {
+              "hiddenColumns": []
+            },
+            "graphChartSettings": {
+              "connectNulls": false
+            },
+            "honeycombSettings": {
+              "showHive": true,
+              "showLegend": true,
+              "showLabels": false
+            }
+          },
+          "queriesSettings": {
+            "resolution": ""
+          },
+          "metricExpressions": [
+            "resolution=Inf&(builtin:service.errors.total.count:splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
+            "resolution=null&(builtin:service.errors.total.count:splitBy():sum:sort(value(sum,descending)):limit(20))"
+          ]
         },
         {
-          "name" : "Data volume",
-          "tileType" : "HEADER",
-          "configured" : true,
-          "bounds" : {
-            "top" : 0,
-            "left" : 1064,
-            "width" : 342,
-            "height" : 38
-          }
+          "name": "Client side errors",
+          "tileType": "DATA_EXPLORER",
+          "configured": true,
+          "bounds": {
+            "top": 38,
+            "left": 722,
+            "width": 342,
+            "height": 304
+          },
+          "tileFilter": {},
+          "isAutoRefreshDisabled": true,
+          "customName": "Client & server errors by operation",
+          "queries": [
+            {
+              "id": "A",
+              "metric": "builtin:service.errors.client.count",
+              "spaceAggregation": "SUM",
+              "timeAggregation": "DEFAULT",
+              "splitBy": [],
+              "sortBy": "DESC",
+              "sortByDimension": "",
+              "filterBy": {
+                "nestedFilters": [],
+                "criteria": []
+              },
+              "limit": 20,
+              "rate": "NONE",
+              "enabled": true
+            }
+          ],
+          "visualConfig": {
+            "type": "SINGLE_VALUE",
+            "global": {
+              "hideLegend": false
+            },
+            "rules": [
+              {
+                "matcher": "A:",
+                "properties": {
+                  "color": "DEFAULT"
+                },
+                "seriesOverrides": []
+              }
+            ],
+            "axes": {
+              "xAxis": {
+                "visible": true
+              },
+              "yAxes": []
+            },
+            "heatmapSettings": {
+              "yAxis": "VALUE"
+            },
+            "singleValueSettings": {
+              "showSparkLine": true
+            },
+            "thresholds": [
+              {
+                "axisTarget": "LEFT",
+                "rules": [
+                  {
+                    "color": "#7dc540"
+                  },
+                  {
+                    "color": "#f5d30f"
+                  },
+                  {
+                    "color": "#dc172a"
+                  }
+                ],
+                "visible": true
+              }
+            ],
+            "tableSettings": {
+              "hiddenColumns": []
+            },
+            "graphChartSettings": {
+              "connectNulls": false
+            },
+            "honeycombSettings": {
+              "showHive": true,
+              "showLegend": true,
+              "showLabels": false
+            }
+          },
+          "queriesSettings": {
+            "resolution": ""
+          },
+          "metricExpressions": [
+            "resolution=Inf&(builtin:service.errors.client.count:splitBy():sum:sort(value(sum,descending)):limit(20)):limit(100):names",
+            "resolution=null&(builtin:service.errors.client.count:splitBy():sum:sort(value(sum,descending)):limit(20))"
+          ]
         }
       ]
-  })
+    }
+  )
 }

--- a/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-a.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-a.tf
@@ -1,7 +1,11 @@
-resource "dynatrace_calculated_mobile_metric" "#name#" {
+data "dynatrace_mobile_application" "application" {
+  name = "Application"
+}
+
+resource "dynatrace_calculated_mobile_metric" "metric" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "MOBILE_APPLICATION-7F6AE72450E14F11"
+  app_identifier = data.dynatrace_mobile_application.application.id
   metric_key     = "calc:apps.mobile.#name#"
   metric_type    = "USER_ACTION_DURATION"
   dimensions {

--- a/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-b.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-b.tf
@@ -1,7 +1,11 @@
-resource "dynatrace_calculated_mobile_metric" "#name#" {
+data "dynatrace_mobile_application" "application" {
+  name = "Application"
+}
+
+resource "dynatrace_calculated_mobile_metric" "metric" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "MOBILE_APPLICATION-7F6AE72450E14F11"
+  app_identifier = data.dynatrace_mobile_application.application.id
   metric_key     = "calc:apps.mobile.#name#"
   metric_type    = "USER_ACTION_DURATION"
   dimensions {

--- a/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-c.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-c.tf
@@ -1,7 +1,11 @@
-resource "dynatrace_calculated_mobile_metric" "#name#" {
+data "dynatrace_mobile_application" "application" {
+  name = "Application"
+}
+
+resource "dynatrace_calculated_mobile_metric" "metric" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "MOBILE_APPLICATION-7F6AE72450E14F11"
+  app_identifier = data.dynatrace_mobile_application.application.id
   metric_key     = "calc:apps.mobile.#name#"
   metric_type    = "USER_ACTION_DURATION"
   dimensions {

--- a/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-d.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-d.tf
@@ -1,7 +1,11 @@
-resource "dynatrace_calculated_mobile_metric" "#name#" {
+data "dynatrace_mobile_application" "application" {
+  name = "Application"
+}
+
+resource "dynatrace_calculated_mobile_metric" "metric" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "MOBILE_APPLICATION-7F6AE72450E14F11"
+  app_identifier = data.dynatrace_mobile_application.application.id
   metric_key     = "calc:apps.mobile.#name#"
   metric_type    = "USER_ACTION_DURATION"
   dimensions {

--- a/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-e.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/mobile/testdata/terraform/example-e.tf
@@ -1,7 +1,11 @@
-resource "dynatrace_calculated_mobile_metric" "#name#" {
+data "dynatrace_mobile_application" "application" {
+  name = "Application"
+}
+
+resource "dynatrace_calculated_mobile_metric" "metric" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "MOBILE_APPLICATION-7F6AE72450E14F11"
+  app_identifier = data.dynatrace_mobile_application.application.id
   metric_key     = "calc:apps.mobile.#name#"
   metric_type    = "USER_ACTION_DURATION"
   dimensions {

--- a/dynatrace/api/v1/config/metrics/calculated/service/service_test.go
+++ b/dynatrace/api/v1/config/metrics/calculated/service/service_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccCalculatedServiceMetrics(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAccParallel(t, api.TestAccOptions{ExternalProviders: map[string]resource.ExternalProvider{"time": {Source: "hashicorp/time"}}})
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_a.tf
@@ -1,7 +1,52 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_request_attribute" "attribute" {
+  name         = "#name#"
+  enabled      = true
+  aggregation  = "FIRST"
+  confidential = false
+
+  data_type                  = "INTEGER"
+  normalization              = "ORIGINAL"
+  skip_personal_data_masking = false
+  data_sources {
+    enabled = true
+    source = "SERVER_VARIABLE"
+    server_variable_technology = "ASP_NET"
+    parameter_name             = "param"
+  }
+}
+
+resource "dynatrace_management_zone_v2" "mzone" {
+  name = "#name#"
+  rules {
+    rule {
+      type            = "ME"
+      enabled         = true
+      entity_selector = ""
+      attribute_rule {
+        entity_type = "CLOUD_APPLICATION_NAMESPACE"
+        attribute_conditions {
+          condition {
+            case_sensitive = false
+            key            = "KUBERNETES_CLUSTER_NAME"
+            operator       = "EQUALS"
+            string_value   = "extensions"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "time_sleep" "wait_for_request_attribute" {
+  depends_on = [dynatrace_request_attribute.attribute]
+  create_duration = "10s"
+}
+
+resource "dynatrace_calculated_service_metric" "metric" {
+  depends_on = [time_sleep.wait_for_request_attribute]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -18,6 +63,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_b.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_b.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_b" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -18,6 +19,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_c.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_c.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_c" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -18,6 +19,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_d.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_d.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_d" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -19,6 +20,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_e.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_e.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_e" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -18,6 +19,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_f.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_f.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_f" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -18,6 +19,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_g.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_g.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_g" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -18,6 +19,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_h.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_h.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_h" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -18,6 +19,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_i.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_i.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_i" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -25,6 +26,6 @@ resource "dynatrace_calculated_service_metric" "#name#" {
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_j.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_j.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_j" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -31,16 +32,16 @@ resource "dynatrace_calculated_service_metric" "#name#" {
         end_delimiter        = "l"
         kind                 = "BETWEEN_DELIMITER"
         normalization        = "TO_UPPER_CASE"
-        request_attribute    = "Accept-Ranges"
+        request_attribute    = dynatrace_request_attribute.accept_ranges.name
         use_from_child_calls = true
         source {
-          management_zone = "AAAA"
+          management_zone = dynatrace_management_zone_v2.mzone.name
         }
       }
     }
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_k.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_k.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_k" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -40,16 +41,16 @@ resource "dynatrace_calculated_service_metric" "#name#" {
         end_delimiter        = "l"
         kind                 = "BETWEEN_DELIMITER"
         normalization        = "TO_UPPER_CASE"
-        request_attribute    = "Accept-Ranges"
+        request_attribute    = dynatrace_request_attribute.accept_ranges.name
         use_from_child_calls = true
         source {
-          management_zone = "AAAA"
+          management_zone = dynatrace_management_zone_v2.mzone.name
         }
       }
     }
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_l.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_l.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_l" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -13,7 +14,7 @@ resource "dynatrace_calculated_service_metric" "#name#" {
           case_sensitive       = true
           match_on_child_calls = false
           operator             = "BEGINS_WITH"
-          request_attribute    = "BehaviorClass"
+          request_attribute    = dynatrace_request_attribute.behavior_class.name
           value                = "\"kk"
         }
       }
@@ -34,16 +35,16 @@ resource "dynatrace_calculated_service_metric" "#name#" {
         end_delimiter        = "l"
         kind                 = "BETWEEN_DELIMITER"
         normalization        = "TO_UPPER_CASE"
-        request_attribute    = "Accept-Ranges"
+        request_attribute    = dynatrace_request_attribute.accept_ranges.name
         use_from_child_calls = true
         source {
-          management_zone = "AAAA"
+          management_zone = dynatrace_management_zone_v2.mzone.name
         }
       }
     }
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_m.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_m.tf
@@ -1,7 +1,8 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_m" {
+  depends_on = [time_sleep.wait_for_request_attributes]
   name             = "#name#"
   enabled          = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key       = "calc:service.#name#"
   unit             = "MILLI_SECOND_PER_MINUTE"
   conditions {
@@ -32,17 +33,17 @@ resource "dynatrace_calculated_service_metric" "#name#" {
         end_delimiter        = "l"
         kind                 = "BETWEEN_DELIMITER"
         normalization        = "TO_UPPER_CASE"
-        request_attribute    = "Accept-Ranges"
+        request_attribute    = dynatrace_request_attribute.accept_ranges.name
         use_from_child_calls = true
         source {
-          management_zone = "AAAA"
+          management_zone = dynatrace_management_zone_v2.mzone.name
         }
       }
     }
   }
   metric_definition {
     metric            = "REQUEST_ATTRIBUTE"
-    request_attribute = "foo"
+    request_attribute = dynatrace_request_attribute.attribute.name
   }
   ignore_muted_requests = true
 }

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_n.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_n.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_calculated_service_metric" "#name#" {
+resource "dynatrace_calculated_service_metric" "metric_n" {
   name = "#name#"
   enabled = true
-  management_zones = ["AAAA"]
+  management_zones = [dynatrace_management_zone_v2.mzone.name]
   metric_key = "calc:service.#name#"
   unit = "MICRO_SECOND"
   conditions {

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/request_attributes.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/request_attributes.tf
@@ -1,0 +1,63 @@
+resource "dynatrace_request_attribute" "accept_ranges" {
+  name         = "Accept-Ranges-#name#"
+  enabled      = true
+  aggregation  = "FIRST"
+  confidential = false
+
+  data_type                  = "STRING"
+  normalization              = "ORIGINAL"
+  skip_personal_data_masking = false
+  data_sources {
+    enabled = true
+    source = "RESPONSE_HEADER"
+    parameter_name                 = "Accept-Ranges"
+    capturing_and_storage_location = "CAPTURE_ON_CLIENT_STORE_ON_SERVER"
+  }
+}
+
+resource "dynatrace_request_attribute" "behavior_class" {
+  name = "BehaviorClass-#name#"
+  enabled = true
+  aggregation = "FIRST"
+  confidential = false
+  normalization = "ORIGINAL"
+  skip_personal_data_masking = false
+  data_type = "STRING"
+  data_sources {
+    enabled = false
+    source  = "METHOD_PARAM"
+    technology = "DOTNET"
+    value_processing {
+      value_condition {
+        operator = "ENDS_WITH"
+        negate   = false
+        value    = "gh"
+      }
+      value_extractor_regex = "s(.*+)"
+      split_at              = "t"
+      trim                  = true
+      extract_substring {
+        position  = "BEFORE"
+        delimiter = "h"
+      }
+    }
+    methods {
+      capture = "CLASS_NAME"
+      method {
+        visibility = "PUBLIC"
+        class_name = "NServiceBus.Pipeline.Behavior`1"
+        method_name = "Invoke"
+        argument_types = [
+          "!0",
+          "System.Func`1<System.Threading.Tasks.Task>"
+        ]
+        return_type = "System.Threading.Tasks.Task"
+      }
+    }
+  }
+}
+
+resource "time_sleep" "wait_for_request_attributes" {
+  depends_on = [dynatrace_request_attribute.attribute, dynatrace_request_attribute.accept_ranges, dynatrace_request_attribute.behavior_class]
+  create_duration = "10s"
+}

--- a/dynatrace/api/v1/config/metrics/calculated/synthetic/service_test.go
+++ b/dynatrace/api/v1/config/metrics/calculated/synthetic/service_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestAccCalculatedSyntheticMetrics(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAccParallel(t)
 }

--- a/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-a.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-a.tf
@@ -1,7 +1,53 @@
-resource "dynatrace_calculated_synthetic_metric" "#name#" {
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
+resource "dynatrace_browser_monitor" "monitor" {
+  name                   = "#name#"
+  frequency              = 15
+  locations              = [data.dynatrace_synthetic_location.location.id]
+  key_performance_metrics {
+    load_action_kpm = "VISUALLY_COMPLETE"
+    xhr_action_kpm  = "VISUALLY_COMPLETE"
+  }
+  anomaly_detection {
+    loading_time_thresholds {
+      enabled = false
+    }
+    outage_handling {
+      global_outage = true
+      local_outage = false
+      retry_on_error = true
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  script {
+    type = "clickpath"
+    configuration {
+      bypass_csp = true
+      user_agent = "Mozilla"
+      device {
+        name        = "Desktop"
+        orientation = "landscape"
+      }
+    }
+    events {
+      event {
+        description = "my description"
+        navigate {
+          url = "https://www.example.com"
+        }
+      }
+    }
+  }
+}
+
+resource "dynatrace_calculated_synthetic_metric" "metric" {
   name               = "#name#"
   enabled            = true
   metric             = "ResourceCount"
   metric_key         = "calc:synthetic.browser.#name#"
-  monitor_identifier = "SYNTHETIC_TEST-147CFF44DDB25C05"
+  monitor_identifier = dynatrace_browser_monitor.monitor.id
 }

--- a/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-b.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-b.tf
@@ -1,8 +1,7 @@
-# ID calc:synthetic.browser.easytravelbooknow.javascripterrors
-resource "dynatrace_calculated_synthetic_metric" "#name#" {
+resource "dynatrace_calculated_synthetic_metric" "metric_b" {
   name               = "#name#"
   enabled            = true
   metric             = "JavaScriptErrors"
   metric_key         = "calc:synthetic.browser.#name#"
-  monitor_identifier = "SYNTHETIC_TEST-147CFF44DDB25C05"
+  monitor_identifier = dynatrace_browser_monitor.monitor.id
 }

--- a/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-c.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-c.tf
@@ -1,8 +1,7 @@
-# ID calc:synthetic.browser.easytravelbooknow.httperrors
-resource "dynatrace_calculated_synthetic_metric" "#name#" {
+resource "dynatrace_calculated_synthetic_metric" "metric_c" {
   name               = "#name#"
   enabled            = true
   metric             = "HttpErrors"
   metric_key         = "calc:synthetic.browser.#name#"
-  monitor_identifier = "SYNTHETIC_TEST-147CFF44DDB25C05"
+  monitor_identifier = dynatrace_browser_monitor.monitor.id
 }

--- a/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-d.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-d.tf
@@ -1,10 +1,9 @@
-# ID calc:synthetic.browser.targethomepageco.htmldownloaded_responseend_splitbygeolocation
-resource "dynatrace_calculated_synthetic_metric" "#name#" {
+resource "dynatrace_calculated_synthetic_metric" "metric_d" {
   name               = "#name#"
   enabled            = true
   metric             = "HTMLDownloaded"
   metric_key         = "calc:synthetic.browser.#name#"
-  monitor_identifier = "SYNTHETIC_TEST-147CFF44DDB25C05"
+  monitor_identifier = dynatrace_browser_monitor.monitor.id
   dimensions {
     dimension {
       dimension = "Location"

--- a/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-e.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/synthetic/testdata/terraform/example-e.tf
@@ -1,10 +1,9 @@
-# ID calc:synthetic.browser.easytravelbooknow.domcompletesplitbygeolocation
-resource "dynatrace_calculated_synthetic_metric" "#name#" {
+resource "dynatrace_calculated_synthetic_metric" "metric_e" {
   name               = "#name#"
   enabled            = true
   metric             = "DOMComplete"
   metric_key         = "calc:synthetic.browser.#name#"
-  monitor_identifier = "SYNTHETIC_TEST-147CFF44DDB25C05"
+  monitor_identifier = dynatrace_browser_monitor.monitor.id
   dimensions {
     dimension {
       dimension = "Location"

--- a/dynatrace/api/v1/config/metrics/calculated/web/service_test.go
+++ b/dynatrace/api/v1/config/metrics/calculated/web/service_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestAccCalculatedWebMetrics(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAccParallel(t)
 }

--- a/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-a.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-a.tf
@@ -1,7 +1,74 @@
-resource "dynatrace_calculated_web_metric" "#name#" {
+data "dynatrace_synthetic_location" "location" {
+  type           = "PUBLIC"
+  name           = "Sydney"
+}
+
+resource "dynatrace_web_application" "application" {
+  name                                 = "#name#"
+  type                                 = "AUTO_INJECTED"
+  cost_control_user_session_percentage = 100
+  load_action_key_performance_metric   = "VISUALLY_COMPLETE"
+  real_user_monitoring_enabled         = true
+  xhr_action_key_performance_metric    = "VISUALLY_COMPLETE"
+  custom_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  load_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  monitoring_settings {
+    add_cross_origin_anonymous_attribute = true
+    cache_control_header_optimizations   = true
+    injection_mode = "JAVASCRIPT_TAG"
+    script_tag_cache_duration_in_hours = 1
+    advanced_javascript_tag_settings {
+      max_action_name_length = 100
+      max_errors_to_capture  = 10
+      additional_event_handlers {
+        max_dom_nodes = 5000
+      }
+    }
+    content_capture {
+      resource_timing_settings {
+        instrumentation_delay    = 53
+        non_w3c_resource_timings = true
+        w3c_resource_timings     = true
+      }
+      timeout_settings {
+        temporary_action_limit         = 3
+        temporary_action_total_timeout = 100
+        timed_action_support           = true
+      }
+    }
+  }
+  user_action_naming_settings {}
+  waterfall_settings {
+    resource_browser_caching_threshold            = 50
+    resources_threshold                           = 100000
+    slow_cnd_resources_threshold                  = 200000
+    slow_first_party_resources_threshold          = 200000
+    slow_third_party_resources_threshold          = 200000
+    speed_index_visually_complete_ratio_threshold = 50
+    uncompressed_resources_threshold              = 860
+  }
+  xhr_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+}
+
+resource "dynatrace_calculated_web_metric" "metric" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "APPLICATION-EA7C4B59F27D43EB"
+  app_identifier = dynatrace_web_application.application.id
   metric_key     = "calc:apps.web.#name#"
   dimensions {
     dimension {
@@ -14,7 +81,7 @@ resource "dynatrace_calculated_web_metric" "#name#" {
     metric = "VisuallyComplete"
   }
   user_action_filter {
-    continent                         = "GEOLOCATION-970B6D0A98F55995"
+    continent                         = data.dynatrace_synthetic_location.location.geo_location_id
     target_view_group_name_match_type = "Equals"
     target_view_name_match_type       = "Equals"
   }

--- a/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-b.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-b.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_calculated_web_metric" "#name#" {
+resource "dynatrace_calculated_web_metric" "apdex" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "APPLICATION-EA7C4B59F27D43EB"
+  app_identifier = dynatrace_web_application.application.id
   metric_key     = "calc:apps.web.#name#"
   metric_definition {
     metric = "Apdex"

--- a/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-c.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-c.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_calculated_web_metric" "#name#" {
+resource "dynatrace_calculated_web_metric" "user_action_duration" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "APPLICATION-EA7C4B59F27D43EB"
+  app_identifier = dynatrace_web_application.application.id
   metric_key     = "calc:apps.web.#name#"
   metric_definition {
     metric = "UserActionDuration"

--- a/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-d.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-d.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_calculated_web_metric" "#name#" {
+resource "dynatrace_calculated_web_metric" "application_cache" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "APPLICATION-EA7C4B59F27D43EB"
+  app_identifier = dynatrace_web_application.application.id
   metric_key     = "calc:apps.web.#name#"
   metric_definition {
     metric = "ApplicationCache"

--- a/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-e.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-e.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_calculated_web_metric" "#name#" {
+resource "dynatrace_calculated_web_metric" "error_count" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "APPLICATION-EA7C4B59F27D43EB"
+  app_identifier = dynatrace_web_application.application.id
   metric_key     = "calc:apps.web.#name#"
   metric_definition {
     metric = "ErrorCount"

--- a/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-f.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-f.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_calculated_web_metric" "#name#" {
+resource "dynatrace_calculated_web_metric" "dimensions" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "APPLICATION-EA7C4B59F27D43EB"
+  app_identifier = dynatrace_web_application.application.id
   metric_key     = "calc:apps.web.#name#"
   dimensions {
     dimension {

--- a/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-g.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-g.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_calculated_web_metric" "#name#" {
+resource "dynatrace_calculated_web_metric" "user_action_properties" {
   name           = "#name#"
   enabled        = true
-  app_identifier = "APPLICATION-EA7C4B59F27D43EB"
+  app_identifier = dynatrace_web_application.application.id
   metric_key     = "calc:apps.web.#name#"
   dimensions {
     dimension {
@@ -14,7 +14,7 @@ resource "dynatrace_calculated_web_metric" "#name#" {
     metric = "VisuallyComplete"
   }
   user_action_filter {
-    continent                         = "GEOLOCATION-970B6D0A98F55995"
+    continent                         = data.dynatrace_synthetic_location.location.geo_location_id
     target_view_group_name_match_type = "Equals"
     target_view_name_match_type       = "Equals"
     user_action_properties {

--- a/dynatrace/api/v1/config/reports/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/reports/testdata/terraform/example_a.tf
@@ -1,6 +1,17 @@
-resource "dynatrace_report" "#name#" {
+resource "dynatrace_dashboard" "dashboard" {
+  dashboard_metadata {
+    name   = "#name#"
+    owner  = "Dynatrace"
+  }
+  tile {
+    name      = "my tile"
+    tile_type = "HOST"
+  }
+}
+
+resource "dynatrace_report" "report" {
   type                = "DASHBOARD"
-  dashboard_id        = "41eae96d-4930-4f44-bbd8-3699f21a8bbf"
+  dashboard_id        = dynatrace_dashboard.dashboard.id
   email_notifications = true
   subscriptions {
     month = ["terraform1@dynatrace.com", "terraform2@dynatrace.com"]

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/service_test.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/service_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccBrowserMonitors(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAcc(t, api.TestAccOptions{ExternalProviders: map[string]resource.ExternalProvider{"time": {Source: "hashicorp/time"}}})
 }

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/testdata/terraform/example_a.tf
@@ -1,8 +1,95 @@
-resource "dynatrace_browser_monitor" "#name#" {
+resource "dynatrace_synthetic_location" "location" {
+  name                                  = "#name#"
+  city                                  = "San Francisco de Asis"
+  country_code                          = "VE"
+  region_code                           = "04"
+  deployment_type                       = "STANDARD"
+  latitude                              = 10.0756
+  location_node_outage_delay_in_minutes = 3
+  longitude                             = -67.5442
+}
+
+resource "dynatrace_web_application" "application" {
+  name                                 = "#name#"
+  type                                 = "AUTO_INJECTED"
+  cost_control_user_session_percentage = 100
+  load_action_key_performance_metric   = "VISUALLY_COMPLETE"
+  real_user_monitoring_enabled         = true
+  xhr_action_key_performance_metric    = "VISUALLY_COMPLETE"
+  custom_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  load_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  monitoring_settings {
+    add_cross_origin_anonymous_attribute = true
+    cache_control_header_optimizations   = true
+    injection_mode = "JAVASCRIPT_TAG"
+    script_tag_cache_duration_in_hours = 1
+    advanced_javascript_tag_settings {
+      max_action_name_length = 100
+      max_errors_to_capture  = 10
+      additional_event_handlers {
+        max_dom_nodes = 5000
+      }
+    }
+    content_capture {
+      resource_timing_settings {
+        instrumentation_delay    = 53
+        non_w3c_resource_timings = true
+        w3c_resource_timings     = true
+      }
+      timeout_settings {
+        temporary_action_limit         = 3
+        temporary_action_total_timeout = 100
+        timed_action_support           = true
+      }
+    }
+  }
+  user_action_naming_settings {}
+  waterfall_settings {
+    resource_browser_caching_threshold            = 50
+    resources_threshold                           = 100000
+    slow_cnd_resources_threshold                  = 200000
+    slow_first_party_resources_threshold          = 200000
+    slow_third_party_resources_threshold          = 200000
+    speed_index_visually_complete_ratio_threshold = 50
+    uncompressed_resources_threshold              = 860
+  }
+  xhr_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+}
+
+resource "dynatrace_credentials" "credentials_vault" {
+  name        = "#name#"
+  description = "my credentials vault"
+  scopes      = ["SYNTHETIC"]
+  username = "username"
+  password = "password"
+}
+
+resource "time_sleep" "wait_5_seconds" {
+  depends_on = [dynatrace_synthetic_location.location, dynatrace_web_application.application, dynatrace_credentials.credentials_vault]
+  create_duration = "5s"
+}
+
+resource "dynatrace_browser_monitor" "monitor" {
+  depends_on = [time_sleep.wait_5_seconds]
   name                   = "#name#"
   frequency              = 15
-  locations              = ["GEOLOCATION-B4B9167CAAA88F6A", "GEOLOCATION-03E96F97A389F96A"]
-  manually_assigned_apps = ["APPLICATION-EA7C4B59F27D43EB"]
+  locations              = [dynatrace_synthetic_location.location.id]
+  manually_assigned_apps = [dynatrace_web_application.application.id]
   anomaly_detection {
     loading_time_thresholds {
       enabled = true
@@ -54,12 +141,12 @@ resource "dynatrace_browser_monitor" "#name#" {
     }
     events {
       event {
-        description = "Loading of \"https://www.orf.at\""
+        description = "Loading of \"https://example.com\""
         navigate {
-          url = "https://www.orf.at"
+          url = "https://example.com"
           authentication {
             type  = "http_authentication"
-            creds = "CREDENTIALS_VAULT-26F62024BC3ABBCF"
+            creds = dynatrace_credentials.credentials_vault.id
           }
           wait {
             wait_for = "page_complete"
@@ -69,10 +156,10 @@ resource "dynatrace_browser_monitor" "#name#" {
       event {
         description = "jhjhjh"
         navigate {
-          url = "https://www.orf.at"
+          url = "https://example.com"
           authentication {
             type  = "http_authentication"
-            creds = "CREDENTIALS_VAULT-26F62024BC3ABBCF"
+            creds = dynatrace_credentials.credentials_vault.id
           }
           validate {
             validation {

--- a/dynatrace/api/v1/config/synthetic/monitors/http/script/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/script/testdata/terraform/example_a.tf
@@ -1,29 +1,11 @@
-resource "dynatrace_http_monitor_script" "#name#" {
-  http_id = "${dynatrace_http_monitor.monitor.id}"
-  script {
-    request {
-      description     = "request1"
-      method          = "GET"
-      url             = "http://httpstat.us/200"
-      configuration {
-        accept_any_certificate = true
-      }
-    }
-    request {
-      description     = "request2"
-      method          = "GET"
-      url             = "http://httpstat.us/400"
-      configuration {
-        accept_any_certificate = true
-      }
-    }
-  }
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
 }
 
 resource "dynatrace_http_monitor" "monitor" {
   name      = "#name#"
   frequency = 1
-  locations = ["GEOLOCATION-F3E06A526BE3B4C4"]
+  locations = [data.dynatrace_synthetic_location.location.id]
   anomaly_detection {
     loading_time_thresholds {
     }
@@ -35,4 +17,26 @@ resource "dynatrace_http_monitor" "monitor" {
     }
   }
   no_script = true
+}
+
+resource "dynatrace_http_monitor_script" "script" {
+  http_id = dynatrace_http_monitor.monitor.id
+  script {
+    request {
+      description     = "request1"
+      method          = "GET"
+      url             = "https://example.com"
+      configuration {
+        accept_any_certificate = true
+      }
+    }
+    request {
+      description     = "request2"
+      method          = "GET"
+      url             = "https://example.com"
+      configuration {
+        accept_any_certificate = true
+      }
+    }
+  }
 }

--- a/dynatrace/api/v1/config/synthetic/monitors/http/service_test.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service_test.go
@@ -23,8 +23,11 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccHTTPMonitors(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAcc(t, api.TestAccOptions{ExternalProviders: map[string]resource.ExternalProvider{
+		"time": {Source: "hashicorp/time"},
+	}})
 }

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_a.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_a.tf
@@ -1,7 +1,31 @@
-resource "dynatrace_http_monitor" "#name#" {
+resource "dynatrace_synthetic_location" "location" {
+  name                                  = "#name#"
+  city                                  = "San Francisco de Asis"
+  country_code                          = "VE"
+  region_code                           = "04"
+  deployment_type                       = "STANDARD"
+  latitude                              = 10.0756
+  location_node_outage_delay_in_minutes = 3
+  longitude                             = -67.5442
+}
+
+resource "dynatrace_credentials" "credentials_vault" {
+  name        = "#name#"
+  description = "my credentials vault"
+  scopes      = ["SYNTHETIC"]
+  token = "my-token"
+}
+
+resource "time_sleep" "wait_5_seconds" {
+  depends_on = [dynatrace_synthetic_location.location]
+  create_duration = "5s"
+}
+
+resource "dynatrace_http_monitor" "monitor" {
+  depends_on = [time_sleep.wait_5_seconds]
   name      = "#name#"
   frequency = 1
-  locations = ["GEOLOCATION-F3E06A526BE3B4C4"]
+  locations = [dynatrace_synthetic_location.location.id]
   anomaly_detection {
     loading_time_thresholds {
     }
@@ -71,7 +95,7 @@ resource "dynatrace_http_monitor" "#name#" {
         headers {
           header {
             name  = "Authorization"
-            value = "Bearer {CREDENTIALS_VAULT-93C49382ACCA047B|token}"
+            value = "Bearer {${dynatrace_credentials.credentials_vault.id}|token}"
           }
           header {
             name  = "Accept"
@@ -134,7 +158,7 @@ resource "dynatrace_http_monitor" "#name#" {
         headers {
           header {
             name  = "Authorization"
-            value = "Bearer {CREDENTIALS_VAULT-93C49382ACCA047B|token}"
+            value = "Bearer {${dynatrace_credentials.credentials_vault.id}|token}"
           }
         }
       }
@@ -192,7 +216,7 @@ resource "dynatrace_http_monitor" "#name#" {
         headers {
           header {
             name  = "Authorization"
-            value = "Bearer {CREDENTIALS_VAULT-93C49382ACCA047B|token}"
+            value = "Bearer {${dynatrace_credentials.credentials_vault.id}|token}"
           }
         }
       }
@@ -252,7 +276,7 @@ resource "dynatrace_http_monitor" "#name#" {
         headers {
           header {
             name  = "Authorization"
-            value = "Bearer {CREDENTIALS_VAULT-93C49382ACCA047B|token}"
+            value = "Bearer {${dynatrace_credentials.credentials_vault.id}|token}"
           }
         }
       }
@@ -312,7 +336,7 @@ resource "dynatrace_http_monitor" "#name#" {
         headers {
           header {
             name  = "Authorization"
-            value = "Bearer {CREDENTIALS_VAULT-93C49382ACCA047B|token}"
+            value = "Bearer {${dynatrace_credentials.credentials_vault.id}|token}"
           }
         }
       }
@@ -354,14 +378,14 @@ resource "dynatrace_http_monitor" "#name#" {
         });
         api.setValue("service_status", payload);
       EOT
-      url             = "https://manage.office.com/api/v1.0/{CREDENTIALS_VAULT-1A8E917381883F54|token}/ServiceComms/CurrentStatus"
+      url             = "https://manage.office.com/api/v1.0/{${dynatrace_credentials.credentials_vault.id}|token}/ServiceComms/CurrentStatus"
       configuration {
         accept_any_certificate = true
         follow_redirects       = true
         headers {
           header {
             name  = "Authorization"
-            value = "Bearer {CREDENTIALS_VAULT-CE4EA27BA94C9061|token}"
+            value = "Bearer {${dynatrace_credentials.credentials_vault.id}|token}"
           }
           header {
             name  = "Accept"
@@ -408,7 +432,7 @@ resource "dynatrace_http_monitor" "#name#" {
           }
           header {
             name  = "Authorization"
-            value = "Api-Token {CREDENTIALS_VAULT-55F1E51535993619|token}"
+            value = "Api-Token {${dynatrace_credentials.credentials_vault.id}|token}"
           }
         }
       }
@@ -420,4 +444,9 @@ resource "dynatrace_http_monitor" "#name#" {
       }
     }
   }
+}
+
+resource "time_sleep" "wait_to_be_consistent" {
+  depends_on = [dynatrace_http_monitor.monitor]
+  create_duration = "10s"
 }

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_a.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_a.tf
@@ -1,12 +1,5 @@
-resource "dynatrace_synthetic_location" "location" {
-  name                                  = "#name#"
-  city                                  = "San Francisco de Asis"
-  country_code                          = "VE"
-  region_code                           = "04"
-  deployment_type                       = "STANDARD"
-  latitude                              = 10.0756
-  location_node_outage_delay_in_minutes = 3
-  longitude                             = -67.5442
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
 }
 
 resource "dynatrace_credentials" "credentials_vault" {
@@ -16,16 +9,10 @@ resource "dynatrace_credentials" "credentials_vault" {
   token = "my-token"
 }
 
-resource "time_sleep" "wait_5_seconds" {
-  depends_on = [dynatrace_synthetic_location.location]
-  create_duration = "5s"
-}
-
 resource "dynatrace_http_monitor" "monitor" {
-  depends_on = [time_sleep.wait_5_seconds]
   name      = "#name#"
   frequency = 1
-  locations = [dynatrace_synthetic_location.location.id]
+  locations = [data.dynatrace_synthetic_location.location.id]
   anomaly_detection {
     loading_time_thresholds {
     }

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_advanced.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_advanced.tf
@@ -1,7 +1,11 @@
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
 resource "dynatrace_http_monitor" "advanced" {
   name      = "#name#"
   frequency = 1
-  locations = ["GEOLOCATION-F3E06A526BE3B4C4"]
+  locations = [data.dynatrace_synthetic_location.location.id]
   anomaly_detection {
     loading_time_thresholds {
     }

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_b.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_b.tf
@@ -1,12 +1,5 @@
-resource "dynatrace_synthetic_location" "location" {
-  name                                  = "#name#"
-  city                                  = "San Francisco de Asis"
-  country_code                          = "VE"
-  region_code                           = "04"
-  deployment_type                       = "STANDARD"
-  latitude                              = 10.0756
-  location_node_outage_delay_in_minutes = 3
-  longitude                             = -67.5442
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
 }
 
 resource "dynatrace_credentials" "credentials_vault" {
@@ -17,16 +10,10 @@ resource "dynatrace_credentials" "credentials_vault" {
   password = "password"
 }
 
-resource "time_sleep" "wait_5_seconds" {
-  depends_on = [dynatrace_synthetic_location.location]
-  create_duration = "5s"
-}
-
 resource "dynatrace_http_monitor" "monitor" {
-  depends_on = [time_sleep.wait_5_seconds]
   name = "#name#"
   frequency = 1
-  locations = [dynatrace_synthetic_location.location.id]
+  locations = [data.dynatrace_synthetic_location.location.id]
   anomaly_detection {
     loading_time_thresholds {
     }

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_b.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_b.tf
@@ -1,7 +1,32 @@
-resource "dynatrace_http_monitor" "#name#" {
+resource "dynatrace_synthetic_location" "location" {
+  name                                  = "#name#"
+  city                                  = "San Francisco de Asis"
+  country_code                          = "VE"
+  region_code                           = "04"
+  deployment_type                       = "STANDARD"
+  latitude                              = 10.0756
+  location_node_outage_delay_in_minutes = 3
+  longitude                             = -67.5442
+}
+
+resource "dynatrace_credentials" "credentials_vault" {
+  name        = "#name#"
+  description = "my credentials vault"
+  scopes      = ["SYNTHETIC"]
+  username = "username"
+  password = "password"
+}
+
+resource "time_sleep" "wait_5_seconds" {
+  depends_on = [dynatrace_synthetic_location.location]
+  create_duration = "5s"
+}
+
+resource "dynatrace_http_monitor" "monitor" {
+  depends_on = [time_sleep.wait_5_seconds]
   name = "#name#"
   frequency = 1
-  locations = ["GEOLOCATION-03E96F97A389F96A","GEOLOCATION-9999453BE4BDB3CD","GEOLOCATION-2FD31C834DE4D601","GEOLOCATION-924D253001531722","GEOLOCATION-7F39AED31559436D","GEOLOCATION-DDAA176627F5667A"]
+  locations = [dynatrace_synthetic_location.location.id]
   anomaly_detection {
     loading_time_thresholds {
     }
@@ -22,7 +47,7 @@ resource "dynatrace_http_monitor" "#name#" {
       }
       authentication {
         type = "KERBEROS"
-        credentials = "CREDENTIALS_VAULT-4DFB50E5F50A21A4"
+        credentials = dynatrace_credentials.credentials_vault.id
         realm_name = "ABCDE"
         kdc_ip = "10.0.0.1"
       }

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -34,6 +34,7 @@ import (
 
 type TestAccOptions struct {
 	ExpectNonEmptyPlan bool
+	ExternalProviders  map[string]resource.ExternalProvider
 }
 
 func AccEnvsGiven(t *testing.T) bool {
@@ -124,6 +125,7 @@ func TestAcc(t *testing.T, opts ...TestAccOptions) {
 
 			testCase := resource.TestCase{
 				ProviderFactories: providerFactories,
+				ExternalProviders: options.ExternalProviders,
 				Steps:             []resource.TestStep{{Config: config, ExpectNonEmptyPlan: options.ExpectNonEmptyPlan}},
 			}
 			resource.Test(t, testCase)

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -97,10 +97,6 @@ func readTestData(t *testing.T) []string {
 }
 
 func TestAcc(t *testing.T, opts ...TestAccOptions) {
-	var options TestAccOptions
-	if len(opts) > 0 {
-		options = opts[0]
-	}
 	t.Helper()
 
 	if !AccEnvsGiven(t) {
@@ -108,12 +104,6 @@ func TestAcc(t *testing.T, opts ...TestAccOptions) {
 	}
 
 	allFiles := readTestData(t)
-
-	providerFactories := map[string]func() (*schema.Provider, error){
-		"dynatrace": func() (*schema.Provider, error) {
-			return provider.Provider(), nil
-		},
-	}
 
 	for _, file := range allFiles {
 		subTestName := strings.TrimPrefix(file, "testdata/")
@@ -123,12 +113,50 @@ func TestAcc(t *testing.T, opts ...TestAccOptions) {
 
 			config, _ := ReadTfConfig(t, file)
 
-			testCase := resource.TestCase{
-				ProviderFactories: providerFactories,
-				ExternalProviders: options.ExternalProviders,
-				Steps:             []resource.TestStep{{Config: config, ExpectNonEmptyPlan: options.ExpectNonEmptyPlan}},
-			}
+			testCase := createTestCaseWithOptions(t, config, opts)
 			resource.Test(t, testCase)
 		})
+	}
+}
+
+// TestAccParallel runs all tests in parallel by concatenating all configs into one and running them together.
+// Make sure that the tests do not interfere with each other, e.g. by using unique names for resources.
+func TestAccParallel(t *testing.T, opts ...TestAccOptions) {
+	t.Helper()
+
+	if !AccEnvsGiven(t) {
+		return
+	}
+
+	allFiles := readTestData(t)
+
+	// concatenate all configs into one, so that they can be run in parallel
+	var configs strings.Builder
+	for _, file := range allFiles {
+		config, _ := ReadTfConfig(t, file)
+		configs.WriteString(config)
+		configs.WriteByte('\n')
+	}
+
+	testCase := createTestCaseWithOptions(t, configs.String(), opts)
+	resource.Test(t, testCase)
+}
+
+func createTestCaseWithOptions(t *testing.T, config string, opts []TestAccOptions) resource.TestCase {
+	t.Helper()
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+	var options TestAccOptions
+	if len(opts) > 0 {
+		options = opts[0]
+	}
+
+	return resource.TestCase{
+		ProviderFactories: providerFactories,
+		ExternalProviders: options.ExternalProviders,
+		Steps:             []resource.TestStep{{Config: config, ExpectNonEmptyPlan: options.ExpectNonEmptyPlan}},
 	}
 }


### PR DESCRIPTION
This is the first PR of multiple. More are incoming later.
This one mostly touches the dependencies of and to V1 resources

#### **Why** this PR?
Some E2E tests (e.g., examples) refer to existing objects (e.g., management zones, request attributes, process groups, etc.). As this can easily break if someone just deletes something in the environment, we need to remove hardcoded IDs and create the needed dependencies on demand.

#### **What** has changed?
E2E tests are more stable. Changes in the environment will less likely cause E2Es to fail.

#### **How** does it do it?
Hardcoded IDs in E2E (examples) are removed, and referenced resources are created via resource or fetched via data source within the example.
This includes
- management zones
- request attributes
- process groups (not fully, but aligned)
- synthetic locations (private ones are created on demand and public ones are referenced via a data source)
- synthetic monitors
- mobile applications
- dashboards
- credentials

For `dynatrace_calculated_web_metric`, I combined the Terraform files. Web applications take longer than 1m30s to create, that's why I decided to join the configs and create them all at once, referring to the same web application

Also changed some payloads.
- json dashboard: The payload used doesn't depend on installed extensions anymore

#### How is it **tested**?
That's literally about tests

#### How does it affect **users**?
They will see better documentation if the touched examples are included. They will now see the correct relation between resources or data sources.

**Issue:** CA-17770


## Additional notes:
There is still one small dependency. Process groups can't be manually created. Also, a data source can't be used, as process groups fade out after 3 days, meaning the OneAgent would have to run continuously. Even though process groups time out, they can still be used and queried via ID. Therefore, the best approach here is to provide the process group ID.

This implementation already relies on the created setup-resources of https://github.com/dynatrace-oss/terraform-provider-dynatrace/pull/986