### PR TITLE
doc: Assistance for `terraform-provider-dynatrace` is provided by Dynatrace Support

### DIFF
--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -143,4 +143,4 @@ export DYNATRACE_DEBUG=true
 export DYNATRACE_LOG_HTTP=terraform-provider-dynatrace.http.log
 export DYNATRACE_HTTP_RESPONSE=true
 ```
-For any assistance, please create a [GitHub](https://github.com/dynatrace-oss/terraform-provider-dynatrace/issues) issue.
+For assistance, please contact the Dynatrace Support team as described on the [support page](https://support.dynatrace.com/).


### PR DESCRIPTION
#### **Why** this PR?
As the provider is officially supported, contacting Dynatrace Support directly is now the preferred option.
 
#### **What** has changed and **How** does it do it?
Updated the documentation.

#### How is it **tested**?
N/A

#### How does it affect **users**?
Supporting them will be more efficient.

**Issue:** N/A
