### PR TITLE
refactor: Centralize environment variables

### DIFF
--- a/datasources/common.go
+++ b/datasources/common.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ package common
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	tagapi "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/topology/tag"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/google/uuid"
 )
 
@@ -67,7 +67,7 @@ func StringsToTags(tagList []any, tags *[]tagapi.Tag) {
 }
 
 func NotFoundID(values ...any) string {
-	if os.Getenv("MIGRATION") != "true" {
+	if !envutils.Migration.Get() {
 		return ""
 	}
 	stringValues := []string{}

--- a/datasources/dql/data_source.go
+++ b/datasources/dql/data_source.go
@@ -22,42 +22,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const ENV_VAR_POLL_SLEEP_DURATION = "DYNATRACE_DQL_POLL_SLEEP_DURATION"
-const DEFAULT_POLL_SLEEP_DURATION = 5000
-const MIN_POLL_SLEEP_DURATION = 0
-const MAX_POLL_SLEEP_DURATION = 60000
-
-var POLL_SLEEP_DURATION = evalPollSleepDuration()
-
-func evalPollSleepDuration() int {
-	value := os.Getenv(ENV_VAR_POLL_SLEEP_DURATION)
-	if len(value) == 0 {
-		return DEFAULT_POLL_SLEEP_DURATION
-	}
-	iValue, err := strconv.Atoi(value)
-	if err != nil {
-		return DEFAULT_POLL_SLEEP_DURATION
-	}
-	if iValue < 0 {
-		return DEFAULT_POLL_SLEEP_DURATION
-	}
-	if iValue > MAX_POLL_SLEEP_DURATION {
-		return DEFAULT_POLL_SLEEP_DURATION
-	}
-	return iValue
-}
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
@@ -198,7 +173,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 			if len(dqlResponse.RequestToken) == 0 {
 				return diag.FromErr(fmt.Errorf("query is running but no request token for result polling was provided by REST API"))
 			}
-			time.Sleep(time.Duration(POLL_SLEEP_DURATION) * time.Millisecond)
+			time.Sleep(time.Duration(envutils.DynatraceDQLPollSleepDuration.Get()) * time.Millisecond)
 			response, err := client.Poll(ctx, dqlResponse.RequestToken)
 			if err != nil {
 				return diag.FromErr(err)

--- a/datasources/v2alerting/resource.go
+++ b/datasources/v2alerting/resource.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	restlogging "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
@@ -93,7 +94,7 @@ func Update(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics
 func Read(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var err error
 	var restLogFile *os.File
-	restLogFileName := os.Getenv("DT_REST_DEBUG_LOG")
+	restLogFileName := envutils.DTRestDebugLog.Get()
 	if len(restLogFileName) > 0 {
 		if restLogFile, err = os.Create(restLogFileName); err != nil {
 			return diag.FromErr(err)

--- a/dynatrace/address/address.go
+++ b/dynatrace/address/address.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,16 +19,15 @@ package address
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/spf13/afero"
 )
 
 // To speed things up when using Dynatrace Config Manager
-var BUILD_ADDRESS_FILES = os.Getenv("DYNATRACE_BUILD_ADDRESS_FILES") == "true"
 
 type AddressOriginal struct {
 	TerraformSchemaID string
@@ -64,7 +63,7 @@ func NewAddressMap() *AddressMap {
 }
 
 func (al *AddressMap) AddToAddressMap(a Address) {
-	if !BUILD_ADDRESS_FILES {
+	if !envutils.DynatraceBuildAddressFiles.Get() {
 		return
 	}
 
@@ -75,7 +74,7 @@ func (al *AddressMap) AddToAddressMap(a Address) {
 }
 
 func SaveAddressMap(addresses any, OutputFolder string, filename string) error {
-	if !BUILD_ADDRESS_FILES {
+	if !envutils.DynatraceBuildAddressFiles.Get() {
 		return nil
 	}
 

--- a/dynatrace/api/automation/workflows/settings/task.go
+++ b/dynatrace/api/automation/workflows/settings/task.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package workflows
 
 import (
 	"encoding/json"
-	"os"
 	"regexp"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -54,10 +54,8 @@ func (me *Tasks) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var useTypeList = os.Getenv("DYNATRACE_WORKFLOW_TASKS_USE_TYPE_LIST") == "true"
-
 func (me *Tasks) Schema(prefix string) map[string]*schema.Schema {
-	if useTypeList {
+	if envutils.DynatraceWorkflowTasksUseTypeList.Get() {
 		return map[string]*schema.Schema{
 			"task": {
 				Type:        schema.TypeList,

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/node/settings/settings.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/node/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,8 +18,7 @@
 package node
 
 import (
-	"os"
-
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -58,8 +57,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"node_problematic_condition": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(NodeProblematicCondition).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/workload/settings/settings.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/workload/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,8 +18,7 @@
 package workload
 
 import (
-	"os"
-
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -67,8 +66,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"high_cpu_throttling": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(HighCpuThrottling).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -76,8 +75,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"high_cpu_usage": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(HighCpuUsage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -85,8 +84,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"high_memory_usage": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(HighMemoryUsage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -94,8 +93,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"job_failure_events": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(JobFailureEvents).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -111,8 +110,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"oom_kills": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(OOMKills).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -128,8 +127,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"pod_backoff_events": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(PodBackoffEvents).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -137,8 +136,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"pod_eviction_events": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(PodEvictionEvents).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
@@ -146,8 +145,8 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"pod_preemption_events": {
 			Type:        schema.TypeList,
 			Description: "no documentation available",
-			Required:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") != "true",
-			Optional:    os.Getenv("DT_BACKWARDS_COMPATIBILITY") == "true",
+			Required:    !envutils.DTBackwardsCompatibility.Get(),
+			Optional:    envutils.DTBackwardsCompatibility.Get(),
 			Elem:        &schema.Resource{Schema: new(PodPreemptionEvents).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/host/monitoring/mode/service.go
+++ b/dynatrace/api/builtin/host/monitoring/mode/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,13 +31,13 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 const SchemaVersion = "1.3"
 const SchemaID = "builtin:host.monitoring.mode"
 
 var WarnOnAgentOffline = os.Getenv("DYNATRACE_HOST_MONITORING_WARNINGS") == "true"
-var ExportOfflineHosts = os.Getenv("DYNATRACE_HOST_MONITORING_OFFLINE") == "true"
 var StrictUpdateRetries = os.Getenv("DYNATRACE_HOST_MONITORING_STRICT_UPDATE_RETRIES")
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*mode.Settings] {
@@ -77,7 +77,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 			if len(entity.Properties.State) == 0 {
 				continue
 			}
-			if !ExportOfflineHosts && (entity.Properties.State == "OFFLINE" || entity.Properties.State == "SHUTDOWN" || entity.Properties.State == "MONITORING_DISABLED") {
+			if !envutils.DynatraceHostMonitoringOffline.Get() && (entity.Properties.State == "OFFLINE" || entity.Properties.State == "SHUTDOWN" || entity.Properties.State == "MONITORING_DISABLED") {
 				continue
 			}
 			if entity.Properties.MonitoringMode == "INFRASTRUCTURE" {

--- a/dynatrace/api/builtin/host/monitoring/mode/service.go
+++ b/dynatrace/api/builtin/host/monitoring/mode/service.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -36,8 +34,6 @@ import (
 
 const SchemaVersion = "1.3"
 const SchemaID = "builtin:host.monitoring.mode"
-
-var StrictUpdateRetries = os.Getenv("DYNATRACE_HOST_MONITORING_STRICT_UPDATE_RETRIES")
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*mode.Settings] {
 	return &service{
@@ -156,12 +152,7 @@ func (me *service) Update(ctx context.Context, id string, v *mode.Settings) erro
 func (me *service) update(ctx context.Context, id string, v *mode.Settings) error {
 	_, err := me.service.Create(ctx, v)
 	if err == nil {
-		remainingRetries := 0
-		if len(StrictUpdateRetries) > 0 {
-			if iStrictUpdateRetries, err := strconv.Atoi(StrictUpdateRetries); err == nil && iStrictUpdateRetries >= 0 {
-				remainingRetries = iStrictUpdateRetries
-			}
-		}
+		remainingRetries := envutils.DynatraceHostMonitoringStrictUpdateRetries.Get()
 		readMode := ""
 		for remainingRetries > 0 && readMode != string(v.MonitoringMode) {
 			getSettings := new(mode.Settings)

--- a/dynatrace/api/builtin/host/monitoring/mode/service.go
+++ b/dynatrace/api/builtin/host/monitoring/mode/service.go
@@ -37,7 +37,6 @@ import (
 const SchemaVersion = "1.3"
 const SchemaID = "builtin:host.monitoring.mode"
 
-var WarnOnAgentOffline = os.Getenv("DYNATRACE_HOST_MONITORING_WARNINGS") == "true"
 var StrictUpdateRetries = os.Getenv("DYNATRACE_HOST_MONITORING_STRICT_UPDATE_RETRIES")
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*mode.Settings] {
@@ -179,7 +178,7 @@ func (me *service) update(ctx context.Context, id string, v *mode.Settings) erro
 	}
 	// we don't want to error out just because the Agent isn't online
 	if strings.Contains(err.Error(), "Monitoring mode can't be changed while OneAgent is offline") {
-		if WarnOnAgentOffline {
+		if envutils.DynatraceHostMonitoringWarnings.Get() {
 			return rest.Warning{Message: fmt.Sprintf("The host '%s' is currently offline - changing the monitoring mode was not possible", id)}
 		}
 		return nil

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/service_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/service_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -14,8 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
-//go:build integration
 
 package aws_test
 

--- a/dynatrace/api/builtin/managementzones/service.go
+++ b/dynatrace/api/builtin/managementzones/service.go
@@ -20,9 +20,6 @@ package managementzones
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -53,32 +50,6 @@ type service struct {
 	credentials *rest.Credentials
 }
 
-const DefaultNumRequiredSuccesses = 5
-const MinNumRequiredSuccesses = 5
-const MaxNumRequiredSuccesses = 100
-
-const DefaultMaxConfirmationRetries = 50
-const MaxMaxConfirmationRetries = 600
-const MinMaxConfirmationRetries = 50
-
-func getEnv(key string, def int, min int, max int) int {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return def
-	}
-	iValue, err := strconv.Atoi(strings.TrimSpace(value))
-	if err != nil {
-		return def
-	}
-	if iValue > max {
-		iValue = max
-	}
-	if iValue < min {
-		iValue = min
-	}
-	return iValue
-}
-
 func (me *service) Create(ctx context.Context, v *managementzones.Settings) (*api.Stub, error) {
 	stub, err := me.service.Create(ctx, v)
 	if err != nil {
@@ -105,7 +76,7 @@ func (me *service) Create(ctx context.Context, v *managementzones.Settings) (*ap
 	validator := slo.Service(me.credentials).(settings.Validator[*slosettings.Settings])
 
 	maxConfirmationRetries := envutils.DTMgmzRetries.Get()
-	numRequiredSuccesses := getEnv("DT_MGMZ_SUCCESSES", DefaultNumRequiredSuccesses, MinNumRequiredSuccesses, MaxNumRequiredSuccesses)
+	numRequiredSuccesses := envutils.DTMgmzSuccesses.Get()
 	success := 0
 	for range maxConfirmationRetries {
 		if err := validator.Validate(ctx, &sloValue); err == nil {

--- a/dynatrace/api/builtin/managementzones/service.go
+++ b/dynatrace/api/builtin/managementzones/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	managementzones "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/managementzones/settings"
 	slo "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/monitoring/slo"
@@ -103,7 +104,7 @@ func (me *service) Create(ctx context.Context, v *managementzones.Settings) (*ap
 
 	validator := slo.Service(me.credentials).(settings.Validator[*slosettings.Settings])
 
-	maxConfirmationRetries := getEnv("DT_MGMZ_RETRIES", DefaultMaxConfirmationRetries, MinMaxConfirmationRetries, MaxMaxConfirmationRetries)
+	maxConfirmationRetries := envutils.DTMgmzRetries.Get()
 	numRequiredSuccesses := getEnv("DT_MGMZ_SUCCESSES", DefaultNumRequiredSuccesses, MinNumRequiredSuccesses, MaxNumRequiredSuccesses)
 	success := 0
 	for range maxConfirmationRetries {

--- a/dynatrace/api/builtin/problem/notifications/http/header.go
+++ b/dynatrace/api/builtin/problem/notifications/http/header.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,14 +18,12 @@
 package http
 
 import (
-	"os"
-
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var ForceNewOnHeaders = os.Getenv("DYNATRACE_FORCE_NEW_ON_HEADERS") == "true"
 
 type Headers []*Header
 
@@ -37,7 +35,7 @@ func (me *Headers) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			Description: "An additional HTTP Header to include when sending requests",
 			Elem:        &schema.Resource{Schema: new(Header).Schema()},
-			ForceNew:    ForceNewOnHeaders,
+			ForceNew:    envutils.DynatraceForceNewOnHeaders.Get(),
 		},
 	}
 }
@@ -134,20 +132,20 @@ func (me *Header) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "The name of the HTTP header.",
 			Required:    true,
-			ForceNew:    ForceNewOnHeaders,
+			ForceNew:    envutils.DynatraceForceNewOnHeaders.Get(),
 		},
 		"secret_value": {
 			Type:        schema.TypeString,
 			Description: "The secret value of the HTTP header. May contain an empty value.",
 			Optional:    true, // precondition
 			Sensitive:   true,
-			ForceNew:    ForceNewOnHeaders,
+			ForceNew:    envutils.DynatraceForceNewOnHeaders.Get(),
 		},
 		"value": {
 			Type:        schema.TypeString,
 			Description: "The value of the HTTP header. May contain an empty value.",
 			Optional:    true, // precondition
-			ForceNew:    ForceNewOnHeaders,
+			ForceNew:    envutils.DynatraceForceNewOnHeaders.Get(),
 		},
 	}
 }

--- a/dynatrace/api/builtin/problem/notifications/webhook/settings/web_hook.go
+++ b/dynatrace/api/builtin/problem/notifications/webhook/settings/web_hook.go
@@ -18,6 +18,7 @@
 package notifications
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"fmt"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/problem/notifications/http"
@@ -103,7 +104,7 @@ func (me *WebHook) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(http.Headers).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
-			ForceNew:    http.ForceNewOnHeaders,
+			ForceNew:    envutils.DynatraceForceNewOnHeaders.Get(),
 		},
 		"notify_closed_problems": {
 			Type:        schema.TypeBool,

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ package documents
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	docclient "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 
@@ -36,7 +36,6 @@ func Service(credentials *rest.Credentials) settings.CRUDService[*documents.Docu
 	return &service{credentials}
 }
 
-var IGNORE_UNEXPECTED_EOF = (os.Getenv("DT_DOCUMENTS_IGNORE_UNEXPECTED_EOF") == "true")
 
 type service struct {
 	credentials *rest.Credentials
@@ -52,7 +51,7 @@ func (me *service) client(ctx context.Context) (*docclient.Client, error) {
 
 func (me *service) Get(ctx context.Context, id string, v *documents.Document) (err error) {
 	err = me.get(ctx, id, v)
-	if IGNORE_UNEXPECTED_EOF && err != nil {
+	if envutils.DTDocumentsIgnoreUnexpectedEOF.Get() && err != nil {
 		if strings.Contains(err.Error(), "unexpected EOF") {
 			cfg := ctx.Value(settings.ContextKeyStateConfig)
 			if stateDocument, ok := cfg.(*documents.Document); ok {

--- a/dynatrace/api/openpipeline/settings/configuration_test.go
+++ b/dynatrace/api/openpipeline/settings/configuration_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -14,8 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
-//go:build unit
 
 package openpipeline
 

--- a/dynatrace/api/platform/buckets/service.go
+++ b/dynatrace/api/platform/buckets/service.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -52,7 +50,6 @@ func (me *service) client(ctx context.Context) (*bucket.Client, error) {
 	}
 	return bucket.NewClient(platformClient), nil
 }
-
 
 func (me *service) Get(ctx context.Context, id string, v *buckets.Bucket) (err error) {
 	err = me.get(ctx, id, v)
@@ -118,32 +115,6 @@ func (me *service) Validate(v *buckets.Bucket) error {
 	return nil // no endpoint for that
 }
 
-const DefaultNumRequiredSuccesses = 10
-const MinNumRequiredSuccesses = 10
-const MaxNumRequiredSuccesses = 50
-
-const DefaultMaxConfirmationRetries = 180
-const MaxMaxConfirmationRetries = 360
-const MinMaxConfirmationRetries = 180
-
-func getEnv(key string, def int, min int, max int) int {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return def
-	}
-	iValue, err := strconv.Atoi(strings.TrimSpace(value))
-	if err != nil {
-		return def
-	}
-	if iValue > max {
-		iValue = max
-	}
-	if iValue < min {
-		iValue = min
-	}
-	return iValue
-}
-
 func (me *service) Create(ctx context.Context, v *buckets.Bucket) (stub *api.Stub, err error) {
 	client, err := me.client(ctx)
 	if err != nil {
@@ -163,7 +134,7 @@ func (me *service) Create(ctx context.Context, v *buckets.Bucket) (stub *api.Stu
 	}
 
 	maxConfirmationRetries := envutils.DTBucketsRetries.Get()
-	numRequiredSuccesses := getEnv("DT_BUCKETS_NUM_SUCCESSES", DefaultNumRequiredSuccesses, MinNumRequiredSuccesses, MaxNumRequiredSuccesses)
+	numRequiredSuccesses := envutils.DTBucketsNumSuccesses.Get()
 	requiredSuccessesLeft := numRequiredSuccesses
 	retries := 0
 	var responseBucket buckets.Bucket

--- a/dynatrace/api/platform/buckets/service.go
+++ b/dynatrace/api/platform/buckets/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	bucket "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
@@ -52,11 +53,10 @@ func (me *service) client(ctx context.Context) (*bucket.Client, error) {
 	return bucket.NewClient(platformClient), nil
 }
 
-var IGNORE_UNEXPECTED_EOF = (os.Getenv("DT_BUCKETS_IGNORE_UNEXPECTED_EOF") == "true")
 
 func (me *service) Get(ctx context.Context, id string, v *buckets.Bucket) (err error) {
 	err = me.get(ctx, id, v)
-	if IGNORE_UNEXPECTED_EOF && err != nil {
+	if envutils.DTBucketsIgnoreUnexpectedEOF.Get() && err != nil {
 		if strings.Contains(err.Error(), "unexpected EOF") {
 			cfg := ctx.Value(settings.ContextKeyStateConfig)
 			if stateBucket, ok := cfg.(*buckets.Bucket); ok {

--- a/dynatrace/api/platform/buckets/service.go
+++ b/dynatrace/api/platform/buckets/service.go
@@ -162,7 +162,7 @@ func (me *service) Create(ctx context.Context, v *buckets.Bucket) (stub *api.Stu
 		return nil, err
 	}
 
-	maxConfirmationRetries := getEnv("DT_BUCKETS_RETRIES", DefaultMaxConfirmationRetries, MinMaxConfirmationRetries, MaxMaxConfirmationRetries)
+	maxConfirmationRetries := envutils.DTBucketsRetries.Get()
 	numRequiredSuccesses := getEnv("DT_BUCKETS_NUM_SUCCESSES", DefaultNumRequiredSuccesses, MinNumRequiredSuccesses, MaxNumRequiredSuccesses)
 	requiredSuccessesLeft := numRequiredSuccesses
 	retries := 0
@@ -214,7 +214,7 @@ func (me *service) Update(ctx context.Context, id string, v *buckets.Bucket) (er
 		return err
 	}
 
-	maxConfirmationRetries := getEnv("DT_BUCKETS_RETRIES", DefaultMaxConfirmationRetries, MinMaxConfirmationRetries, MaxMaxConfirmationRetries)
+	maxConfirmationRetries := envutils.DTBucketsRetries.Get()
 	retries := 0
 	for {
 		var bucket buckets.Bucket
@@ -245,7 +245,7 @@ func (me *service) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	maxConfirmationRetries := getEnv("DT_BUCKETS_RETRIES", DefaultMaxConfirmationRetries, MinMaxConfirmationRetries, MaxMaxConfirmationRetries)
+	maxConfirmationRetries := envutils.DTBucketsRetries.Get()
 	retries := 0
 	response, err := client.Get(ctx, id)
 	for response.StatusCode != 404 {

--- a/dynatrace/api/v1/config/anomalies/common/load/threshold.go
+++ b/dynatrace/api/v1/config/anomalies/common/load/threshold.go
@@ -18,7 +18,8 @@
 package load
 
 // Threshold Minimal service load to detect response time degradation.
-//  Response time degradation of services with smaller load won't trigger alerts.
+//
+//	Response time degradation of services with smaller load won't trigger alerts.
 type Threshold string
 
 // Thresholds offers the known enum values

--- a/dynatrace/api/v1/config/applications/web/service.go
+++ b/dynatrace/api/v1/config/applications/web/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,14 +26,13 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	web "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/applications/web/settings"
 )
 
 const SchemaID = "v1:config:applications:web"
 
-var DefaultCreateConfirmTimeout = 280
-var createConfirmTimeout = settings.GetIntEnv("DYNATRACE_CREATE_CONFIRM_WEB_APPLICATION", DefaultCreateConfirmTimeout, 20, 500)
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*web.Application] {
 	return &service{
@@ -43,7 +42,7 @@ func Service(credentials *rest.Credentials) settings.CRUDService[*web.Applicatio
 			&settings.ServiceOptions[*web.Application]{
 				Get:           settings.Path("/api/config/v1/applications/web/%s"),
 				List:          settings.Path("/api/config/v1/applications/web"),
-				CreateConfirm: createConfirmTimeout,
+				CreateConfirm: envutils.DynatraceCreateConfirmWebApplication.Get(),
 				Duplicates:    Duplicates,
 			},
 		),

--- a/dynatrace/api/v1/config/credentials/aws/settings/enums.go
+++ b/dynatrace/api/v1/config/credentials/aws/settings/enums.go
@@ -50,7 +50,7 @@ var Types = struct {
 }
 
 // ConnectionStatus The status of the connection to the AWS environment.
-//  * `CONNECTED`: There was a connection within last 10 minutes.
+// * `CONNECTED`: There was a connection within last 10 minutes.
 // * `DISCONNECTED`: A problem occurred with establishing connection using these credentials. Check whether the data is correct.
 // * `UNINITIALIZED`: The successful connection has never been established for these credentials.
 type ConnectionStatus string

--- a/dynatrace/api/v1/config/customtags/list/list.go
+++ b/dynatrace/api/v1/config/customtags/list/list.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2025 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,16 +23,12 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 )
 
 const (
-	TIME_FRAME                                        = "now-3y"
-	DYNATRACE_MAX_CONCURRENT_CUSTOM_TAG_LIST_REQUESTS = "DYNATRACE_MAX_CONCURRENT_CUSTOM_TAG_LIST_REQUESTS"
-	DefaultMaxConcurrent                              = 4
-	MaxConcurrentMinValue                             = 1
-	MaxConcurrentMaxValue                             = 20
+	TIME_FRAME = "now-3y"
 )
 
 type EntityTags struct {
@@ -47,7 +43,7 @@ func List(ctx context.Context, client rest.Client) (api.Stubs, error) {
 		return nil, err
 	}
 
-	maxConcurrent := settings.GetIntEnvCtx(ctx, DYNATRACE_MAX_CONCURRENT_CUSTOM_TAG_LIST_REQUESTS, DefaultMaxConcurrent, MaxConcurrentMinValue, MaxConcurrentMaxValue)
+	maxConcurrent := envutils.DynatraceMaxConcurrentCustomTagListRequests.Get()
 
 	// limiter shared by *all* downstream calls using the same client
 	limiter := make(chan struct{}, maxConcurrent)

--- a/dynatrace/api/v1/config/customtags/list/list_test.go
+++ b/dynatrace/api/v1/config/customtags/list/list_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -15,8 +17,6 @@
 * limitations under the License.
  */
 
-//go:build unit
-
 package list
 
 import (
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 const (
@@ -175,7 +176,7 @@ func TestCustomTagExport(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if got := client.MaxConcurrent(); got > DefaultMaxConcurrent {
-		t.Fatalf("saw %d concurrent requests; want <= 8", got)
+	if got := (int)(client.MaxConcurrent()); got > envutils.DynatraceMaxConcurrentCustomTagListRequests.DefaultValue {
+		t.Fatalf("saw %d concurrent requests; want <= %d", got, envutils.DynatraceMaxConcurrentCustomTagListRequests.DefaultValue)
 	}
 }

--- a/dynatrace/api/v1/config/customtags/service.go
+++ b/dynatrace/api/v1/config/customtags/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,18 +22,17 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"regexp"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/customtags/list"
 	customtags "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/customtags/settings"
 )
 
-var ErrZeroMatched = os.Getenv("DYNATRACE_TAGS_ERR_ZERO_MATCHED") == "true"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*customtags.Settings] {
 	return &service{credentials: credentials}
@@ -94,7 +93,7 @@ func (me *service) Update(ctx context.Context, id string, v *customtags.Settings
 	if err = client.Post(ctx, fmt.Sprintf("/api/v2/tags?entitySelector=%s&from=now-3y&to=now", url.QueryEscape(v.EntitySelector)), v, 200).Finish(&settingsObj); err != nil {
 		return err
 	}
-	if ErrZeroMatched && settingsObj.MatchedEntities == 0 {
+	if envutils.DynatraceTagsErrZeroMatched.Get() && settingsObj.MatchedEntities == 0 {
 		return rest.Error{Message: fmt.Sprintf("No entities matching the selector '%s' were found within the past three years.", v.EntitySelector)}
 	}
 

--- a/dynatrace/api/v1/config/dashboards/settings/json_dashboard.go
+++ b/dynatrace/api/v1/config/dashboards/settings/json_dashboard.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ package dashboards
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	slices0 "slices"
 	"sort"
@@ -28,6 +27,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -39,7 +39,6 @@ type JSONDashboard struct {
 	Contents string
 }
 
-var DYNATRACE_DASHBOARD_TESTS = len(os.Getenv("DYNATRACE_DASHBOARD_TESTS")) > 0
 
 func denullslice(s []any) []any {
 	if len(s) == 0 {
@@ -185,7 +184,7 @@ func enrm(m map[string]any, bc string, fordiff bool) {
 	}
 	if bc == "tiles[#].filterConfig.chartConfig.series[#].dimensions[#]" {
 		ensure(m, "values", []string{})
-		if DYNATRACE_DASHBOARD_TESTS && fordiff {
+		if envutils.DynatraceDashboardTests.Get() && fordiff {
 			delete(m, "name")
 		}
 	}
@@ -352,7 +351,7 @@ func get(v any, key string) any {
 func diffSuppressedContent(content string) string {
 	m := map[string]any{}
 	json.Unmarshal([]byte(content), &m)
-	if DYNATRACE_DASHBOARD_TESTS {
+	if envutils.DynatraceDashboardTests.Get() {
 		if dmd := get(m, "dashboardMetadata"); dmd != nil {
 			if df := get(dmd, "dashboardFilter"); df != nil {
 				if mgmz := get(df, "managementZone"); mgmz != nil {
@@ -364,7 +363,7 @@ func diffSuppressedContent(content string) string {
 	denullmap(m)
 	delete(m, "metadata")
 	enrm(m, "", true)
-	if DYNATRACE_DASHBOARD_TESTS {
+	if envutils.DynatraceDashboardTests.Get() {
 		if tiles, found := m["tiles"]; found {
 			if tileSlice, ok := tiles.([]any); ok {
 				for _, tile := range tileSlice {

--- a/dynatrace/api/v2/customdevice/service.go
+++ b/dynatrace/api/v2/customdevice/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
-	"strconv"
 	"sync"
 	"time"
 
@@ -30,6 +28,7 @@ import (
 	customdevice "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/customdevice/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/google/uuid"
 )
 
@@ -43,11 +42,6 @@ type service struct {
 	credentials *rest.Credentials
 }
 
-const DT_CUSTOM_DEVICE_APPLY_TIMEOUT = "DT_CUSTOM_DEVICE_APPLY_TIMEOUT"
-const DefaultApplyTimeout = 100
-const MinApplyTimeout = 100
-const MaxApplyTimeout = 500
-
 func (me *service) Get(ctx context.Context, id string, v *customdevice.CustomDevice) error {
 	cfg := ctx.Value(settings.ContextKeyStateConfig)
 	stateConfig, stateConfigFound := cfg.(*customdevice.CustomDevice)
@@ -57,18 +51,7 @@ func (me *service) Get(ctx context.Context, id string, v *customdevice.CustomDev
 	entitySelector := `detectedName("` + id + `"),type("CUSTOM_DEVICE")`
 	var CustomDeviceGetResponse customdevice.CustomDeviceGetResponse
 
-	applyTimeout := DefaultApplyTimeout
-	sApplyTimeout := os.Getenv(DT_CUSTOM_DEVICE_APPLY_TIMEOUT)
-	if len(sApplyTimeout) > 0 {
-		if timeOutValue, err := strconv.Atoi(sApplyTimeout); err == nil {
-			if timeOutValue < MinApplyTimeout {
-				timeOutValue = MinApplyTimeout
-			} else if timeOutValue > MaxApplyTimeout {
-				timeOutValue = MaxApplyTimeout
-			}
-			applyTimeout = timeOutValue
-		}
-	}
+	applyTimeout := envutils.DTCustomDeviceApplyTimeout.Get()
 
 	maxIteration := applyTimeout / 5
 
@@ -240,18 +223,7 @@ func (me *service) Create(ctx context.Context, v *customdevice.CustomDevice) (*a
 		return nil, err
 	}
 
-	applyTimeout := DefaultApplyTimeout
-	sApplyTimeout := os.Getenv(DT_CUSTOM_DEVICE_APPLY_TIMEOUT)
-	if len(sApplyTimeout) > 0 {
-		if timeOutValue, err := strconv.Atoi(sApplyTimeout); err == nil {
-			if timeOutValue < MinApplyTimeout {
-				timeOutValue = MinApplyTimeout
-			} else if timeOutValue > MaxApplyTimeout {
-				timeOutValue = MaxApplyTimeout
-			}
-			applyTimeout = timeOutValue
-		}
-	}
+	applyTimeout := envutils.DTCustomDeviceApplyTimeout.Get()
 
 	maxIteration := applyTimeout / 5
 	// Check the custom device was indeed created before finishing up

--- a/dynatrace/api/v2/entity/service.go
+++ b/dynatrace/api/v2/entity/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	entity "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/entity/settings"
 )
@@ -70,7 +70,7 @@ func (me *dataSourceService) Get(ctx context.Context, id string, v *entity.Entit
 
 	var result *entity.Entity
 
-	if os.Getenv("DYNATRACE_DISABLE_ENTITY_CACHE") == "true" {
+	if envutils.DynatraceDisableEntityCache.Get() {
 		result = getEntityByID(ctx, me.client, id)
 	} else {
 		result = getEntity(ctx, id, me.client, getEntitiesRecord(entityType))

--- a/dynatrace/api/v2/settings/objects/permissions/convert/convert_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/convert/convert_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -14,8 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
-//go:build unit
 
 package convert_test
 

--- a/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/reconcile/reconcile_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -14,8 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
-//go:build unit
 
 package reconcile_test
 

--- a/dynatrace/api/v2/synthetic/monitors/service.go
+++ b/dynatrace/api/v2/synthetic/monitors/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,13 +27,12 @@ import (
 	monitors "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/synthetic/monitors/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 const SchemaID = "v2:synthetic:monitors:network"
 const BasePath = "/api/v2/synthetic/monitors"
 
-var defaultCreateConfirm = 8
-var createConfirm = settings.GetIntEnv("DYNATRACE_CREATE_CONFIRM_SYNTHETIC_MONITORS_V2", defaultCreateConfirm, 1, 50)
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*monitors.Settings] {
 	return &service{credentials: credentials}
@@ -61,7 +60,7 @@ func (me *service) Create(ctx context.Context, v *monitors.Settings) (*api.Stub,
 	for {
 		if err = client.Get(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(resp.EntityId)), 200).Finish(); err == nil {
 			successes = successes + 1
-			if successes >= createConfirm {
+			if successes >= envutils.DynatraceCreateConfirmSyntheticMonitorsV2.Get() {
 				break
 			}
 			time.Sleep(time.Millisecond * 100)
@@ -78,7 +77,7 @@ func (me *service) Create(ctx context.Context, v *monitors.Settings) (*api.Stub,
 			if err = client.Get(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(resp.EntityId)), 200).Finish(&validateMonitor); err == nil {
 				if len(v.Tags) == len(validateMonitor.Tags) {
 					successes = successes + 1
-					if successes >= createConfirm {
+					if successes >= envutils.DynatraceCreateConfirmSyntheticMonitorsV2.Get() {
 						break
 					}
 				} else {

--- a/dynatrace/export/dependencies.go
+++ b/dynatrace/export/dependencies.go
@@ -20,7 +20,6 @@ package export
 import (
 	"fmt"
 	maps0 "maps"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -733,7 +732,7 @@ func (me *tenantds) Replace(environment *Environment, s string, replacingIn Reso
 	}
 	// when running on HTTP Cache no data sources should get replaced
 	// The IDs of these entities are guaranteed to match existing ones
-	if len(os.Getenv("DYNATRACE_MIGRATION_CACHE_FOLDER")) > 0 {
+	if len(envutils.DynatraceMigrationCacheFolder.Get()) > 0 {
 		return s, []any{}
 	}
 	if !strings.Contains(s, tenantID) {
@@ -762,7 +761,7 @@ func (me *policyds) DataSourceType() DataSourceType {
 func (me *policyds) Replace(environment *Environment, s string, replacingIn ResourceType, resourceId string, nonPostProcessedResources []*Resource) (string, []any) {
 	// when running on HTTP Cache no data sources should get replaced
 	// The IDs of these entities are guaranteed to match existing ones
-	if len(os.Getenv("DYNATRACE_MIGRATION_CACHE_FOLDER")) > 0 {
+	if len(envutils.DynatraceMigrationCacheFolder.Get()) > 0 {
 		return s, []any{}
 	}
 	if environment.Flags.FlagMigrationOutput {
@@ -807,7 +806,7 @@ func (me *entityds) DataSourceType() DataSourceType {
 func (me *entityds) Replace(environment *Environment, s string, replacingIn ResourceType, resourceId string, nonPostProcessedResources []*Resource) (string, []any) {
 	// when running on HTTP Cache no data sources should get replaced
 	// The IDs of these entities are guaranteed to match existing ones
-	if len(os.Getenv("DYNATRACE_MIGRATION_CACHE_FOLDER")) > 0 {
+	if len(envutils.DynatraceMigrationCacheFolder.Get()) > 0 {
 		return s, []any{}
 	}
 	if environment.Flags.FlagMigrationOutput {

--- a/dynatrace/export/dependencies.go
+++ b/dynatrace/export/dependencies.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,10 +24,11 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 // To allow -target to work with dependencies at an atomic level
-var ATOMIC_DEPENDENCIES = os.Getenv("DYNATRACE_ATOMIC_DEPENDENCIES") == "true"
 
 type Dependency interface {
 	Replace(environment *Environment, s string, replacingIn ResourceType, resourceId string, nonPostProcessedResources []*Resource) (string, []any)
@@ -126,7 +127,7 @@ func (me *mgmzdep) DataSourceType() DataSourceType {
 
 func (me *mgmzdep) Replace(environment *Environment, s string, replacingIn ResourceType, resourceId string, nonPostProcessedResources []*Resource) (string, []any) {
 	var replacePattern string
-	if ATOMIC_DEPENDENCIES {
+	if envutils.DynatraceAtomicDependencies.Get() {
 		replacePattern = "${var.%s_%s.value.name}"
 	} else {
 		replacePattern = "${var.%s.%s.name}"
@@ -153,7 +154,7 @@ func (me *mgmzdep) Replace(environment *Environment, s string, replacingIn Resou
 				replacePattern = "${data.%s.%s.name}"
 			}
 		} else {
-			if ATOMIC_DEPENDENCIES {
+			if envutils.DynatraceAtomicDependencies.Get() {
 				replacePattern = "${var.%s_%s.value.name}"
 			} else {
 				replacePattern = "${var.%s.%s.name}"
@@ -305,7 +306,7 @@ func (me *dashdep) Replace(environment *Environment, s string, replacingIn Resou
 	isParent := !environment.ChildResourceOverride && childDescriptor.Parent != nil && string(*childDescriptor.Parent) == string(me.resourceType)
 
 	var replacePattern string
-	if ATOMIC_DEPENDENCIES {
+	if envutils.DynatraceAtomicDependencies.Get() {
 		replacePattern = "${var.%s_%s.value.id}"
 	} else {
 		replacePattern = "${var.%s.%s.id}"
@@ -331,7 +332,7 @@ func (me *dashdep) Replace(environment *Environment, s string, replacingIn Resou
 					replacePattern = "${data.%s.%s.id}"
 				}
 			} else {
-				if ATOMIC_DEPENDENCIES {
+				if envutils.DynatraceAtomicDependencies.Get() {
 					replacePattern = "${var.%s_%s.value.id}"
 				} else {
 					replacePattern = "${var.%s.%s.id}"
@@ -371,7 +372,7 @@ func (me *legacyID) DataSourceType() DataSourceType {
 
 func (me *legacyID) Replace(environment *Environment, s string, replacingIn ResourceType, resourceId string, nonPostProcessedResources []*Resource) (string, []any) {
 	var replacePattern string
-	if ATOMIC_DEPENDENCIES {
+	if envutils.DynatraceAtomicDependencies.Get() {
 		replacePattern = "${var.%s_%s.value.legacy_id}"
 	} else {
 		replacePattern = "${var.%s.%s.legacy_id}"
@@ -419,7 +420,7 @@ func (me *legacyID) Replace(environment *Environment, s string, replacingIn Reso
 				replacePattern = "${data.%s.%s.legacy_id}"
 			}
 		} else {
-			if ATOMIC_DEPENDENCIES {
+			if envutils.DynatraceAtomicDependencies.Get() {
 				replacePattern = "${var.%s_%s.value.legacy_id}"
 			} else {
 				replacePattern = "${var.%s.%s.legacy_id}"
@@ -563,7 +564,7 @@ func (me *iddep) Replace(environment *Environment, s string, replacingIn Resourc
 	}
 
 	var replacePattern string
-	if ATOMIC_DEPENDENCIES {
+	if envutils.DynatraceAtomicDependencies.Get() {
 		replacePattern = "${var.%s_%s.value.id}"
 	} else {
 		replacePattern = "${var.%s.%s.id}"
@@ -600,7 +601,7 @@ func (me *iddep) Replace(environment *Environment, s string, replacingIn Resourc
 					replacePattern = "${data.%s.%s.id}"
 				}
 			} else {
-				if ATOMIC_DEPENDENCIES {
+				if envutils.DynatraceAtomicDependencies.Get() {
 					replacePattern = "${var.%s_%s.value.id}"
 				} else {
 					replacePattern = "${var.%s.%s.id}"
@@ -850,7 +851,7 @@ func (me *reqAttName) DataSourceType() DataSourceType {
 
 func (me *reqAttName) Replace(environment *Environment, s string, replacingIn ResourceType, resourceId string, nonPostProcessedResources []*Resource) (string, []any) {
 	var replacePattern string
-	if ATOMIC_DEPENDENCIES {
+	if envutils.DynatraceAtomicDependencies.Get() {
 		replacePattern = "${var.%s_%s.value.name}"
 	} else {
 		replacePattern = "${var.%s.%s.name}"
@@ -875,7 +876,7 @@ func (me *reqAttName) Replace(environment *Environment, s string, replacingIn Re
 					replacePattern = "${data.%s.%s.name}"
 				}
 			} else {
-				if ATOMIC_DEPENDENCIES {
+				if envutils.DynatraceAtomicDependencies.Get() {
 					replacePattern = "${var.%s_%s.value.name}"
 				} else {
 					replacePattern = "${var.%s.%s.name}"

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -48,7 +48,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-var ULTRA_PARALLEL = os.Getenv("DYNATRACE_ULTRA_PARALLEL") == "true"
 
 type Environment struct {
 	mu                    sync.Mutex

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -240,7 +240,7 @@ func (me *Environment) ProcessPrevState() error {
 }
 
 func (me *Environment) InitialDownload() error {
-	parallel := (os.Getenv("DYNATRACE_PARALLEL") != "false")
+	parallel := envutils.DynatraceParallel.Get()
 	logging.Debug.Info.Println("DYNATRACE_PARALLEL:", parallel)
 	resourceTypes := []string{}
 	for resourceType := range me.ResArgs {
@@ -321,7 +321,7 @@ func (me *Environment) InitialDownload() error {
 
 func (me *Environment) PostProcess() error {
 	fmt.Println("Post-Processing Resources ...")
-	parallel := (os.Getenv("DYNATRACE_PARALLEL") != "false")
+	parallel := envutils.DynatraceParallel.Get()
 	logging.Debug.Info.Println("DYNATRACE_PARALLEL:", parallel)
 	resources := me.GetNonPostProcessedResources()
 
@@ -675,7 +675,7 @@ func (me *Environment) WriteDataSourceFiles() (err error) {
 
 		return nil
 	}
-	parallel := (os.Getenv("DYNATRACE_PARALLEL") != "false")
+	parallel := envutils.DynatraceParallel.Get()
 	if parallel {
 		var wg sync.WaitGroup
 		wg.Add(len(me.Modules))
@@ -707,7 +707,7 @@ func (me *Environment) WriteResourceFiles() (err error) {
 		return nil
 	}
 	fmt.Println("Writing ___resources___.tf")
-	parallel := (os.Getenv("DYNATRACE_PARALLEL") != "false")
+	parallel := envutils.DynatraceParallel.Get()
 	if parallel {
 		var wg sync.WaitGroup
 		wg.Add(len(me.Modules))
@@ -772,7 +772,7 @@ func (me *Environment) WriteProviderFiles() (err error) {
 	}
 
 	fmt.Println("Writing modules ___providers___.tf")
-	parallel := (os.Getenv("DYNATRACE_PARALLEL") != "false")
+	parallel := envutils.DynatraceParallel.Get()
 	if parallel {
 		var wg sync.WaitGroup
 		wg.Add(len(me.Modules))
@@ -812,10 +812,10 @@ func (me *Environment) WriteMainProviderFile() error {
 	}()
 	providerSource := "dynatrace-oss/dynatrace"
 	providerVersion := version.Version
-	if value := os.Getenv(DYNATRACE_PROVIDER_SOURCE); len(value) != 0 {
+	if value := envutils.DynatraceProviderSource.Get(); len(value) != 0 {
 		providerSource = value
 	}
-	if value := os.Getenv(DYNATRACE_PROVIDER_VERSION); len(value) != 0 {
+	if value := envutils.DynatraceProviderVersion.Get(); len(value) != 0 {
 		providerVersion = value
 	}
 
@@ -839,7 +839,7 @@ func (me *Environment) WriteMainProviderFile() error {
 
 func (me *Environment) WriteVariablesFiles() (err error) {
 	fmt.Println("Writing ___variables___.tf")
-	parallel := (os.Getenv("DYNATRACE_PARALLEL") != "false")
+	parallel := envutils.DynatraceParallel.Get()
 	if parallel {
 		var wg sync.WaitGroup
 

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -923,7 +923,7 @@ func (me *Environment) WriteMainFile() error {
 		module := me.Module(resourceType)
 		me.writeOpeningMainSection(mainFile, resourceType.Trim(), module.GetFolder(true))
 
-		if ATOMIC_DEPENDENCIES {
+		if envutils.DynatraceAtomicDependencies.Get() {
 
 			uniqueNameExists := map[string]bool{}
 			referencedResources := module.GetResourceReferences()

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -216,7 +216,7 @@ func (me *Environment) LoadImportState() error {
 }
 
 func (me *Environment) ProcessPrevState() error {
-	if PREV_STATE_ON {
+	if envutils.DynatracePrevStateOn.Get() {
 		// pass
 	} else {
 		return nil
@@ -1044,7 +1044,7 @@ func (me *Environment) executeImportV2() error {
 }
 
 func (me *Environment) importPrevResources(state *state) {
-	if PREV_STATE_ON {
+	if envutils.DynatracePrevStateOn.Get() {
 		for _, statePrev := range me.PrevStateMapCommon.resources {
 			if statePrev.Used {
 				continue

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -41,6 +41,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/cache"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"github.com/google/uuid"
@@ -50,8 +51,6 @@ import (
 var NO_REFRESH_ON_IMPORT = os.Getenv("DYNATRACE_NO_REFRESH_ON_IMPORT") == "true"
 var QUICK_INIT = os.Getenv("DYNATRACE_QUICK_INIT") == "true"
 var ULTRA_PARALLEL = os.Getenv("DYNATRACE_ULTRA_PARALLEL") == "true"
-
-const ENV_VAR_CUSTOM_PROVIDER_LOCATION = "DYNATRACE_CUSTOM_PROVIDER_LOCATION"
 
 type Environment struct {
 	mu                    sync.Mutex
@@ -1167,7 +1166,7 @@ func (me *Environment) RunTerraformInit() error {
 	}
 	cmdOptions := []string{"init", "-no-color"}
 
-	customProviderLocation := os.Getenv(ENV_VAR_CUSTOM_PROVIDER_LOCATION)
+	customProviderLocation := envutils.DynatraceCustomProviderLocation.Get()
 	if len(customProviderLocation) != 0 && customProviderLocation != "" {
 		cmdOptions = append(cmdOptions, fmt.Sprint("-plugin-dir=", customProviderLocation))
 	}

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -199,11 +199,11 @@ func (me *Environment) ProcessHasDependenciesTo() {
 }
 
 func (me *Environment) LoadImportState() error {
-	if IMPORT_STATE_PATH == "" {
+	if envutils.DynatraceImportStatePath.Get() == "" {
 		return nil
 	}
 
-	state, err := LoadStateFile(IMPORT_STATE_PATH)
+	state, err := LoadStateFile(envutils.DynatraceImportStatePath.Get())
 	if err != nil {
 		return err
 	}

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -48,7 +48,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-var NO_REFRESH_ON_IMPORT = os.Getenv("DYNATRACE_NO_REFRESH_ON_IMPORT") == "true"
 var QUICK_INIT = os.Getenv("DYNATRACE_QUICK_INIT") == "true"
 var ULTRA_PARALLEL = os.Getenv("DYNATRACE_ULTRA_PARALLEL") == "true"
 
@@ -1036,7 +1035,7 @@ func (me *Environment) executeImportV2() error {
 		return err
 	}
 
-	if NO_REFRESH_ON_IMPORT {
+	if envutils.DynatraceNoRefreshOnImport.Get() {
 		fmt.Println("NO_REFRESH_ON_IMPORT set to true")
 	} else {
 		me.executeTF(genPlanCmd())

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -48,7 +48,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-var QUICK_INIT = os.Getenv("DYNATRACE_QUICK_INIT") == "true"
 var ULTRA_PARALLEL = os.Getenv("DYNATRACE_ULTRA_PARALLEL") == "true"
 
 type Environment struct {
@@ -760,7 +759,7 @@ func (me *Environment) RemoveNonReferencedModules() (err error) {
 
 func (me *Environment) WriteProviderFiles() (err error) {
 
-	if QUICK_INIT {
+	if envutils.DynatraceQuickInit.Get() {
 		// pass
 	} else {
 		err = me.WriteMainProviderFile()
@@ -1135,7 +1134,7 @@ func (me *Environment) FinishExport() error {
 	address.SaveOriginalMap(me.OutputFolder)
 	address.SaveCompletedMap(me.OutputFolder)
 
-	if QUICK_INIT {
+	if envutils.DynatraceQuickInit.Get() {
 		err := me.WriteQuickModulesJSON()
 		if err != nil {
 			return err
@@ -1203,7 +1202,7 @@ type TerraformInitModule struct {
 
 func (me *Environment) RunQuickInit() error {
 
-	if QUICK_INIT {
+	if envutils.DynatraceQuickInit.Get() {
 		// pass
 	} else {
 		return nil
@@ -1225,7 +1224,7 @@ func (me *Environment) RunQuickInit() error {
 
 func (me *Environment) WriteQuickModulesJSON() error {
 
-	if QUICK_INIT {
+	if envutils.DynatraceQuickInit.Get() {
 		// pass
 	} else {
 		return nil

--- a/dynatrace/export/helpers.go
+++ b/dynatrace/export/helpers.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import (
 	"os/exec"
 	"strings"
 	"unicode"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 // To speed things up when using Dynatrace Config Manager
@@ -34,7 +36,7 @@ func format(name string, force bool) {
 	if HCL_NO_FORMAT {
 		return
 	}
-	if force || os.Getenv("DYNATRACE_FORMAT_HCL_FILES") == "true" {
+	if force || envutils.DynatraceFormatHCLFiles.Get() {
 		exePath, _ := exec.LookPath("terraform.exe")
 		// log.Println(exePath, "fmt", name)
 		cmd := exec.Command(exePath, "fmt", name)

--- a/dynatrace/export/helpers.go
+++ b/dynatrace/export/helpers.go
@@ -18,7 +18,6 @@
 package export
 
 import (
-	"os"
 	"os/exec"
 	"strings"
 	"unicode"
@@ -29,7 +28,6 @@ import (
 // To speed things up when using Dynatrace Config Manager
 
 // To get more unique names when using Dynatrace Config Manager
-var NAME_REPLACE_DASH = os.Getenv("DYNATRACE_NAME_REPLACE_DASH") == "true"
 
 func format(name string, force bool) {
 	if envutils.DynatraceHCLNoFormat.Get() {
@@ -58,7 +56,7 @@ func fileSystemName(filename string) string {
 
 func toTerraformName(s string) string {
 	replaceChar := "_"
-	if NAME_REPLACE_DASH {
+	if envutils.DynatraceNameReplaceDash.Get() {
 		replaceChar = "-"
 	}
 	result := ""

--- a/dynatrace/export/helpers.go
+++ b/dynatrace/export/helpers.go
@@ -27,13 +27,12 @@ import (
 )
 
 // To speed things up when using Dynatrace Config Manager
-var HCL_NO_FORMAT = os.Getenv("DYNATRACE_HCL_NO_FORMAT") == "true"
 
 // To get more unique names when using Dynatrace Config Manager
 var NAME_REPLACE_DASH = os.Getenv("DYNATRACE_NAME_REPLACE_DASH") == "true"
 
 func format(name string, force bool) {
-	if HCL_NO_FORMAT {
+	if envutils.DynatraceHCLNoFormat.Get() {
 		return
 	}
 	if force || envutils.DynatraceFormatHCLFiles.Get() {

--- a/dynatrace/export/ignore_resources.go
+++ b/dynatrace/export/ignore_resources.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2023 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,13 +19,12 @@ package export
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/spf13/afero"
 )
 
-var EXPORT_IGNORE_RESOURCES_PATH = os.Getenv("DYNATRACE_EXPORT_IGNORE_RESOURCES")
 var ANSI_ESCAPE_PATTERN = regexp.MustCompile(`\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`)
 
 type IgnoreResourcesMap map[string]map[string][]string
@@ -33,7 +32,7 @@ type IgnoreResourcesMap map[string]map[string][]string
 var IGNORE_RESOURCES_MAP *IgnoreResourcesMap = nil
 
 func LoadIgnoreResourcesMap() error {
-	if EXPORT_IGNORE_RESOURCES_PATH == "" {
+	if envutils.DynatraceExportIgnoreResources.Get() == "" {
 		return nil
 	}
 
@@ -47,19 +46,19 @@ func LoadIgnoreResourcesMap() error {
 
 	IGNORE_RESOURCES_MAP = &IgnoreResourcesMap{}
 
-	data, err := afero.ReadFile(fs, EXPORT_IGNORE_RESOURCES_PATH)
+	data, err := afero.ReadFile(fs, envutils.DynatraceExportIgnoreResources.Get())
 	if err != nil {
-		fmt.Printf("\nIgnore Resource file not found: %s", EXPORT_IGNORE_RESOURCES_PATH)
+		fmt.Printf("\nIgnore Resource file not found: %s", envutils.DynatraceExportIgnoreResources.Get())
 		return nil
 	}
 
 	err = json.Unmarshal(data, IGNORE_RESOURCES_MAP)
 	if err != nil {
-		fmt.Printf("\nThe Ignore Resource file wasn't formatted properly: %s, error: %s", EXPORT_IGNORE_RESOURCES_PATH, err)
+		fmt.Printf("\nThe Ignore Resource file wasn't formatted properly: %s, error: %s", envutils.DynatraceExportIgnoreResources.Get(), err)
 		return nil
 	}
 
-	fmt.Printf("\nThe Ignore Resource file was read properly: %s", EXPORT_IGNORE_RESOURCES_PATH)
+	fmt.Printf("\nThe Ignore Resource file was read properly: %s", envutils.DynatraceExportIgnoreResources.Get())
 	for module_name, resourceMap := range *IGNORE_RESOURCES_MAP {
 
 		fmt.Printf("\n- %s", module_name)

--- a/dynatrace/export/initialize.go
+++ b/dynatrace/export/initialize.go
@@ -155,7 +155,7 @@ func Initialize(cfgGetter config.Getter) (environment *Environment, err error) {
 		fmt.Println("The environment variable DYNATRACE_TARGET_FOLDER has not been set - using folder 'configuration' as default")
 		targetFolder = "configuration"
 	}
-	if os.Getenv("DYNATRACE_CLEAN_TARGET_FOLDER") == "true" {
+	if envutils.DynatraceCleanTargetFolder.Get() {
 		os.RemoveAll(targetFolder)
 	}
 

--- a/dynatrace/export/initialize.go
+++ b/dynatrace/export/initialize.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/cache"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 func Initialize(cfgGetter config.Getter) (environment *Environment, err error) {
@@ -149,7 +150,7 @@ func Initialize(cfgGetter config.Getter) (environment *Environment, err error) {
 		}
 	}
 
-	targetFolder := os.Getenv("DYNATRACE_TARGET_FOLDER")
+	targetFolder := envutils.DynatraceTargetFolder.Get()
 	if targetFolder == "" {
 		fmt.Println("The environment variable DYNATRACE_TARGET_FOLDER has not been set - using folder 'configuration' as default")
 		targetFolder = "configuration"

--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -468,7 +468,7 @@ func (me *Module) WriteVariablesFile(logToScreen bool) (err error) {
 		}
 	}()
 
-	if ATOMIC_DEPENDENCIES {
+	if envutils.DynatraceAtomicDependencies.Get() {
 		uniqueNameExists := map[string]bool{}
 		referencedResources := me.GetResourceReferences()
 		if len(referencedResources) == 0 {
@@ -698,7 +698,7 @@ func (me *Module) WriteResourcesFile() (err error) {
 		format(resourcesFile.Name(), true)
 	}()
 
-	if ATOMIC_DEPENDENCIES {
+	if envutils.DynatraceAtomicDependencies.Get() {
 
 		uniqueNameExists := map[string]bool{}
 		for _, resource := range referencedResources {

--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"github.com/spf13/afero"
@@ -413,7 +414,7 @@ func (me *Module) writeProviderFile(specificPath string) error {
 	}()
 	providerSource := "dynatrace-oss/dynatrace"
 	providerVersion := version.Version
-	if value := os.Getenv("DYNATRACE_PROVIDER_SOURCE"); len(value) != 0 {
+	if value := envutils.DynatraceProviderSource.Get(); len(value) != 0 {
 		providerSource = value
 	}
 	if value := os.Getenv("DYNATRACE_PROVIDER_VERSION"); len(value) != 0 {
@@ -1464,7 +1465,7 @@ func (me *Module) ExecuteImportV2(fs afero.Fs) (resList resources, err error) {
 
 		}
 
-		providerSource := os.Getenv("DYNATRACE_PROVIDER_SOURCE")
+		providerSource := envutils.DynatraceProviderSource.Get()
 		if len(providerSource) == 0 {
 			providerSource = `provider["registry.terraform.io/dynatrace-oss/dynatrace"]`
 		} else {

--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -458,7 +458,7 @@ func (me *Module) WriteVariablesFile(logToScreen bool) (err error) {
 	defer func() {
 		variablesFile.Close()
 
-		if HCL_NO_FORMAT {
+		if envutils.DynatraceHCLNoFormat.Get() {
 			// pass
 		} else {
 			exePath, _ := exec.LookPath("terraform.exe")

--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -885,7 +885,7 @@ func (me *Module) Download(multiThreaded bool, keys ...string) (err error) {
 }
 
 func (me *Module) blockPrevNames() {
-	if PREV_STATE_ON {
+	if envutils.DynatracePrevStateOn.Get() {
 		names, found := me.Environment.PrevNamesByModule[string(me.Type)]
 		if found {
 			for _, name := range names {

--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -1245,7 +1245,7 @@ func (me *Module) getResourcesPerBundle(resourcesCount int, maxThreads int) bund
 func (me *Module) IsBundleImpossible() bool {
 	resourceDefinition := AllResources[me.Type]
 
-	if ULTRA_PARALLEL {
+	if envutils.DynatraceUltraParallel.Get() {
 		// pass
 	} else {
 		return true

--- a/dynatrace/export/module.go
+++ b/dynatrace/export/module.go
@@ -417,7 +417,7 @@ func (me *Module) writeProviderFile(specificPath string) error {
 	if value := envutils.DynatraceProviderSource.Get(); len(value) != 0 {
 		providerSource = value
 	}
-	if value := os.Getenv("DYNATRACE_PROVIDER_VERSION"); len(value) != 0 {
+	if value := envutils.DynatraceProviderVersion.Get(); len(value) != 0 {
 		providerVersion = value
 	}
 

--- a/dynatrace/export/resource.go
+++ b/dynatrace/export/resource.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,12 +31,12 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hclgen"
 )
 
-var SHORTER_NAMES = os.Getenv("DYNATRACE_SHORTER_NAMES") == "true"
 
 type Resource struct {
 	ID                              string
@@ -205,7 +205,7 @@ const MAX_PATH_LENGTH_FILENAME_SHORTER = 240
 func (me *Resource) GetFileName() string {
 	filename := fileSystemName(fmt.Sprintf("%s.%s.tf", strings.TrimSpace(me.UniqueName), me.Type.Trim()))
 
-	if SHORTER_NAMES {
+	if envutils.DynatraceShorterNames.Get() {
 		filename = me.getShorterFileName(filename)
 	}
 

--- a/dynatrace/export/resource_descriptor.go
+++ b/dynatrace/export/resource_descriptor.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 package export
 
 import (
-	"os"
 	"reflect"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/openpipeline"
 	settingsPermissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	msentraidconnection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/app/dynatrace/azure/connector/microsoftentraidentitydeveloperconnection"
 	dbfeatureflags "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/app/dynatrace/database/featureflags"
@@ -2048,10 +2048,9 @@ func genExcludeListedResourceGroups() []ResourceType {
 	return result
 }
 
-var ENABLE_EXPORT_DASHBOARD = os.Getenv("DYNATRACE_ENABLE_EXPORT_DASHBOARD") == "true"
 
 func GetExcludeListedResourceGroups() []ResourceExclusionGroup {
-	if ENABLE_EXPORT_DASHBOARD {
+	if envutils.DynatraceEnableExportDashboard.Get() {
 		return excludeListedResourceGroups
 	}
 
@@ -2068,7 +2067,7 @@ func GetExcludeListedResourceGroups() []ResourceExclusionGroup {
 
 func GetExcludeListedResources() []ResourceType {
 
-	if ENABLE_EXPORT_DASHBOARD {
+	if envutils.DynatraceEnableExportDashboard.Get() {
 		return excludeListedResources
 	}
 

--- a/dynatrace/export/rest_log.go
+++ b/dynatrace/export/rest_log.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,12 +21,13 @@ import (
 	"os"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 var restLogFile *os.File
 
 func ConfigureRESTLog() (err error) {
-	restLogFileName := os.Getenv("DT_REST_DEBUG_LOG")
+	restLogFileName := envutils.DTRestDebugLog.Get()
 	if len(restLogFileName) > 0 {
 		if restLogFile, err = os.Create(restLogFileName); err != nil {
 			return err

--- a/dynatrace/export/sensitive/ignore_changes_sensitive.go
+++ b/dynatrace/export/sensitive/ignore_changes_sensitive.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2023 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,16 +19,15 @@ package sensitive
 
 import (
 	"fmt"
-	"os"
 	"slices"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/meta"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Avoid overwriting password that the user has changed manually with known bad data
-var IGNORE_CHANGES_REQUIRES_ATTENTION = os.Getenv("DYNATRACE_IGNORE_CHANGES_REQUIRES_ATTENTION") == "true"
 
 const SecretValueExact = "${state.secret_value.exact}"
 const SecretValue = "${state.secret_value}"
@@ -47,7 +46,7 @@ func ConditionalIgnoreChangesMap(schema map[string]*schema.Schema, itemsToEncode
 	return ConditionalIgnoreChangesMapPlus(schema, itemsToEncode, []string{})
 }
 func ConditionalIgnoreChangesMapPlus(schema map[string]*schema.Schema, itemsToEncode map[string]any, additionalIgnoreFields []string) map[string]any {
-	if IGNORE_CHANGES_REQUIRES_ATTENTION {
+	if envutils.DynatraceIgnoreChangesRequiresAttention.Get() {
 
 		lifeCycleIgnoreChanges := buildIgnoreSensitiveFromSchema(schema, additionalIgnoreFields)
 
@@ -71,7 +70,7 @@ func ConditionalIgnoreChangesSingle(schema map[string]*schema.Schema, properties
 func ConditionalIgnoreChangesSinglePlus(schema map[string]*schema.Schema, properties *hcl.Properties, additionalIgnoreFields []string) error {
 	lifeCycleIgnoreChanges := buildIgnoreSensitiveFromSchema(schema, additionalIgnoreFields)
 
-	if IGNORE_CHANGES_REQUIRES_ATTENTION {
+	if envutils.DynatraceIgnoreChangesRequiresAttention.Get() {
 		if err := properties.Encode("lifecycle", &lifeCycleIgnoreChanges); err != nil {
 			return err
 		}

--- a/dynatrace/export/state.go
+++ b/dynatrace/export/state.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-var PREV_STATE_PATH_THIS = os.Getenv("DYNATRACE_PREV_STATE_PATH_THIS")
 var PREV_STATE_PATH_LINKED = os.Getenv("DYNATRACE_PREV_STATE_PATH_LINKED")
 
 type StateMap struct {
@@ -241,7 +240,7 @@ func getResourceByUniqueName(res *Resource, sm *StateMap) (string, StateResource
 }
 
 func LoadStateThis() (*state, error) {
-	return LoadStateFile(PREV_STATE_PATH_THIS)
+	return LoadStateFile(envutils.DynatracePrevStatePathThis.Get())
 }
 
 func LoadStateLinked() (*state, error) {

--- a/dynatrace/export/state.go
+++ b/dynatrace/export/state.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2023 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,13 +24,13 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/spf13/afero"
 )
 
 var PREV_STATE_ON = os.Getenv("DYNATRACE_PREV_STATE_ON") == "true"
 var PREV_STATE_PATH_THIS = os.Getenv("DYNATRACE_PREV_STATE_PATH_THIS")
 var PREV_STATE_PATH_LINKED = os.Getenv("DYNATRACE_PREV_STATE_PATH_LINKED")
-var IMPORT_STATE_PATH = os.Getenv("DYNATRACE_IMPORT_STATE_PATH")
 
 type StateMap struct {
 	mutex     *sync.Mutex
@@ -179,7 +179,7 @@ func getResourceOfReference(nameKey string, res *Resource, typeOfReference strin
 }
 
 func (sm *StateMap) GetResourceSplitId(res *Resource) (int, bool) {
-	if IMPORT_STATE_PATH == "" {
+	if envutils.DynatraceImportStatePath.Get() == "" {
 		return -1, false
 	}
 

--- a/dynatrace/export/state.go
+++ b/dynatrace/export/state.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-var PREV_STATE_ON = os.Getenv("DYNATRACE_PREV_STATE_ON") == "true"
 var PREV_STATE_PATH_THIS = os.Getenv("DYNATRACE_PREV_STATE_PATH_THIS")
 var PREV_STATE_PATH_LINKED = os.Getenv("DYNATRACE_PREV_STATE_PATH_LINKED")
 
@@ -119,7 +118,7 @@ func (sm *StateMap) GetPrevUniqueName(res *Resource) string {
 	typeOfReference := res.getTypeOfReference()
 	name := ""
 
-	if PREV_STATE_ON {
+	if envutils.DynatracePrevStateOn.Get() {
 		// pass
 	} else {
 		return name

--- a/dynatrace/export/state.go
+++ b/dynatrace/export/state.go
@@ -19,7 +19,6 @@ package export
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,7 +27,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-var PREV_STATE_PATH_LINKED = os.Getenv("DYNATRACE_PREV_STATE_PATH_LINKED")
 
 type StateMap struct {
 	mutex     *sync.Mutex
@@ -244,7 +242,7 @@ func LoadStateThis() (*state, error) {
 }
 
 func LoadStateLinked() (*state, error) {
-	return LoadStateFile(PREV_STATE_PATH_LINKED)
+	return LoadStateFile(envutils.DynatracePrevStatePathLinked.Get())
 }
 
 func LoadStateFile(filePath string) (*state, error) {

--- a/dynatrace/rest/admin_retry_test.go
+++ b/dynatrace/rest/admin_retry_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -14,8 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
-//go:build unit
 
 package rest_test
 

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -18,6 +18,7 @@
 package rest
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"context"
 	"errors"
 	"net/http"
@@ -83,7 +84,7 @@ func (me *api_token_request) Finish(vs ...any) error {
 	if !credentials.ContainsAPIToken() {
 		return NoAPITokenError
 	}
-	if DYNATRACE_HTTP_LEGACY {
+	if envutils.DynatraceHTTPLegacy.Get() {
 		legacyRequest := legacy_request(*me)
 		if credentials.URL == TestCaseEnvURL {
 			return errors.New("legacy")

--- a/dynatrace/rest/cluster_v1_client.go
+++ b/dynatrace/rest/cluster_v1_client.go
@@ -18,6 +18,7 @@
 package rest
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"context"
 	"errors"
 	"net/http"
@@ -111,7 +112,7 @@ func clusterV1Client(baseURL string, apiToken string) (*rest.Client, error) {
 
 func (me *cluster_v1_request) Finish(optionalTarget ...any) error {
 	credentials := me.client.Credentials()
-	if DYNATRACE_HTTP_LEGACY {
+	if envutils.DynatraceHTTPLegacy.Get() {
 		if !credentials.ContainsClusterURL() {
 			return NoClusterURLError
 		}

--- a/dynatrace/rest/cluster_v2_client.go
+++ b/dynatrace/rest/cluster_v2_client.go
@@ -18,6 +18,7 @@
 package rest
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"context"
 	"errors"
 	"net/http"
@@ -111,7 +112,7 @@ func clusterV2Client(baseURL string, apiToken string) (*rest.Client, error) {
 
 func (me *cluster_v2_request) Finish(optionalTarget ...any) error {
 	credentials := me.client.Credentials()
-	if DYNATRACE_HTTP_LEGACY {
+	if envutils.DynatraceHTTPLegacy.Get() {
 		if !credentials.ContainsClusterURL() {
 			return NoClusterURLError
 		}

--- a/dynatrace/rest/hybrid_client.go
+++ b/dynatrace/rest/hybrid_client.go
@@ -71,7 +71,7 @@ func (me *hybrid_client) Delete(ctx context.Context, url string, expectedStatusC
 }
 
 func (me *hybrid_request) Finish(optionalTarget ...any) error {
-	isOAuthPreferred := DYNATRACE_HTTP_OAUTH_PREFERENCE
+	isOAuthPreferred := envutils.DynatraceHTTPOAuthPreference.Get()
 	if v := me.ctx.Value("DYNATRACE_HTTP_OAUTH_PREFERENCE"); v != nil {
 		if bv, ok := v.(bool); ok {
 			isOAuthPreferred = bv

--- a/dynatrace/rest/hybrid_client.go
+++ b/dynatrace/rest/hybrid_client.go
@@ -18,6 +18,7 @@
 package rest
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"context"
 	"errors"
 	"net/http"
@@ -79,7 +80,7 @@ func (me *hybrid_request) Finish(optionalTarget ...any) error {
 
 	credentials := me.client.Credentials()
 
-	if DYNATRACE_HTTP_LEGACY {
+	if envutils.DynatraceHTTPLegacy.Get() {
 		if !credentials.ContainsAPIToken() {
 			return NoAPITokenError
 		}

--- a/dynatrace/rest/hybrid_client_test.go
+++ b/dynatrace/rest/hybrid_client_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -14,8 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
-//go:build unit
 
 package rest
 

--- a/dynatrace/rest/legacy_request.go
+++ b/dynatrace/rest/legacy_request.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
-	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -167,7 +166,7 @@ func (me *legacy_request) Raw() ([]byte, error) {
 		return nil, err
 	}
 	if envutils.DynatraceHTTPResponse.Get() {
-		var dataStr string
+		dataStr := ""
 		if data != nil {
 			dataStr = " " + string(data)
 		}
@@ -212,30 +211,8 @@ func Envelope(data []byte, url string, method string) error {
 	return nil
 }
 
-const defaultMaxWorkers = 20
-const highLimitMaxWorkers = 50
 
-var maxWorkers = resolveMaxWorkers()
-
-func resolveMaxWorkers() int64 {
-	sMaxWorkers := os.Getenv("DYNATRACE_MAX_HTTP_WORKERS")
-	if len(sMaxWorkers) == 0 {
-		return defaultMaxWorkers
-	}
-	mw, err := strconv.Atoi(sMaxWorkers)
-	if err != nil {
-		return defaultMaxWorkers
-	}
-	if mw > highLimitMaxWorkers {
-		return highLimitMaxWorkers
-	}
-	if mw < 1 {
-		return 1
-	}
-	return int64(mw)
-}
-
-var sem = semaphore.NewWeighted(maxWorkers)
+var sem = semaphore.NewWeighted(int64(envutils.DynatraceMaxHTTPWorkers.Get()))
 
 func (s *legacy_request) execute(ctx context.Context, callback func() (*http.Response, error)) (*http.Response, error) {
 	if ctx == nil {

--- a/dynatrace/rest/legacy_request.go
+++ b/dynatrace/rest/legacy_request.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@ import (
 	"os"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"golang.org/x/sync/semaphore"
 )
@@ -134,7 +134,7 @@ func (me *legacy_request) Raw() ([]byte, error) {
 		Jar:       jar,
 		Transport: http.DefaultTransport,
 	}
-	if strings.TrimSpace(os.Getenv("DYNATRACE_HTTP_INSECURE")) == "true" {
+	if envutils.DynatraceHTTPInsecure.Get() {
 		httpClient.Transport = &http.Transport{
 			ForceAttemptHTTP2:     http.DefaultTransport.(*http.Transport).ForceAttemptHTTP2,
 			Proxy:                 http.DefaultTransport.(*http.Transport).Proxy,

--- a/dynatrace/rest/legacy_request.go
+++ b/dynatrace/rest/legacy_request.go
@@ -166,7 +166,7 @@ func (me *legacy_request) Raw() ([]byte, error) {
 	if data, err = io.ReadAll(res.Body); err != nil {
 		return nil, err
 	}
-	if os.Getenv("DYNATRACE_HTTP_RESPONSE") == "true" {
+	if envutils.DynatraceHTTPResponse.Get() {
 		var dataStr string
 		if data != nil {
 			dataStr = " " + string(data)

--- a/dynatrace/rest/logging/logger.go
+++ b/dynatrace/rest/logging/logger.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,14 @@ import (
 	"log"
 	"os"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	logHTTPTrue   = "true"
+	logHTTPFalse  = "false"
+	logHTTPStdout = "stdout"
 )
 
 type RESTLogger struct {
@@ -32,27 +39,26 @@ type RESTLogger struct {
 }
 
 func (l *RESTLogger) Print(ctx context.Context, v ...any) {
-	if stdoutLog {
+	if envutils.DynatraceLogHTTP.Get() == logHTTPStdout {
 		tflog.Debug(ctx, fmt.Sprint(append(append([]any{}, "[HTTP]"), v...)...))
 	}
 	l.Log.Print(v...)
 }
 
 func (l *RESTLogger) Printf(ctx context.Context, format string, v ...any) {
-	if stdoutLog {
+	if envutils.DynatraceLogHTTP.Get() == logHTTPStdout {
 		tflog.Debug(ctx, fmt.Sprintf("[HTTP] "+format, v...))
 	}
 	l.Log.Printf(format, v...)
 }
 
 func (l *RESTLogger) Println(ctx context.Context, v ...any) {
-	if stdoutLog {
+	if envutils.DynatraceLogHTTP.Get() == logHTTPStdout {
 		tflog.Debug(ctx, fmt.Sprint(append(append([]any{}, "[HTTP]"), v...)...))
 	}
 	l.Log.Println(v...)
 }
 
-var stdoutLog = os.Getenv("DYNATRACE_LOG_HTTP") == "stdout"
 var logger = initLogger()
 var Logger = logger
 
@@ -71,15 +77,17 @@ func (odw *onDemandWriter) Write(p []byte) (n int, err error) {
 }
 
 func initLogger() *RESTLogger {
-	restLogFileName := os.Getenv("DYNATRACE_LOG_HTTP")
-	if len(restLogFileName) > 0 && restLogFileName != "false" && !stdoutLog {
-		logger := log.New(os.Stderr, "", log.LstdFlags)
-		if restLogFileName != "true" {
-			logger.SetOutput(&onDemandWriter{logFileName: restLogFileName})
-		}
-		return &RESTLogger{Log: logger}
+	logHTTP := envutils.DynatraceLogHTTP.Get()
+
+	if logHTTP == "" || logHTTP == logHTTPFalse || logHTTP == logHTTPStdout {
+		return &RESTLogger{Log: log.New(io.Discard, "", log.LstdFlags)}
 	}
-	return &RESTLogger{Log: log.New(io.Discard, "", log.LstdFlags)}
+
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	if logHTTP != logHTTPTrue {
+		logger.SetOutput(&onDemandWriter{logFileName: logHTTP})
+	}
+	return &RESTLogger{Log: logger}
 }
 
 func SetLogWriter(writer io.Writer) error {

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -37,7 +37,6 @@ import (
 )
 
 var preRequestMutex sync.Mutex
-var DYNATRACE_HTTP_LEGACY = (os.Getenv("DYNATRACE_HTTP_LEGACY") == "true")
 var DYNATRACE_HTTP_OAUTH_PREFERENCE = (os.Getenv("DYNATRACE_HTTP_OAUTH_PREFERENCE") == "true")
 
 type Request interface {

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2025 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/google/uuid"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
@@ -74,7 +75,7 @@ func PreRequest() {
 	preRequestMutex.Lock()
 	defer preRequestMutex.Unlock()
 
-	if strings.TrimSpace(os.Getenv("DYNATRACE_HTTP_INSECURE")) == "true" {
+	if envutils.DynatraceHTTPInsecure.Get() {
 		if transport, ok := http.DefaultTransport.(*http.Transport); ok {
 			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		}

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 
@@ -37,7 +36,6 @@ import (
 )
 
 var preRequestMutex sync.Mutex
-var DYNATRACE_HTTP_OAUTH_PREFERENCE = (os.Getenv("DYNATRACE_HTTP_OAUTH_PREFERENCE") == "true")
 
 type Request interface {
 	Finish(v ...any) error

--- a/dynatrace/settings/duplicates.go
+++ b/dynatrace/settings/duplicates.go
@@ -18,26 +18,24 @@
 package settings
 
 import (
-	"os"
 	"slices"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
-const DYNATRACE_DUPLICATE_HIJACK = "DYNATRACE_DUPLICATE_HIJACK"
 const VALUE_ALL = "ALL"
 
 func RejectDuplicate(resourceNames ...string) bool {
-	return envVarContains(envutils.DynatraceDuplicateReject.Get(), resourceNames...)
+	return envVarContains(envutils.DynatraceDuplicateReject, resourceNames...)
 }
 
 func HijackDuplicate(resourceNames ...string) bool {
-	return envVarContains(DYNATRACE_DUPLICATE_HIJACK, resourceNames...)
+	return envVarContains(envutils.DynatraceDuplicateHijack, resourceNames...)
 }
 
-func envVarContains(envVar string, search ...string) bool {
-	svalues := os.Getenv(envVar)
+func envVarContains(envVar envutils.StringEnvVar, search ...string) bool {
+	svalues := envVar.Get()
 	if len(svalues) == 0 {
 		return false
 	}

--- a/dynatrace/settings/duplicates.go
+++ b/dynatrace/settings/duplicates.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2025 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,14 +21,15 @@ import (
 	"os"
 	"slices"
 	"strings"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
-const DYNATRACE_DUPLICATE_REJECT = "DYNATRACE_DUPLICATE_REJECT"
 const DYNATRACE_DUPLICATE_HIJACK = "DYNATRACE_DUPLICATE_HIJACK"
 const VALUE_ALL = "ALL"
 
 func RejectDuplicate(resourceNames ...string) bool {
-	return envVarContains(DYNATRACE_DUPLICATE_REJECT, resourceNames...)
+	return envVarContains(envutils.DynatraceDuplicateReject.Get(), resourceNames...)
 }
 
 func HijackDuplicate(resourceNames ...string) bool {

--- a/dynatrace/settings/services/cache/cache_test.go
+++ b/dynatrace/settings/services/cache/cache_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -14,8 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
-//go:build unit
 
 package cache_test
 

--- a/dynatrace/settings/services/cache/common.go
+++ b/dynatrace/settings/services/cache/common.go
@@ -50,13 +50,11 @@ func Offline() {
 }
 
 func Cleanup() {
-	if os.Getenv(ENV_VAR_NO_CACHE_CLEANUP) == "true" {
+	if envutils.DTNoCacheCleanup.Get() {
 		return
 	}
 	os.RemoveAll(cache_root_folder)
 }
-
-const ENV_VAR_NO_CACHE_CLEANUP = "DT_NO_CACHE_CLEANUP"
 
 var cache_root_folder = getCacheRootFolder()
 

--- a/dynatrace/settings/services/cache/common.go
+++ b/dynatrace/settings/services/cache/common.go
@@ -56,7 +56,6 @@ func Cleanup() {
 	os.RemoveAll(cache_root_folder)
 }
 
-const ENV_VAR_DELETE_CACHE_ON_LAUNCH = "DT_CACHE_DELETE_ON_LAUNCH"
 const ENV_VAR_NO_CACHE_CLEANUP = "DT_NO_CACHE_CLEANUP"
 
 var cache_root_folder = getCacheRootFolder()
@@ -70,8 +69,7 @@ func getCacheRootFolder() string {
 	if envFolder := envutils.DTCacheFolder.Get(); envFolder != "" {
 		folder = envFolder
 	}
-	deleteCache := os.Getenv(ENV_VAR_DELETE_CACHE_ON_LAUNCH)
-	if len(deleteCache) != 0 && deleteCache != "false" {
+	if envutils.DTCacheDeleteOnLaunch.Get() {
 		os.RemoveAll(folder)
 	}
 	if envutils.CacheOfflineMode.Get() {

--- a/dynatrace/settings/services/cache/common.go
+++ b/dynatrace/settings/services/cache/common.go
@@ -56,7 +56,6 @@ func Cleanup() {
 	os.RemoveAll(cache_root_folder)
 }
 
-const ENV_VAR_CACHE_OFFLINE_MODE = "CACHE_OFFLINE_MODE"
 const ENV_VAR_DELETE_CACHE_ON_LAUNCH = "DT_CACHE_DELETE_ON_LAUNCH"
 const ENV_VAR_NO_CACHE_CLEANUP = "DT_NO_CACHE_CLEANUP"
 
@@ -75,7 +74,7 @@ func getCacheRootFolder() string {
 	if len(deleteCache) != 0 && deleteCache != "false" {
 		os.RemoveAll(folder)
 	}
-	if os.Getenv(ENV_VAR_CACHE_OFFLINE_MODE) == "true" {
+	if envutils.CacheOfflineMode.Get() {
 		Offline()
 	}
 	return folder

--- a/dynatrace/settings/services/cache/common.go
+++ b/dynatrace/settings/services/cache/common.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	"path"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/google/uuid"
 )
 
@@ -55,7 +56,6 @@ func Cleanup() {
 	os.RemoveAll(cache_root_folder)
 }
 
-const ENV_VAR_CACHE_ROOT_FOLDER = "DT_CACHE_FOLDER"
 const ENV_VAR_CACHE_OFFLINE_MODE = "CACHE_OFFLINE_MODE"
 const ENV_VAR_DELETE_CACHE_ON_LAUNCH = "DT_CACHE_DELETE_ON_LAUNCH"
 const ENV_VAR_NO_CACHE_CLEANUP = "DT_NO_CACHE_CLEANUP"
@@ -68,7 +68,7 @@ func GetCacheFolder() string {
 
 func getCacheRootFolder() string {
 	folder := path.Join(os.TempDir(), ".terraform-provider-dynatrace", uuid.NewString())
-	if envFolder := os.Getenv(ENV_VAR_CACHE_ROOT_FOLDER); envFolder != "" {
+	if envFolder := envutils.DTCacheFolder.Get(); envFolder != "" {
 		folder = envFolder
 	}
 	deleteCache := os.Getenv(ENV_VAR_DELETE_CACHE_ON_LAUNCH)

--- a/dynatrace/settings/services/cache/tar/tar_folder.go
+++ b/dynatrace/settings/services/cache/tar/tar_folder.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2025 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,13 +27,13 @@ import (
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 const bootstrapentry = "__bootstrap__"
 const bootstrapoffset = 512
 const indexentry = "__index__"
 
-var IN_MEMORY_TAR_FOLDERS = os.Getenv("DYNATRACE_IN_MEMORY_TAR_FOLDERS") == "true"
 
 var folderCache = FolderCache{
 	mu:      sync.Mutex{},
@@ -72,7 +72,7 @@ func New(name string) (*Folder, bool, error) {
 
 func NewExisting(name string) (*Folder, bool, error) {
 
-	if IN_MEMORY_TAR_FOLDERS {
+	if envutils.DynatraceInMemoryTarFolders.Get() {
 		folderCache.mu.Lock()
 		folder, ok := folderCache.folders[name]
 		if ok {
@@ -90,7 +90,7 @@ func NewExisting(name string) (*Folder, bool, error) {
 			return tf, true, err
 		}
 
-		if IN_MEMORY_TAR_FOLDERS {
+		if envutils.DynatraceInMemoryTarFolders.Get() {
 			folderCache.mu.Lock()
 
 			folder, ok := folderCache.folders[name]

--- a/dynatrace/settings/services/settings20/service.go
+++ b/dynatrace/settings/services/settings20/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,13 +31,13 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	"net/url"
 )
 
 var DISABLE_ORDERING_SUPPORT = os.Getenv("DYNATRACE_DISABLE_ORDERING_SUPPORT") == "true"
 
-var NO_REPAIR_INPUT = os.Getenv("DT_NO_REPAIR_INPUT") == "true"
 
 func Service[T settings.Settings](credentials *rest.Credentials, schemaID string, schemaVersion string, options ...*ServiceOptions[T]) settings.ListIDCRUDService[T] {
 	var opts *ServiceOptions[T]
@@ -359,7 +359,7 @@ type Matcher interface {
 }
 
 func (me *service[T]) skipRepairInput() bool {
-	return NO_REPAIR_INPUT
+	return envutils.DTNoRepairInput.Get()
 }
 
 var regexpNeighborWithKey = regexp.MustCompile(`Neighbor\swith\skey\s'[^']*'\snot\sfound\sfor\s'[^']*'`)

--- a/dynatrace/settings/services/settings20/service.go
+++ b/dynatrace/settings/services/settings20/service.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -36,7 +35,6 @@ import (
 	"net/url"
 )
 
-var DISABLE_ORDERING_SUPPORT = os.Getenv("DYNATRACE_DISABLE_ORDERING_SUPPORT") == "true"
 
 
 func Service[T settings.Settings](credentials *rest.Credentials, schemaID string, schemaVersion string, options ...*ServiceOptions[T]) settings.ListIDCRUDService[T] {
@@ -109,7 +107,7 @@ func (me *service[T]) Get(ctx context.Context, id string, v T) error {
 }
 
 func (me *service[T]) handleOrdering(ctx context.Context, id string, v T) error {
-	if DISABLE_ORDERING_SUPPORT {
+	if envutils.DynatraceDisableOrderingSupport.Get() {
 		return nil
 	}
 

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -2,7 +2,7 @@
 
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -46,7 +47,7 @@ func AccEnvsGiven(t *testing.T) bool {
 		t.Skip("TF_ACC has not been set for acceptance tests")
 		return false
 	}
-	if v := os.Getenv("DYNATRACE_ENV_URL"); v == "" {
+	if v := envutils.DynatraceEnvURL.Get(); v == "" {
 		t.Skip("DYNATRACE_ENV_URL has not been set for acceptance tests")
 		return false
 	}
@@ -61,8 +62,8 @@ func replaceWithIdentifier(config string, identifier string) string {
 
 // ReadTfConfig reads a config and replaces "#name#" and "${randomize}" with a random string
 // Returns:
-// 	- The replaced config
-//  - The random string that was used
+//   - The replaced config
+//   - The random string that was used
 func ReadTfConfig(t *testing.T, file string) (config string, identifier string) {
 	identifier = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	return ReadTfConfigWithIdentifier(t, file, identifier), identifier

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -43,7 +43,7 @@ type TestAccOptions struct {
 
 func AccEnvsGiven(t *testing.T) bool {
 	t.Helper()
-	if v := os.Getenv("TF_ACC"); v == "" {
+	if v := envutils.TFAcc.Get(); v == "" {
 		t.Skip("TF_ACC has not been set for acceptance tests")
 		return false
 	}

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,9 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// HTTPVerbose if set to `true` terraform-provider-dynatrace.log will contain request and response payload
-var HTTPVerbose = (strings.TrimSpace(os.Getenv("DYNATRACE_DEBUG")) == "true")
 
 type IAM struct {
 	ClientID     string

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -18,9 +18,9 @@
 package config
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
 
 type IAM struct {
 	ClientID     string
@@ -303,69 +304,26 @@ func (me ConfigGetter) Get(key string) any {
 	if result == nil {
 		return ""
 	}
-	srcEnvVars := []string{}
+	var sourceEnvVar *envutils.MultiStringEnvVar
 	switch key {
 	case "dt_env_url", "automation_env_url":
-		srcEnvVars = sourceEnvURLEnvVars
+		sourceEnvVar = &envutils.DynatraceSourceEnvURL
 	case "dt_api_token":
-		srcEnvVars = sourceAPITokenEnvVars
+		sourceEnvVar = &envutils.DynatraceSourceAPIToken
 	case "client_id", "automation_client_id":
-		srcEnvVars = sourceClientIDEnvVars
+		sourceEnvVar = &envutils.DynatraceSourceClientID
 	case "account_id":
-		srcEnvVars = sourceAccountIDEnvVars
+		sourceEnvVar = &envutils.DynatraceSourceAccountID
 	case "client_secret", "automation_client_secret":
-		srcEnvVars = sourceClientSecretEnvVars
+		sourceEnvVar = &envutils.DynatraceSourceClientSecret
 	case "platform_token":
-		srcEnvVars = sourcePlatformTokenEnvVars
+		sourceEnvVar = &envutils.DynatraceSourcePlatformToken
 	}
-	if len(srcEnvVars) > 0 {
-		sourceValue := evalSourceEnv(sourceEnvURLEnvVars)
-		if len(sourceValue) > 0 {
+	if sourceEnvVar != nil {
+		if sourceValue := envutils.DynatraceSourceEnvURL.Get(); len(sourceValue) > 0 {
 			return sourceValue
 		}
 	}
 
 	return result
-}
-
-var sourceEnvURLEnvVars = []string{
-	"DYNATRACE_SOURCE_ENV_URL",
-	"DT_SOURCE_ENV_URL",
-	"DYNATRACE_SOURCE_ENVIRONMENT_URL",
-	"DT_SOURCE_ENVIRONMENT_URL",
-}
-
-var sourceAPITokenEnvVars = []string{
-	"DYNATRACE_SOURCE_API_TOKEN",
-	"DT_SOURCE_API_TOKEN",
-}
-
-var sourceClientIDEnvVars = []string{
-	"DT_SOURCE_CLIENT_ID",
-	"DYNATRACE_SOURCE_CLIENT_ID",
-}
-
-var sourceAccountIDEnvVars = []string{
-	"DT_SOURCE_ACCOUNT_ID",
-	"DYNATRACE_SOURCE_ACCOUNT_ID",
-}
-
-var sourceClientSecretEnvVars = []string{
-	"DT_SOURCE_CLIENT_SECRET",
-	"DYNATRACE_SOURCE_CLIENT_SECRET",
-}
-
-var sourcePlatformTokenEnvVars = []string{
-	"DYNATRACE_SOURCE_PLATFORM_TOKEN",
-	"DT_SOURCE_PLATFORM_TOKEN",
-}
-
-func evalSourceEnv(envVars []string) string {
-	for _, envVar := range envVars {
-		value := os.Getenv(envVar)
-		if len(value) > 0 {
-			return value
-		}
-	}
-	return ""
 }

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -320,7 +320,7 @@ func (me ConfigGetter) Get(key string) any {
 		sourceEnvVar = &envutils.DynatraceSourcePlatformToken
 	}
 	if sourceEnvVar != nil {
-		if sourceValue := envutils.DynatraceSourceEnvURL.Get(); len(sourceValue) > 0 {
+		if sourceValue := sourceEnvVar.Get(); len(sourceValue) > 0 {
 			return sourceValue
 		}
 	}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -80,3 +80,9 @@ var DynatraceMaxHTTPWorkers = ClampedIntEnvVar{
 	Min:          1,
 	Max:          50,
 }
+
+// DTRestDebugLog sets the file path for REST debug logging.
+var DTRestDebugLog = StringEnvVar{
+	Key:          "DT_REST_DEBUG_LOG",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -356,3 +356,9 @@ var DynatraceUltraParallel = BoolEnvVar{
 	Key:          "DYNATRACE_ULTRA_PARALLEL",
 	DefaultValue: false,
 }
+
+// DynatraceParallel enables parallel export mode.
+var DynatraceParallel = BoolEnvVar{
+	Key:          "DYNATRACE_PARALLEL",
+	DefaultValue: true,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -230,3 +230,11 @@ var DynatraceTagsErrZeroMatched = BoolEnvVar{
 	Key:          "DYNATRACE_TAGS_ERR_ZERO_MATCHED",
 	DefaultValue: false,
 }
+
+// --- Resources ---
+
+// DTTerraformImport enables Terraform import mode.
+var DTTerraformImport = BoolEnvVar{
+	Key:          "DT_TERRAFORM_IMPORT",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -216,3 +216,9 @@ var DynatraceDuplicateReject = StringEnvVar{
 	Key:          "DYNATRACE_DUPLICATE_REJECT",
 	DefaultValue: "",
 }
+
+// DynatraceDuplicateHijack specifies resource types for which duplicate detection hijacks the existing resource.
+var DynatraceDuplicateHijack = StringEnvVar{
+	Key:          "DYNATRACE_DUPLICATE_HIJACK",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -250,3 +250,11 @@ var DynatraceGoldenStateEnabled = BoolEnvVar{
 	Key:          "DYNATRACE_GOLDEN_STATE_ENABLED",
 	DefaultValue: false,
 }
+
+// --- Dashboards ---
+
+// DynatraceDashboardTests enables dashboard test behavior.
+var DynatraceDashboardTests = BoolEnvVar{
+	Key:          "DYNATRACE_DASHBOARD_TESTS",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -430,3 +430,9 @@ var DynatraceImportStatePath = StringEnvVar{
 	Key:          "DYNATRACE_IMPORT_STATE_PATH",
 	DefaultValue: "",
 }
+
+// DynatracePrevStateOn enables keeping resource identifiers stable between runs so downstream Terraform references don't break.
+var DynatracePrevStateOn = BoolEnvVar{
+	Key:          "DYNATRACE_PREV_STATE_ON",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -140,3 +140,11 @@ var DTBackwardsCompatibility = BoolEnvVar{
 	Key:          "DT_BACKWARDS_COMPATIBILITY",
 	DefaultValue: false,
 }
+
+// --- Buckets ---
+
+// DTBucketsIgnoreUnexpectedEOF ignores unexpected EOF errors when managing buckets.
+var DTBucketsIgnoreUnexpectedEOF = BoolEnvVar{
+	Key:          "DT_BUCKETS_IGNORE_UNEXPECTED_EOF",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -182,3 +182,11 @@ var DTMgmzSuccesses = ClampedIntEnvVar{
 	Min:          5,
 	Max:          100,
 }
+
+// --- Documents ---
+
+// DTDocumentsIgnoreUnexpectedEOF ignores unexpected EOF errors when managing documents.
+var DTDocumentsIgnoreUnexpectedEOF = BoolEnvVar{
+	Key:          "DT_DOCUMENTS_IGNORE_UNEXPECTED_EOF",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -374,3 +374,9 @@ var DynatraceEnableExportDashboard = BoolEnvVar{
 	Key:          "DYNATRACE_ENABLE_EXPORT_DASHBOARD",
 	DefaultValue: false,
 }
+
+// DynatraceAtomicDependencies exports dependencies atomically.
+var DynatraceAtomicDependencies = BoolEnvVar{
+	Key:          "DYNATRACE_ATOMIC_DEPENDENCIES",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -442,3 +442,9 @@ var DynatracePrevStatePathThis = StringEnvVar{
 	Key:          "DYNATRACE_PREV_STATE_PATH_THIS",
 	DefaultValue: "",
 }
+
+// DynatracePrevStatePathLinked sets the path to the previous state for linked environments.
+var DynatracePrevStatePathLinked = StringEnvVar{
+	Key:          "DYNATRACE_PREV_STATE_PATH_LINKED",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -398,3 +398,9 @@ var DynatraceHCLNoFormat = BoolEnvVar{
 	Key:          "DYNATRACE_HCL_NO_FORMAT",
 	DefaultValue: false,
 }
+
+// DynatraceNameReplaceDash replaces dashes with underscores in resource names.
+var DynatraceNameReplaceDash = BoolEnvVar{
+	Key:          "DYNATRACE_NAME_REPLACE_DASH",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -1,0 +1,26 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package envutils
+
+// --- General Provider ---
+
+// DynatraceDebug enables debug logging for the provider.
+var DynatraceDebug = BoolEnvVar{
+	Key:          "DYNATRACE_DEBUG",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -66,3 +66,9 @@ var DynatraceHTTPResponse = BoolEnvVar{
 	Key:          "DYNATRACE_HTTP_RESPONSE",
 	DefaultValue: false,
 }
+
+// DTDebugGetOk enables debug logging for successful GET requests.
+var DTDebugGetOk = BoolEnvVar{
+	Key:          "DT_DEBUG_GET_OK",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -108,3 +108,9 @@ var DTCacheFolder = StringEnvVar{
 	Key:          "DT_CACHE_FOLDER",
 	DefaultValue: "",
 }
+
+// CacheOfflineMode enables offline mode using cached data.
+var CacheOfflineMode = BoolEnvVar{
+	Key:          "CACHE_OFFLINE_MODE",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -24,3 +24,9 @@ var DynatraceDebug = BoolEnvVar{
 	Key:          "DYNATRACE_DEBUG",
 	DefaultValue: false,
 }
+
+// DynatraceLogDebugPrefix sets the prefix filter for debug log entries.
+var DynatraceLogDebugPrefix = StringEnvVar{
+	Key:          "DYNATRACE_LOG_DEBUG_PREFIX",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -120,3 +120,9 @@ var DTCacheDeleteOnLaunch = BoolEnvVar{
 	Key:          "DT_CACHE_DELETE_ON_LAUNCH",
 	DefaultValue: false,
 }
+
+// DTNoCacheCleanup specifies whether to skip automatic cache cleanup on provider shutdown.
+var DTNoCacheCleanup = BoolEnvVar{
+	Key:          "DT_NO_CACHE_CLEANUP",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -126,3 +126,9 @@ var DTNoCacheCleanup = BoolEnvVar{
 	Key:          "DT_NO_CACHE_CLEANUP",
 	DefaultValue: false,
 }
+
+// DynatraceInMemoryTarFolders uses in-memory tar archives for cache folders.
+var DynatraceInMemoryTarFolders = BoolEnvVar{
+	Key:          "DYNATRACE_IN_MEMORY_TAR_FOLDERS",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -30,3 +30,13 @@ var DynatraceLogDebugPrefix = StringEnvVar{
 	Key:          "DYNATRACE_LOG_DEBUG_PREFIX",
 	DefaultValue: "",
 }
+
+// DynatraceLogHTTP sets the file path for HTTP request/response logging.
+// If set to "false" (note case) or an empty value, HTTP logging is disabled.
+// If set to "true" (note case), HTTP logs will be written to standard error with a "[HTTP]" prefix.
+// If set to "stdout" (note case), HTTP logs will be written to standard output with a "[HTTP]" prefix.
+// If set to any other non-empty value, it is treated as a file path where HTTP logs will be written.
+var DynatraceLogHTTP = StringEnvVar{
+	Key:          "DYNATRACE_LOG_HTTP",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -528,3 +528,13 @@ var Migration = BoolEnvVar{
 	Key:          "MIGRATION",
 	DefaultValue: false,
 }
+
+// --- Synthetic Monitors ---
+
+// DynatraceCreateConfirmSyntheticMonitorsV2 is the number of confirmation retries when creating synthetic monitors v2. Falls back to the default if the value is outside [Min, Max].
+var DynatraceCreateConfirmSyntheticMonitorsV2 = BoundedIntEnvVar{
+	Key:          "DYNATRACE_CREATE_CONFIRM_SYNTHETIC_MONITORS_V2",
+	DefaultValue: 8,
+	Min:          1,
+	Max:          50,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -368,3 +368,9 @@ var DynatraceShorterNames = BoolEnvVar{
 	Key:          "DYNATRACE_SHORTER_NAMES",
 	DefaultValue: false,
 }
+
+// DynatraceEnableExportDashboard enables export of dashboard resources.
+var DynatraceEnableExportDashboard = BoolEnvVar{
+	Key:          "DYNATRACE_ENABLE_EXPORT_DASHBOARD",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -392,3 +392,9 @@ var DynatraceFormatHCLFiles = BoolEnvVar{
 	Key:          "DYNATRACE_FORMAT_HCL_FILES",
 	DefaultValue: false,
 }
+
+// DynatraceHCLNoFormat disables HCL formatting during export.
+var DynatraceHCLNoFormat = BoolEnvVar{
+	Key:          "DYNATRACE_HCL_NO_FORMAT",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -350,3 +350,9 @@ var DynatraceQuickInit = BoolEnvVar{
 	Key:          "DYNATRACE_QUICK_INIT",
 	DefaultValue: false,
 }
+
+// DynatraceUltraParallel enables ultra-parallel export mode.
+var DynatraceUltraParallel = BoolEnvVar{
+	Key:          "DYNATRACE_ULTRA_PARALLEL",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -244,3 +244,9 @@ var DynatraceForceNewOnHeaders = BoolEnvVar{
 	Key:          "DYNATRACE_FORCE_NEW_ON_HEADERS",
 	DefaultValue: false,
 }
+
+// DynatraceGoldenStateEnabled enables golden state tracking for resources.
+var DynatraceGoldenStateEnabled = BoolEnvVar{
+	Key:          "DYNATRACE_GOLDEN_STATE_ENABLED",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -514,3 +514,9 @@ var DynatraceAPIToken = StringEnvVar{
 	Key:          "DYNATRACE_API_TOKEN",
 	DefaultValue: "",
 }
+
+// TFAcc enables Terraform acceptance tests when set to a non-empty value.
+var TFAcc = StringEnvVar{
+	Key:          "TF_ACC",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -208,3 +208,11 @@ var DynatraceDisableEntityCache = BoolEnvVar{
 	Key:          "DYNATRACE_DISABLE_ENTITY_CACHE",
 	DefaultValue: false,
 }
+
+// --- Duplicates ---
+
+// DynatraceDuplicateReject specifies resource types for which duplicate detection rejects the import.
+var DynatraceDuplicateReject = StringEnvVar{
+	Key:          "DYNATRACE_DUPLICATE_REJECT",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -410,3 +410,9 @@ var DynatraceBuildAddressFiles = BoolEnvVar{
 	Key:          "DYNATRACE_BUILD_ADDRESS_FILES",
 	DefaultValue: false,
 }
+
+// DynatraceExportIgnoreResources is a comma-separated list of resource types to exclude from export.
+var DynatraceExportIgnoreResources = StringEnvVar{
+	Key:          "DYNATRACE_EXPORT_IGNORE_RESOURCES",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -94,3 +94,9 @@ var DTNoRepairInput = BoolEnvVar{
 	Key:          "DT_NO_REPAIR_INPUT",
 	DefaultValue: false,
 }
+
+// DynatraceDisableOrderingSupport disables ordering support for settings resources.
+var DynatraceDisableOrderingSupport = BoolEnvVar{
+	Key:          "DYNATRACE_DISABLE_ORDERING_SUPPORT",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -332,3 +332,9 @@ var DynatraceProviderVersion = StringEnvVar{
 	Key:          "DYNATRACE_PROVIDER_VERSION",
 	DefaultValue: "",
 }
+
+// DynatraceCustomProviderLocation sets the custom provider binary location.
+var DynatraceCustomProviderLocation = StringEnvVar{
+	Key:          "DYNATRACE_CUSTOM_PROVIDER_LOCATION",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -164,3 +164,13 @@ var DTBucketsNumSuccesses = ClampedIntEnvVar{
 	Min:          10,
 	Max:          50,
 }
+
+// --- Management Zones ---
+
+// DTMgmzRetries is the number of retries when waiting for management zone readiness. Values outside [Min, Max] are clamped to the nearest boundary.
+var DTMgmzRetries = ClampedIntEnvVar{
+	Key:          "DT_MGMZ_RETRIES",
+	DefaultValue: 50,
+	Min:          50,
+	Max:          600,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -114,3 +114,9 @@ var CacheOfflineMode = BoolEnvVar{
 	Key:          "CACHE_OFFLINE_MODE",
 	DefaultValue: false,
 }
+
+// DTCacheDeleteOnLaunch enables deleting the cache on provider launch.
+var DTCacheDeleteOnLaunch = BoolEnvVar{
+	Key:          "DT_CACHE_DELETE_ON_LAUNCH",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -86,3 +86,11 @@ var DTRestDebugLog = StringEnvVar{
 	Key:          "DT_REST_DEBUG_LOG",
 	DefaultValue: "",
 }
+
+// --- Settings 2.0 ---
+
+// DTNoRepairInput disables automatic repair of invalid settings input.
+var DTNoRepairInput = BoolEnvVar{
+	Key:          "DT_NO_REPAIR_INPUT",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -448,3 +448,55 @@ var DynatracePrevStatePathLinked = StringEnvVar{
 	Key:          "DYNATRACE_PREV_STATE_PATH_LINKED",
 	DefaultValue: "",
 }
+
+// --- Source Environment (multi-key fallback) ---
+
+// DynatraceSourceEnvURL is the URL of the source Dynatrace environment for migration.
+var DynatraceSourceEnvURL = MultiStringEnvVar{
+	Keys: []string{
+		"DYNATRACE_SOURCE_ENV_URL",
+		"DT_SOURCE_ENV_URL",
+		"DYNATRACE_SOURCE_ENVIRONMENT_URL",
+		"DT_SOURCE_ENVIRONMENT_URL",
+	},
+}
+
+// DynatraceSourceAPIToken is the API token for the source Dynatrace environment.
+var DynatraceSourceAPIToken = MultiStringEnvVar{
+	Keys: []string{
+		"DYNATRACE_SOURCE_API_TOKEN",
+		"DT_SOURCE_API_TOKEN",
+	},
+}
+
+// DynatraceSourceClientID is the OAuth client ID for the source Dynatrace environment.
+var DynatraceSourceClientID = MultiStringEnvVar{
+	Keys: []string{
+		"DT_SOURCE_CLIENT_ID",
+		"DYNATRACE_SOURCE_CLIENT_ID",
+	},
+}
+
+// DynatraceSourceAccountID is the account ID for the source Dynatrace environment.
+var DynatraceSourceAccountID = MultiStringEnvVar{
+	Keys: []string{
+		"DT_SOURCE_ACCOUNT_ID",
+		"DYNATRACE_SOURCE_ACCOUNT_ID",
+	},
+}
+
+// DynatraceSourceClientSecret is the OAuth client secret for the source Dynatrace environment.
+var DynatraceSourceClientSecret = MultiStringEnvVar{
+	Keys: []string{
+		"DT_SOURCE_CLIENT_SECRET",
+		"DYNATRACE_SOURCE_CLIENT_SECRET",
+	},
+}
+
+// DynatraceSourcePlatformToken is the platform token for the source Dynatrace environment.
+var DynatraceSourcePlatformToken = MultiStringEnvVar{
+	Keys: []string{
+		"DYNATRACE_SOURCE_PLATFORM_TOKEN",
+		"DT_SOURCE_PLATFORM_TOKEN",
+	},
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -380,3 +380,9 @@ var DynatraceAtomicDependencies = BoolEnvVar{
 	Key:          "DYNATRACE_ATOMIC_DEPENDENCIES",
 	DefaultValue: false,
 }
+
+// DynatraceMigrationCacheFolder sets the migration cache folder path.
+var DynatraceMigrationCacheFolder = StringEnvVar{
+	Key:          "DYNATRACE_MIGRATION_CACHE_FOLDER",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -548,3 +548,13 @@ var DynatraceCreateConfirmWebApplication = BoundedIntEnvVar{
 	Min:          20,
 	Max:          500,
 }
+
+// --- Custom Tags ---
+
+// DynatraceMaxConcurrentCustomTagListRequests is the maximum number of concurrent requests for listing custom tags. Falls back to the default if the value is outside [Min, Max].
+var DynatraceMaxConcurrentCustomTagListRequests = BoundedIntEnvVar{
+	Key:          "DYNATRACE_MAX_CONCURRENT_CUSTOM_TAG_LIST_REQUESTS",
+	DefaultValue: 4,
+	Min:          1,
+	Max:          20,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -424,3 +424,9 @@ var DynatraceIgnoreChangesRequiresAttention = BoolEnvVar{
 	Key:          "DYNATRACE_IGNORE_CHANGES_REQUIRES_ATTENTION",
 	DefaultValue: false,
 }
+
+// DynatraceImportStatePath sets the path for importing Terraform state.
+var DynatraceImportStatePath = StringEnvVar{
+	Key:          "DYNATRACE_IMPORT_STATE_PATH",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -238,3 +238,9 @@ var DTTerraformImport = BoolEnvVar{
 	Key:          "DT_TERRAFORM_IMPORT",
 	DefaultValue: false,
 }
+
+// DynatraceForceNewOnHeaders forces resource recreation when HTTP headers change.
+var DynatraceForceNewOnHeaders = BoolEnvVar{
+	Key:          "DYNATRACE_FORCE_NEW_ON_HEADERS",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -60,3 +60,9 @@ var DynatraceHTTPOAuthPreference = BoolEnvVar{
 	Key:          "DYNATRACE_HTTP_OAUTH_PREFERENCE",
 	DefaultValue: false,
 }
+
+// DynatraceHTTPResponse logs HTTP responses.
+var DynatraceHTTPResponse = BoolEnvVar{
+	Key:          "DYNATRACE_HTTP_RESPONSE",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -100,3 +100,11 @@ var DynatraceDisableOrderingSupport = BoolEnvVar{
 	Key:          "DYNATRACE_DISABLE_ORDERING_SUPPORT",
 	DefaultValue: false,
 }
+
+// --- Cache ---
+
+// DTCacheFolder sets the path to the cache folder.
+var DTCacheFolder = StringEnvVar{
+	Key:          "DT_CACHE_FOLDER",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -362,3 +362,9 @@ var DynatraceParallel = BoolEnvVar{
 	Key:          "DYNATRACE_PARALLEL",
 	DefaultValue: true,
 }
+
+// DynatraceShorterNames enables shortening resource names longer than would exceed 240 characters in length in generated HCL.
+var DynatraceShorterNames = BoolEnvVar{
+	Key:          "DYNATRACE_SHORTER_NAMES",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -320,3 +320,9 @@ var DynatraceCleanTargetFolder = BoolEnvVar{
 	Key:          "DYNATRACE_CLEAN_TARGET_FOLDER",
 	DefaultValue: false,
 }
+
+// DynatraceProviderSource sets the provider source for generated Terraform files.
+var DynatraceProviderSource = StringEnvVar{
+	Key:          "DYNATRACE_PROVIDER_SOURCE",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -290,3 +290,11 @@ var DynatraceHostMonitoringStrictUpdateRetries = ClampedIntEnvVar{
 	Min:          0,
 	Max:          60,
 }
+
+// --- Workflows ---
+
+// DynatraceWorkflowTasksUseTypeList uses a type list for workflow task filtering.
+var DynatraceWorkflowTasksUseTypeList = BoolEnvVar{
+	Key:          "DYNATRACE_WORKFLOW_TASKS_USE_TYPE_LIST",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -222,3 +222,11 @@ var DynatraceDuplicateHijack = StringEnvVar{
 	Key:          "DYNATRACE_DUPLICATE_HIJACK",
 	DefaultValue: "",
 }
+
+// --- Tags ---
+
+// DynatraceTagsErrZeroMatched returns an error when a tag query matches zero entities.
+var DynatraceTagsErrZeroMatched = BoolEnvVar{
+	Key:          "DYNATRACE_TAGS_ERR_ZERO_MATCHED",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -314,3 +314,9 @@ var DynatraceTargetFolder = StringEnvVar{
 	Key:          "DYNATRACE_TARGET_FOLDER",
 	DefaultValue: "",
 }
+
+// DynatraceCleanTargetFolder enables cleaning of the target folder before export.
+var DynatraceCleanTargetFolder = BoolEnvVar{
+	Key:          "DYNATRACE_CLEAN_TARGET_FOLDER",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -276,3 +276,9 @@ var DynatraceHostMonitoringOffline = BoolEnvVar{
 	Key:          "DYNATRACE_HOST_MONITORING_OFFLINE",
 	DefaultValue: false,
 }
+
+// DynatraceHostMonitoringWarnings enables warnings for host monitoring issues.
+var DynatraceHostMonitoringWarnings = BoolEnvVar{
+	Key:          "DYNATRACE_HOST_MONITORING_WARNINGS",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -48,3 +48,9 @@ var DynatraceHTTPInsecure = BoolEnvVar{
 	Key:          "DYNATRACE_HTTP_INSECURE",
 	DefaultValue: false,
 }
+
+// DynatraceHTTPLegacy uses the legacy HTTP client.
+var DynatraceHTTPLegacy = BoolEnvVar{
+	Key:          "DYNATRACE_HTTP_LEGACY",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -386,3 +386,9 @@ var DynatraceMigrationCacheFolder = StringEnvVar{
 	Key:          "DYNATRACE_MIGRATION_CACHE_FOLDER",
 	DefaultValue: "",
 }
+
+// DynatraceFormatHCLFiles enables formatting of generated HCL files.
+var DynatraceFormatHCLFiles = BoolEnvVar{
+	Key:          "DYNATRACE_FORMAT_HCL_FILES",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -416,3 +416,11 @@ var DynatraceExportIgnoreResources = StringEnvVar{
 	Key:          "DYNATRACE_EXPORT_IGNORE_RESOURCES",
 	DefaultValue: "",
 }
+
+// DynatraceIgnoreChangesRequiresAttention enables adding a lifecycle { ignore_changes = [...] } block
+// to exported resources that contain sensitive fields (passwords, secrets, etc.) — listing those sensitive
+// attributes so Terraform won't overwrite values the user may have set manually after the export.
+var DynatraceIgnoreChangesRequiresAttention = BoolEnvVar{
+	Key:          "DYNATRACE_IGNORE_CHANGES_REQUIRES_ATTENTION",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -404,3 +404,9 @@ var DynatraceNameReplaceDash = BoolEnvVar{
 	Key:          "DYNATRACE_NAME_REPLACE_DASH",
 	DefaultValue: false,
 }
+
+// DynatraceBuildAddressFiles generates address files during export.
+var DynatraceBuildAddressFiles = BoolEnvVar{
+	Key:          "DYNATRACE_BUILD_ADDRESS_FILES",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -156,3 +156,11 @@ var DTBucketsRetries = ClampedIntEnvVar{
 	Min:          180,
 	Max:          360,
 }
+
+// DTBucketsNumSuccesses is the number of consecutive successes required for bucket readiness. Values outside [Min, Max] are clamped to the nearest boundary.
+var DTBucketsNumSuccesses = ClampedIntEnvVar{
+	Key:          "DT_BUCKETS_NUM_SUCCESSES",
+	DefaultValue: 10,
+	Min:          10,
+	Max:          50,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -344,3 +344,9 @@ var DynatraceNoRefreshOnImport = BoolEnvVar{
 	Key:          "DYNATRACE_NO_REFRESH_ON_IMPORT",
 	DefaultValue: false,
 }
+
+// DynatraceQuickInit enables quick initialization during export.
+var DynatraceQuickInit = BoolEnvVar{
+	Key:          "DYNATRACE_QUICK_INIT",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -338,3 +338,9 @@ var DynatraceCustomProviderLocation = StringEnvVar{
 	Key:          "DYNATRACE_CUSTOM_PROVIDER_LOCATION",
 	DefaultValue: "",
 }
+
+// DynatraceNoRefreshOnImport skips refreshing resources after export.
+var DynatraceNoRefreshOnImport = BoolEnvVar{
+	Key:          "DYNATRACE_NO_REFRESH_ON_IMPORT",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -500,3 +500,11 @@ var DynatraceSourcePlatformToken = MultiStringEnvVar{
 		"DT_SOURCE_PLATFORM_TOKEN",
 	},
 }
+
+// --- Testing ---
+
+// DynatraceEnvURL sets the Dynatrace environment URL for acceptance tests.
+var DynatraceEnvURL = StringEnvVar{
+	Key:          "DYNATRACE_ENV_URL",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -298,3 +298,11 @@ var DynatraceWorkflowTasksUseTypeList = BoolEnvVar{
 	Key:          "DYNATRACE_WORKFLOW_TASKS_USE_TYPE_LIST",
 	DefaultValue: false,
 }
+
+// --- HCL / Terraform Generation ---
+
+// DynatraceHeredoc enables heredoc usage in generated HCL.
+var DynatraceHeredoc = BoolEnvVar{
+	Key:          "DYNATRACE_HEREDOC",
+	DefaultValue: true,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -200,3 +200,11 @@ var DTCustomDeviceApplyTimeout = ClampedIntEnvVar{
 	Min:          100,
 	Max:          500,
 }
+
+// --- Entity ---
+
+// DynatraceDisableEntityCache disables the entity cache.
+var DynatraceDisableEntityCache = BoolEnvVar{
+	Key:          "DYNATRACE_DISABLE_ENTITY_CACHE",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -148,3 +148,11 @@ var DTBucketsIgnoreUnexpectedEOF = BoolEnvVar{
 	Key:          "DT_BUCKETS_IGNORE_UNEXPECTED_EOF",
 	DefaultValue: false,
 }
+
+// DTBucketsRetries is the number of retries when waiting for bucket readiness. Values outside [Min, Max] are clamped to the nearest boundary.
+var DTBucketsRetries = ClampedIntEnvVar{
+	Key:          "DT_BUCKETS_RETRIES",
+	DefaultValue: 180,
+	Min:          180,
+	Max:          360,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -268,3 +268,11 @@ var DynatraceDQLPollSleepDuration = BoundedIntEnvVar{
 	Min:          0,
 	Max:          60000,
 }
+
+// --- Host Monitoring ---
+
+// DynatraceHostMonitoringOffline allows managing host monitoring for offline hosts.
+var DynatraceHostMonitoringOffline = BoolEnvVar{
+	Key:          "DYNATRACE_HOST_MONITORING_OFFLINE",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -40,3 +40,11 @@ var DynatraceLogHTTP = StringEnvVar{
 	Key:          "DYNATRACE_LOG_HTTP",
 	DefaultValue: "",
 }
+
+// --- HTTP ---
+
+// DynatraceHTTPInsecure disables TLS certificate verification for HTTP requests.
+var DynatraceHTTPInsecure = BoolEnvVar{
+	Key:          "DYNATRACE_HTTP_INSECURE",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -258,3 +258,13 @@ var DynatraceDashboardTests = BoolEnvVar{
 	Key:          "DYNATRACE_DASHBOARD_TESTS",
 	DefaultValue: false,
 }
+
+// --- DQL ---
+
+// DynatraceDQLPollSleepDuration is the sleep duration in milliseconds between DQL poll attempts. Values outside [Min, Max] are clamped to the nearest boundary.
+var DynatraceDQLPollSleepDuration = BoundedIntEnvVar{
+	Key:          "DYNATRACE_DQL_POLL_SLEEP_DURATION",
+	DefaultValue: 5000,
+	Min:          0,
+	Max:          60000,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -508,3 +508,9 @@ var DynatraceEnvURL = StringEnvVar{
 	Key:          "DYNATRACE_ENV_URL",
 	DefaultValue: "",
 }
+
+// DynatraceAPIToken sets the Dynatrace API token for acceptance tests.
+var DynatraceAPIToken = StringEnvVar{
+	Key:          "DYNATRACE_API_TOKEN",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -72,3 +72,11 @@ var DTDebugGetOk = BoolEnvVar{
 	Key:          "DT_DEBUG_GET_OK",
 	DefaultValue: false,
 }
+
+// DynatraceMaxHTTPWorkers sets the maximum number of concurrent HTTP workers. Values outside [Min, Max] are clamped to the nearest boundary.
+var DynatraceMaxHTTPWorkers = ClampedIntEnvVar{
+	Key:          "DYNATRACE_MAX_HTTP_WORKERS",
+	DefaultValue: 20,
+	Min:          1,
+	Max:          50,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -132,3 +132,11 @@ var DynatraceInMemoryTarFolders = BoolEnvVar{
 	Key:          "DYNATRACE_IN_MEMORY_TAR_FOLDERS",
 	DefaultValue: false,
 }
+
+// --- Backwards Compatibility ---
+
+// DTBackwardsCompatibility enables backwards compatibility mode.
+var DTBackwardsCompatibility = BoolEnvVar{
+	Key:          "DT_BACKWARDS_COMPATIBILITY",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -190,3 +190,13 @@ var DTDocumentsIgnoreUnexpectedEOF = BoolEnvVar{
 	Key:          "DT_DOCUMENTS_IGNORE_UNEXPECTED_EOF",
 	DefaultValue: false,
 }
+
+// --- Custom Device ---
+
+// DTCustomDeviceApplyTimeout is the timeout in seconds for custom device apply operations. Values outside [Min, Max] are clamped to the nearest boundary.
+var DTCustomDeviceApplyTimeout = ClampedIntEnvVar{
+	Key:          "DT_CUSTOM_DEVICE_APPLY_TIMEOUT",
+	DefaultValue: 100,
+	Min:          100,
+	Max:          500,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -436,3 +436,9 @@ var DynatracePrevStateOn = BoolEnvVar{
 	Key:          "DYNATRACE_PREV_STATE_ON",
 	DefaultValue: false,
 }
+
+// DynatracePrevStatePathThis sets the path to the previous state for the current environment.
+var DynatracePrevStatePathThis = StringEnvVar{
+	Key:          "DYNATRACE_PREV_STATE_PATH_THIS",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -306,3 +306,11 @@ var DynatraceHeredoc = BoolEnvVar{
 	Key:          "DYNATRACE_HEREDOC",
 	DefaultValue: true,
 }
+
+// --- Export ---
+
+// DynatraceTargetFolder sets the target folder for export output.
+var DynatraceTargetFolder = StringEnvVar{
+	Key:          "DYNATRACE_TARGET_FOLDER",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -54,3 +54,9 @@ var DynatraceHTTPLegacy = BoolEnvVar{
 	Key:          "DYNATRACE_HTTP_LEGACY",
 	DefaultValue: false,
 }
+
+// DynatraceHTTPOAuthPreference prefers OAuth over API token authentication when both are available.
+var DynatraceHTTPOAuthPreference = BoolEnvVar{
+	Key:          "DYNATRACE_HTTP_OAUTH_PREFERENCE",
+	DefaultValue: false,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -174,3 +174,11 @@ var DTMgmzRetries = ClampedIntEnvVar{
 	Min:          50,
 	Max:          600,
 }
+
+// DTMgmzSuccesses is the number of consecutive successes required for management zone readiness. Values outside [Min, Max] are clamped to the nearest boundary.
+var DTMgmzSuccesses = ClampedIntEnvVar{
+	Key:          "DT_MGMZ_SUCCESSES",
+	DefaultValue: 5,
+	Min:          5,
+	Max:          100,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -326,3 +326,9 @@ var DynatraceProviderSource = StringEnvVar{
 	Key:          "DYNATRACE_PROVIDER_SOURCE",
 	DefaultValue: "",
 }
+
+// DynatraceProviderVersion sets the provider version for generated Terraform files.
+var DynatraceProviderVersion = StringEnvVar{
+	Key:          "DYNATRACE_PROVIDER_VERSION",
+	DefaultValue: "",
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -282,3 +282,11 @@ var DynatraceHostMonitoringWarnings = BoolEnvVar{
 	Key:          "DYNATRACE_HOST_MONITORING_WARNINGS",
 	DefaultValue: false,
 }
+
+// DynatraceHostMonitoringStrictUpdateRetries sets the number of retries for strict host monitoring updates. Values outside [Min, Max] are clamped to the nearest boundary.
+var DynatraceHostMonitoringStrictUpdateRetries = ClampedIntEnvVar{
+	Key:          "DYNATRACE_HOST_MONITORING_STRICT_UPDATE_RETRIES",
+	DefaultValue: 0,
+	Min:          0,
+	Max:          60,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -538,3 +538,13 @@ var DynatraceCreateConfirmSyntheticMonitorsV2 = BoundedIntEnvVar{
 	Min:          1,
 	Max:          50,
 }
+
+// --- Web Application ---
+
+// DynatraceCreateConfirmWebApplication is the number of confirmation retries when creating web applications. Falls back to the default if the value is outside [Min, Max].
+var DynatraceCreateConfirmWebApplication = BoundedIntEnvVar{
+	Key:          "DYNATRACE_CREATE_CONFIRM_WEB_APPLICATION",
+	DefaultValue: 280,
+	Min:          20,
+	Max:          500,
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -520,3 +520,11 @@ var TFAcc = StringEnvVar{
 	Key:          "TF_ACC",
 	DefaultValue: "",
 }
+
+// --- Migration ---
+
+// Migration enables migration mode.
+var Migration = BoolEnvVar{
+	Key:          "MIGRATION",
+	DefaultValue: false,
+}

--- a/provider/envutils/envutils.go
+++ b/provider/envutils/envutils.go
@@ -1,0 +1,133 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package envutils
+
+import (
+	"os"
+	"strconv"
+)
+
+// BoolEnvVar represents a boolean environment variable with a default value.
+type BoolEnvVar struct {
+	Key          string
+	DefaultValue bool
+}
+
+// Get returns the environment variable's boolean value or its default value if unset or invalid.
+func (b BoolEnvVar) Get() bool {
+	v, found := os.LookupEnv(b.Key)
+	if !found {
+		return b.DefaultValue
+	}
+
+	value, err := strconv.ParseBool(v)
+	if err != nil {
+		return b.DefaultValue
+	}
+	return value
+}
+
+// StringEnvVar represents a string environment variable with a default value.
+type StringEnvVar struct {
+	Key          string
+	DefaultValue string
+}
+
+// Get returns the environment variable's string value or its default value if unset.
+func (s StringEnvVar) Get() string {
+	v, found := os.LookupEnv(s.Key)
+	if !found {
+		return s.DefaultValue
+	}
+	return v
+}
+
+// ClampedIntEnvVar reads an integer environment variable and clamps it
+// to the [Min, Max] range. If the env var is not set or cannot be parsed,
+// the DefaultValue is returned.
+type ClampedIntEnvVar struct {
+	Key          string
+	DefaultValue int
+	Min          int
+	Max          int
+}
+
+// Get returns the clamped integer value of the environment variable or its default value if unset or invalid.
+func (c ClampedIntEnvVar) Get() int {
+	v, found := os.LookupEnv(c.Key)
+	if !found || len(v) == 0 {
+		return c.DefaultValue
+	}
+
+	value, err := strconv.Atoi(v)
+	if err != nil {
+		return c.DefaultValue
+	}
+	if value > c.Max {
+		value = c.Max
+	}
+	if value < c.Min {
+		value = c.Min
+	}
+	return value
+}
+
+// BoundedIntEnvVar reads an integer environment variable and returns the
+// DefaultValue if the value is outside the [Min, Max] range (unlike
+// ClampedIntEnvVar which clamps to the boundary).
+type BoundedIntEnvVar struct {
+	Key          string
+	DefaultValue int
+	Min          int
+	Max          int
+}
+
+// Get returns the integer value of the environment variable if it's within the [Min, Max] range, otherwise returns the default value.
+func (b BoundedIntEnvVar) Get() int {
+	v, found := os.LookupEnv(b.Key)
+	if !found || len(v) == 0 {
+		return b.DefaultValue
+	}
+
+	value, err := strconv.Atoi(v)
+	if err != nil {
+		return b.DefaultValue
+	}
+	if value < b.Min || value > b.Max {
+		return b.DefaultValue
+	}
+	return value
+}
+
+// MultiStringEnvVar checks multiple environment variable keys in order
+// and returns the first non-empty value found. If none are set, the
+// DefaultValue is returned.
+type MultiStringEnvVar struct {
+	Keys         []string
+	DefaultValue string
+}
+
+// Get returns the first non-empty environment variable value from the list of keys, or the default value if none are set.
+func (m MultiStringEnvVar) Get() string {
+	for _, key := range m.Keys {
+		if v, found := os.LookupEnv(key); found && len(v) > 0 {
+			return v
+		}
+	}
+	return m.DefaultValue
+}

--- a/provider/envutils/envutils_test.go
+++ b/provider/envutils/envutils_test.go
@@ -1,0 +1,203 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package envutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoolEnvVar_Get(t *testing.T) {
+	t.Run("returns default when env var is not set", func(t *testing.T) {
+		b := BoolEnvVar{Key: "TEST_BOOL_UNSET", DefaultValue: true}
+		assert.Equal(t, true, b.Get())
+	})
+
+	t.Run("returns true when env var is 'true'", func(t *testing.T) {
+		t.Setenv("TEST_BOOL_TRUE", "true")
+		b := BoolEnvVar{Key: "TEST_BOOL_TRUE", DefaultValue: false}
+		assert.Equal(t, true, b.Get())
+	})
+
+	t.Run("returns false when env var is 'false'", func(t *testing.T) {
+		t.Setenv("TEST_BOOL_FALSE", "false")
+		b := BoolEnvVar{Key: "TEST_BOOL_FALSE", DefaultValue: true}
+		assert.Equal(t, false, b.Get())
+	})
+
+	t.Run("returns true when env var is '1'", func(t *testing.T) {
+		t.Setenv("TEST_BOOL_ONE", "1")
+		b := BoolEnvVar{Key: "TEST_BOOL_ONE", DefaultValue: false}
+		assert.Equal(t, true, b.Get())
+	})
+
+	t.Run("returns false when env var is '0'", func(t *testing.T) {
+		t.Setenv("TEST_BOOL_ZERO", "0")
+		b := BoolEnvVar{Key: "TEST_BOOL_ZERO", DefaultValue: true}
+		assert.Equal(t, false, b.Get())
+	})
+
+	t.Run("returns default when env var is invalid", func(t *testing.T) {
+		t.Setenv("TEST_BOOL_INVALID", "notabool")
+		b := BoolEnvVar{Key: "TEST_BOOL_INVALID", DefaultValue: true}
+		assert.Equal(t, true, b.Get())
+	})
+
+	t.Run("returns default (false) when env var is invalid", func(t *testing.T) {
+		t.Setenv("TEST_BOOL_INVALID2", "notabool")
+		b := BoolEnvVar{Key: "TEST_BOOL_INVALID2", DefaultValue: false}
+		assert.Equal(t, false, b.Get())
+	})
+}
+
+func TestStringEnvVar_Get(t *testing.T) {
+	t.Run("returns default when env var is not set", func(t *testing.T) {
+		s := StringEnvVar{Key: "TEST_STRING_UNSET", DefaultValue: "default"}
+		assert.Equal(t, "default", s.Get())
+	})
+
+	t.Run("returns env var value when set", func(t *testing.T) {
+		t.Setenv("TEST_STRING_SET", "custom")
+		s := StringEnvVar{Key: "TEST_STRING_SET", DefaultValue: "default"}
+		assert.Equal(t, "custom", s.Get())
+	})
+
+	t.Run("returns empty string when env var is set to empty", func(t *testing.T) {
+		t.Setenv("TEST_STRING_EMPTY", "")
+		s := StringEnvVar{Key: "TEST_STRING_EMPTY", DefaultValue: "default"}
+		assert.Equal(t, "", s.Get())
+	})
+
+	t.Run("returns empty default when env var is not set", func(t *testing.T) {
+		s := StringEnvVar{Key: "TEST_STRING_EMPTY_DEFAULT", DefaultValue: ""}
+		assert.Equal(t, "", s.Get())
+	})
+}
+
+func TestClampedIntEnvVar_Get(t *testing.T) {
+	t.Run("returns default when env var is not set", func(t *testing.T) {
+		c := ClampedIntEnvVar{Key: "TEST_CLAMPED_UNSET", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 50, c.Get())
+	})
+
+	t.Run("returns parsed value when within range", func(t *testing.T) {
+		t.Setenv("TEST_CLAMPED_VALID", "75")
+		c := ClampedIntEnvVar{Key: "TEST_CLAMPED_VALID", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 75, c.Get())
+	})
+
+	t.Run("clamps to max when value exceeds max", func(t *testing.T) {
+		t.Setenv("TEST_CLAMPED_HIGH", "200")
+		c := ClampedIntEnvVar{Key: "TEST_CLAMPED_HIGH", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 100, c.Get())
+	})
+
+	t.Run("clamps to min when value is below min", func(t *testing.T) {
+		t.Setenv("TEST_CLAMPED_LOW", "5")
+		c := ClampedIntEnvVar{Key: "TEST_CLAMPED_LOW", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 10, c.Get())
+	})
+
+	t.Run("returns default when env var is invalid", func(t *testing.T) {
+		t.Setenv("TEST_CLAMPED_INVALID", "notanint")
+		c := ClampedIntEnvVar{Key: "TEST_CLAMPED_INVALID", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 50, c.Get())
+	})
+
+	t.Run("returns default when env var is empty", func(t *testing.T) {
+		t.Setenv("TEST_CLAMPED_EMPTY", "")
+		c := ClampedIntEnvVar{Key: "TEST_CLAMPED_EMPTY", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 50, c.Get())
+	})
+}
+
+func TestMultiStringEnvVar_Get(t *testing.T) {
+	t.Run("returns default when no env vars are set", func(t *testing.T) {
+		m := MultiStringEnvVar{Keys: []string{"TEST_MULTI_A", "TEST_MULTI_B"}, DefaultValue: "fallback"}
+		assert.Equal(t, "fallback", m.Get())
+	})
+
+	t.Run("returns first set env var", func(t *testing.T) {
+		t.Setenv("TEST_MULTI_FIRST_A", "valueA")
+		t.Setenv("TEST_MULTI_FIRST_B", "valueB")
+		m := MultiStringEnvVar{Keys: []string{"TEST_MULTI_FIRST_A", "TEST_MULTI_FIRST_B"}}
+		assert.Equal(t, "valueA", m.Get())
+	})
+
+	t.Run("skips empty env vars and returns first non-empty", func(t *testing.T) {
+		t.Setenv("TEST_MULTI_SKIP_A", "")
+		t.Setenv("TEST_MULTI_SKIP_B", "valueB")
+		m := MultiStringEnvVar{Keys: []string{"TEST_MULTI_SKIP_A", "TEST_MULTI_SKIP_B"}}
+		assert.Equal(t, "valueB", m.Get())
+	})
+
+	t.Run("returns empty default when no keys match", func(t *testing.T) {
+		m := MultiStringEnvVar{Keys: []string{"TEST_MULTI_NONE_A", "TEST_MULTI_NONE_B"}}
+		assert.Equal(t, "", m.Get())
+	})
+}
+
+func TestBoundedIntEnvVar_Get(t *testing.T) {
+	t.Run("returns default when env var is not set", func(t *testing.T) {
+		b := BoundedIntEnvVar{Key: "TEST_BOUNDED_UNSET", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 50, b.Get())
+	})
+
+	t.Run("returns parsed value when within range", func(t *testing.T) {
+		t.Setenv("TEST_BOUNDED_VALID", "75")
+		b := BoundedIntEnvVar{Key: "TEST_BOUNDED_VALID", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 75, b.Get())
+	})
+
+	t.Run("returns default when value exceeds max", func(t *testing.T) {
+		t.Setenv("TEST_BOUNDED_HIGH", "200")
+		b := BoundedIntEnvVar{Key: "TEST_BOUNDED_HIGH", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 50, b.Get())
+	})
+
+	t.Run("returns default when value is below min", func(t *testing.T) {
+		t.Setenv("TEST_BOUNDED_LOW", "5")
+		b := BoundedIntEnvVar{Key: "TEST_BOUNDED_LOW", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 50, b.Get())
+	})
+
+	t.Run("returns default when env var is invalid", func(t *testing.T) {
+		t.Setenv("TEST_BOUNDED_INVALID", "notanint")
+		b := BoundedIntEnvVar{Key: "TEST_BOUNDED_INVALID", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 50, b.Get())
+	})
+
+	t.Run("returns default when env var is empty", func(t *testing.T) {
+		t.Setenv("TEST_BOUNDED_EMPTY", "")
+		b := BoundedIntEnvVar{Key: "TEST_BOUNDED_EMPTY", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 50, b.Get())
+	})
+
+	t.Run("returns value at exact min boundary", func(t *testing.T) {
+		t.Setenv("TEST_BOUNDED_MIN", "10")
+		b := BoundedIntEnvVar{Key: "TEST_BOUNDED_MIN", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 10, b.Get())
+	})
+
+	t.Run("returns value at exact max boundary", func(t *testing.T) {
+		t.Setenv("TEST_BOUNDED_MAX", "100")
+		b := BoundedIntEnvVar{Key: "TEST_BOUNDED_MAX", DefaultValue: 50, Min: 10, Max: 100}
+		assert.Equal(t, 100, b.Get())
+	})
+}

--- a/provider/logging/logging.go
+++ b/provider/logging/logging.go
@@ -50,7 +50,7 @@ func createDebugLogger(name string) *log.Logger {
 
 	prefix := "terraform-provider-dynatrace"
 
-	logDebugPrefix := os.Getenv("DYNATRACE_LOG_DEBUG_PREFIX")
+	logDebugPrefix := envutils.DynatraceLogDebugPrefix.Get()
 	if len(logDebugPrefix) > 0 && logDebugPrefix != "false" {
 		prefix = logDebugPrefix
 	}

--- a/provider/logging/logging.go
+++ b/provider/logging/logging.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -56,7 +57,7 @@ func createDebugLogger(name string) *log.Logger {
 
 	name = fmt.Sprintf("%s.%s", prefix, name)
 
-	if os.Getenv("DYNATRACE_DEBUG") != "true" {
+	if !envutils.DynatraceDebug.Get() {
 		return log.New(&void{}, "", log.LstdFlags)
 	}
 	if len(name) == 0 {
@@ -106,7 +107,7 @@ func (odl *onDemandLogger) Write(p []byte) (int, error) {
 
 // Enable redirects logging into a an output file
 func Enable(fn func(context.Context, *schema.ResourceData, any) diag.Diagnostics) func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
-	if os.Getenv("DYNATRACE_DEBUG") != "true" {
+	if !envutils.DynatraceDebug.Get() {
 		return fn
 	}
 	return func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
@@ -116,7 +117,7 @@ func Enable(fn func(context.Context, *schema.ResourceData, any) diag.Diagnostics
 }
 
 func EnableDS(fn func(d *schema.ResourceData, m any) error) func(*schema.ResourceData, any) error {
-	if os.Getenv("DYNATRACE_DEBUG") != "true" {
+	if !envutils.DynatraceDebug.Get() {
 		return fn
 	}
 	return func(d *schema.ResourceData, m any) error {
@@ -126,7 +127,7 @@ func EnableDS(fn func(d *schema.ResourceData, m any) error) func(*schema.Resourc
 }
 
 func EnableDSCtx(fn func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics) func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
-	if os.Getenv("DYNATRACE_DEBUG") != "true" {
+	if !envutils.DynatraceDebug.Get() {
 		return fn
 	}
 	return func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
@@ -136,7 +137,7 @@ func EnableDSCtx(fn func(ctx context.Context, d *schema.ResourceData, m any) dia
 }
 
 func EnableSchemaSetFunc(fn func(v any) int) func(v any) int {
-	if os.Getenv("DYNATRACE_DEBUG") != "true" {
+	if !envutils.DynatraceDebug.Get() {
 		return fn
 	}
 	return func(v any) int {
@@ -147,7 +148,7 @@ func EnableSchemaSetFunc(fn func(v any) int) func(v any) int {
 
 // Enable redirects logging into a an output file
 func SetOutput() {
-	if os.Getenv("DYNATRACE_DEBUG") != "true" {
+	if !envutils.DynatraceDebug.Get() {
 		return
 	}
 	log.SetOutput(odl)
@@ -155,7 +156,7 @@ func SetOutput() {
 
 // EnableSchemaDiff redirects logging into a an output file
 func EnableSchemaDiff(fn func(k, old, new string, d *schema.ResourceData) bool) func(k, old, new string, d *schema.ResourceData) bool {
-	if os.Getenv("DYNATRACE_DEBUG") != "true" {
+	if !envutils.DynatraceDebug.Get() {
 		return fn
 	}
 	return func(k, old, new string, d *schema.ResourceData) bool {
@@ -166,7 +167,7 @@ func EnableSchemaDiff(fn func(k, old, new string, d *schema.ResourceData) bool) 
 
 // EnableCustomizeDiff redirects logging into a an output file
 func EnableCustomizeDiff(fn func(context.Context, *schema.ResourceDiff, any) error) func(context.Context, *schema.ResourceDiff, any) error {
-	if os.Getenv("DYNATRACE_DEBUG") != "true" {
+	if !envutils.DynatraceDebug.Get() {
 		return fn
 	}
 	return func(ctx context.Context, d *schema.ResourceDiff, meta any) error {

--- a/resources/generic.go
+++ b/resources/generic.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -356,14 +355,14 @@ func (me *Generic) ReadForSettings(ctx context.Context, d *schema.ResourceData, 
 	if preparer, ok := sttngs.(MarshalPreparer); ok {
 		preparer.PrepareMarshalHCL(hcl.DecoderFrom(d))
 	}
-	if os.Getenv("DT_TERRAFORM_IMPORT") == "true" {
+	if envutils.DTTerraformImport.Get() {
 		if demoSettings, ok := sttngs.(settings.DemoSettings); ok {
 			demoSettings.FillDemoValues()
 		}
 	}
 	marshalled := hcl.Properties{}
 	err = sttngs.MarshalHCL(marshalled)
-	if os.Getenv("DT_TERRAFORM_IMPORT") != "true" {
+	if !envutils.DTTerraformImport.Get() {
 		stateAttributes := NewAttributes(d.State().Attributes)
 
 		// Replacing Algorithm A

--- a/resources/generic.go
+++ b/resources/generic.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/confighcl"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
@@ -442,7 +443,7 @@ func (me *Generic) ReadForSettings(ctx context.Context, d *schema.ResourceData, 
 		err := d.Set(k, v)
 		// currently behind an env variable, because it could potentially break existing resources
 		// TODO: Remove this once we have proper integration tests
-		if err != nil && os.Getenv("DYNATRACE_DEBUG") == "true" {
+		if err != nil && envutils.DynatraceDebug.Get() {
 			return diag.FromErr(err)
 		}
 	}

--- a/resources/goldenstate/resource.go
+++ b/resources/goldenstate/resource.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ package goldenstate
 import (
 	"context"
 	"fmt"
-	"os"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -31,7 +31,6 @@ import (
 
 const Debug = true
 
-var Enabled = os.Getenv("DYNATRACE_GOLDEN_STATE_ENABLED") == "true"
 
 func Resource() *schema.Resource {
 	schemaMap := map[string]*schema.Schema{
@@ -63,7 +62,7 @@ func Resource() *schema.Resource {
 
 func Delete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	d.SetId("")
-	if !Enabled {
+	if !envutils.DynatraceGoldenStateEnabled.Get() {
 		return diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: DisabledMessage}}
 	}
 	return diag.Diagnostics{}

--- a/resources/goldenstate/resource_create.go
+++ b/resources/goldenstate/resource_create.go
@@ -18,6 +18,7 @@
 package goldenstate
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"context"
 	"fmt"
 	"strings"
@@ -35,14 +36,14 @@ const DisabledMessage = "The resource `dynatrace_golden_state` is currently only
 
 func Create(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	d.SetId(uuid.NewString())
-	if !Enabled {
+	if !envutils.DynatraceGoldenStateEnabled.Get() {
 		return diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: DisabledMessage}}
 	}
 	return update(ctx, d, m, "  ")
 }
 
 func Update(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	if !Enabled {
+	if !envutils.DynatraceGoldenStateEnabled.Get() {
 		return diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: DisabledMessage}}
 	}
 	return update(ctx, d, m, "  ")

--- a/resources/goldenstate/resource_read.go
+++ b/resources/goldenstate/resource_read.go
@@ -18,6 +18,7 @@
 package goldenstate
 
 import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"context"
 	"fmt"
 	"regexp"
@@ -32,7 +33,7 @@ import (
 )
 
 func Read(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	if !Enabled {
+	if !envutils.DynatraceGoldenStateEnabled.Get() {
 		return diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: DisabledMessage}}
 	}
 	return read(ctx, d, m, "")

--- a/terraform/confighcl/confighcl.go
+++ b/terraform/confighcl/confighcl.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,15 +19,14 @@ package confighcl
 
 import (
 	"log"
-	"os"
 	"strings"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-var debugGetOk = (os.Getenv("DT_DEBUG_GET_OK") == "true")
 
 type bootstrapDecoder struct {
 	Reader schema.FieldReader
@@ -47,7 +46,7 @@ func (me *bootstrapDecoder) getRaw(key string) (any, bool) {
 
 func (me *bootstrapDecoder) GetOk(key string) (any, bool) {
 	res, ok := me.getRaw(key)
-	if debugGetOk {
+	if envutils.DTDebugGetOk.Get() {
 		log.Println("GetOK("+key+")", "=>", res, ok)
 	}
 	return res, ok

--- a/terraform/hcl/diff_suppress.go
+++ b/terraform/hcl/diff_suppress.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2025 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -130,10 +130,9 @@ func SuppressJSONorEOT(k, old, new string, d *schema.ResourceData) bool {
 	return equalLineByLine(old, new)
 }
 
-var DYNATRACE_DASHBOARD_TESTS = len(os.Getenv("DYNATRACE_DASHBOARD_TESTS")) > 0
 
 func Println(path string, message string, b ...bool) {
-	if !DYNATRACE_DASHBOARD_TESTS {
+	if !envutils.DynatraceDashboardTests.Get() {
 		return
 	}
 	if len(b) > 0 {
@@ -213,7 +212,7 @@ func DeepEqual(a any, b any, path string) bool {
 		delete(bTyped, "metricExpressions")
 		if len(aTyped) != len(bTyped) {
 			Println(path, "MAP len(a) != len(b)")
-			if DYNATRACE_DASHBOARD_TESTS {
+			if envutils.DynatraceDashboardTests.Get() {
 				aData, _ := json.Marshal(a)
 				Println(path, "--- THIS IS A ---")
 				Println(path, string(aData))
@@ -265,7 +264,7 @@ func DeepEqual(a any, b any, path string) bool {
 			}
 			if !found {
 				Println(fmt.Sprintf("%s[%d]", path, ai), "not found in b")
-				if DYNATRACE_DASHBOARD_TESTS {
+				if envutils.DynatraceDashboardTests.Get() {
 					aData, _ := json.Marshal(a)
 					Println(path, "--- THIS IS A ---")
 					Println(path, string(aData))

--- a/terraform/hclgen/primitive_entry.go
+++ b/terraform/hclgen/primitive_entry.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,17 +20,16 @@ package hclgen
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
 
-var preventHeredoc = os.Getenv("DYNATRACE_HEREDOC") == "false"
 
 type primitiveEntry struct {
 	Indent      string
@@ -108,7 +107,7 @@ func (me *primitiveEntry) Write(w *hclwrite.Body, indent string) error {
 		w.SetAttributeRaw(me.Key, hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenStringLit, Bytes: []byte(toJSONencode(strVal, indent))}})
 	} else if strValP, ok := me.Value.(*string); ok && strValP != nil && isJSON(*strValP) {
 		w.SetAttributeRaw(me.Key, hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenStringLit, Bytes: []byte(toJSONencode(*strValP, indent))}})
-	} else if strVal, ok := me.Value.(string); ok && !preventHeredoc && strings.Contains(strVal, "\n") {
+	} else if strVal, ok := me.Value.(string); ok && envutils.DynatraceHeredoc.Get() && strings.Contains(strVal, "\n") {
 		var eotIndent string
 		// If we always add a newline before the EOT end, then we end up with an extra blank line at the end of the string if the string already ends with a newline.
 		// This would cause a non-empty terraform plan
@@ -117,13 +116,13 @@ func (me *primitiveEntry) Write(w *hclwrite.Body, indent string) error {
 		}
 		mlstr := "<<-EOT\n" + indent + "  " + finalizeString(strVal, indent) + eotIndent + "EOT"
 		w.SetAttributeRaw(me.Key, hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenStringLit, Bytes: []byte(mlstr)}})
-	} else if strVal, ok := me.Value.(string); ok && !preventHeredoc && strings.Count(strVal, "\"") > 3 {
+	} else if strVal, ok := me.Value.(string); ok && envutils.DynatraceHeredoc.Get() && strings.Count(strVal, "\"") > 3 {
 		mlstr := "<<-EOT\n" + indent + "  " + finalizeString(strVal, indent) + "\n" + indent + "EOT"
 		w.SetAttributeRaw(me.Key, hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenStringLit, Bytes: []byte(mlstr)}})
-	} else if strValP, ok := me.Value.(*string); ok && !preventHeredoc && strValP != nil && strings.Count(*strValP, "\"") > 3 {
+	} else if strValP, ok := me.Value.(*string); ok && envutils.DynatraceHeredoc.Get() && strValP != nil && strings.Count(*strValP, "\"") > 3 {
 		mlstr := "<<-EOT\n" + indent + "  " + finalizeString(*strValP, indent) + "\n" + indent + "EOT"
 		w.SetAttributeRaw(me.Key, hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenStringLit, Bytes: []byte(mlstr)}})
-	} else if strValP, ok := me.Value.(*string); ok && !preventHeredoc && strValP != nil && strings.Contains(*strValP, "\n") {
+	} else if strValP, ok := me.Value.(*string); ok && envutils.DynatraceHeredoc.Get() && strValP != nil && strings.Contains(*strValP, "\n") {
 		mlstr := "<<-EOT\n" + indent + "  " + finalizeString(*strValP, indent) + "\n" + indent + "EOT"
 		w.SetAttributeRaw(me.Key, hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenStringLit, Bytes: []byte(mlstr)}})
 	} else if strVal, ok := me.Value.(string); ok {

--- a/testbase/provider.go
+++ b/testbase/provider.go
@@ -19,7 +19,6 @@ package testbase
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
@@ -63,7 +62,7 @@ func TestAccPreCheck(t *testing.T) {
 		t.Fatalf("[WARN] DYNATRACE_ENV_URL has not been set for acceptance tests")
 	}
 
-	if v := os.Getenv("DYNATRACE_API_TOKEN"); v == "" {
+	if v := envutils.DynatraceAPIToken.Get(); v == "" {
 		t.Fatalf("[WARN] DYNATRACE_API_TOKEN must be set for acceptance tests")
 	}
 

--- a/testbase/provider.go
+++ b/testbase/provider.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -58,7 +59,7 @@ func init() {
 func TestAccPreCheck(t *testing.T) {
 	ctx := context.Background()
 
-	if v := os.Getenv("DYNATRACE_ENV_URL"); v == "" {
+	if v := envutils.DynatraceEnvURL.Get(); v == "" {
 		t.Fatalf("[WARN] DYNATRACE_ENV_URL has not been set for acceptance tests")
 	}
 


### PR DESCRIPTION
#### **Why** this PR?

This PR centralizes all environment variable access into a single `envutils` package with typed wrappers to ensure that environment variables are all processed consistently, reducing duplication and increasing maintainability.

Every environment variable is defined in one place (`provider/envutils/env_vars.go`), with a GoDoc explaining the purpose of each one.

#### **What** has changed and **how** does it do it?
- Five typed wrappers are defined in `provider/envutils/envutils.go`: `BoolEnvVar`, `StringEnvVar`, `ClampedIntEnvVar`, `BoundedIntEnvVar`, and `MultiStringEnvVar`, each with a `Get()` method that reads the variable(s) using `os.LookupEnv(...)`, parses the value, and returns a typed result (or the default).

- Then, the PR progressively adds to `provider/envutils/env_vars.go`, where each environment variable is declared with its key, default, and bounds where applicable.

- The code is refactored to always read from environment variables rather than temporarily store values in package-level variables  

- `ConfigGetter.Get()` always checked the source URL environment variables regardless of which config key was requested. This meant source overrides for API tokens, client IDs, secrets, and other non-URL keys were silently ignored. The fix ensures each key resolves its own corresponding source environment variable.

#### How is it **tested**?
Tests are added for the `Get(...)` method of `BoolEnvVar`, `StringEnvVar`, `IntEnvVar`, `ClampedIntEnvVar`, `BoundedIntEnvVar`, and `MultiStringEnvVar`.

#### How does it affect **users**?
There should be no substantial change as the environment variables should continue to work as before.  However, there are a few behavioral changes worth noting:
- `DYNATRACE_PARALLEL` — Previously accepted any string; "false" disabled parallelism, anything else (including unset) enabled it. Now uses strconv.ParseBool, so only standard boolean strings ("true", "false", "1", "0", "t", "f", etc.) are recognized. Setting it to e.g. "yes" previously enabled parallelism; now it falls back to the default (true), which happens to be the same result — but for different reasons.
- `DYNATRACE_HEREDOC` — Same pattern. Previously "false" disabled heredoc, anything else enabled it. Now uses strconv.ParseBool. Non-standard values like "no" previously kept heredoc enabled (default); now they still fall back to the default (true). Functionally equivalent for all practical inputs.
- `DT_CACHE_DELETE_ON_LAUNCH` — Previously any non-empty, non-"false" string triggered cache deletion. Now uses strconv.ParseBool. Setting it to e.g. "yes" or "delete" previously triggered deletion; now those values fall back to the default (false) and will not trigger deletion. This is a real behavioral change for users who set non-standard truthy values.
- `DYNATRACE_DASHBOARD_TESTS` — Previously any non-empty string activated dashboard tests. Now requires a valid boolean. Setting it to e.g. "verbose" previously activated tests; now it falls back to false. Real behavioral change for non-standard values.
- `DYNATRACE_HOST_MONITORING_STRICT_UPDATE_RETRIES` — Previously had no upper bound; any non-negative integer was accepted. Now clamped to [0, 60]. Values above 60 are silently reduced to 60. Real behavioral change for users setting values > 60.

**Issue:** CA-18065
