### PR TITLE
feat: update dynatrace_openpipeline_v2_* resources to 1.51

### DIFF
--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.bizevents.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineBizeventsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.bizevents.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineBizeventsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.bizevents.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -493,7 +509,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +539,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +618,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -832,15 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
-						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -851,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -867,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -883,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -1240,7 +1332,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1408,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1636,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1954,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2117,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2280,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2369,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2449,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2566,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2877,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3215,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.davis.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineDavisEventsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.davis.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineDavisEventsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.davis.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.davis.problems.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineDavisProblemsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.davis.problems.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineDavisProblemsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.davis.problems.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineEventsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,38 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
+				}
+			],
+			"type": "enum"
+		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
 				}
 			],
 			"type": "enum"
@@ -201,6 +233,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +295,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +349,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +418,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +558,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +588,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +667,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -827,15 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
-						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -846,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -862,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -878,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -1235,7 +1381,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1457,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1685,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +2003,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2166,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2329,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2418,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2498,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2615,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2926,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3203,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineEventsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/enums.go
@@ -51,6 +51,26 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +133,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.sdlc.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineEventsSdlcIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,38 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
+				}
+			],
+			"type": "enum"
+		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
 				}
 			],
 			"type": "enum"
@@ -201,6 +233,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +295,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +349,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +418,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +558,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +588,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +667,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -827,15 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
-						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -846,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -862,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -878,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -1235,7 +1381,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1457,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1685,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +2003,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2166,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2329,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2418,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2498,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2615,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2926,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3203,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.sdlc.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineEventsSdlcPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/enums.go
@@ -51,6 +51,26 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +133,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.sdlc.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.security.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineEventsSecurityIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.security.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineEventsSecurityPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -105,7 +106,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.events.security.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.logs.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineLogsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.logs.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineLogsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/logs/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.logs.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.metrics.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineMetricsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.metrics.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineMetricsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -105,7 +106,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.metrics.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.security.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineSecurityEventsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.security.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineSecurityEventsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -105,7 +106,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.security.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.spans.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineSpansIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.spans.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineSpansPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/spans/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.spans.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -493,7 +509,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -523,12 +539,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -599,7 +618,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -832,15 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
-						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -851,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -867,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -883,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -1240,7 +1332,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1316,6 +1408,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1543,7 +1636,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1861,7 +1954,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2024,7 +2117,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2187,7 +2280,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2276,7 +2369,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2356,7 +2449,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2473,48 +2566,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2778,7 +2877,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3116,7 +3215,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3151,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.system.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineSystemEventsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.system.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineSystemEventsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -105,7 +106,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.system.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.user.events.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineUserEventsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,38 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
+				}
+			],
+			"type": "enum"
+		},
+		"GroupRole": {
+			"description": "",
+			"displayName": "Group Role",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be used as a pre/post pipeline within a Pipeline Group's composition.",
+					"value": "memberPipeline"
+				},
+				{
+					"displayName": "Can be part of a Pipeline Group as a member pipeline and is subject to the group’s policies.",
+					"value": "compositionPipeline"
 				}
 			],
 			"type": "enum"
@@ -201,6 +233,22 @@
 			],
 			"type": "enum"
 		},
+		"Routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Can be referenced in the routing table.",
+					"value": "routable"
+				},
+				{
+					"displayName": "Cannot be referenced in the routing table.",
+					"value": "notRoutable"
+				}
+			],
+			"type": "enum"
+		},
 		"Sampling": {
 			"description": "",
 			"displayName": "Sampling",
@@ -247,7 +295,7 @@
 				},
 				{
 					"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-					"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+					"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 					"type": "PATTERN"
 				}
 			],
@@ -301,6 +349,17 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "text"
+		},
+		"groupRole": {
+			"description": "",
+			"displayName": "Group role",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/GroupRole"
+			}
 		},
 		"metadataList": {
 			"constraints": [
@@ -359,6 +418,17 @@
 			"nullable": true,
 			"type": {
 				"$ref": "#/types/Stage"
+			}
+		},
+		"routing": {
+			"description": "",
+			"displayName": "Routing",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": true,
+			"type": {
+				"$ref": "#/enums/Routing"
 			}
 		},
 		"securityContext": {
@@ -488,7 +558,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -518,12 +588,15 @@
 				"bucketName": {
 					"constraints": [
 						{
+							"type": "NOT_BLANK"
+						},
+						{
 							"maxLength": 500,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
 					],
-					"default": "default-bucket",
+					"default": "",
 					"description": "",
 					"displayName": "Bucket name",
 					"documentation": "",
@@ -594,7 +667,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -827,15 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"customMessage": "Must be a number",
-							"pattern": "^-?(?:\\d+?\\.\\d+?|\\d+?)$",
-							"type": "PATTERN"
-						},
-						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -846,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -862,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -878,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -1235,7 +1381,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -1311,6 +1457,7 @@
 					"type": "text"
 				}
 			},
+			"searchPattern": "`{entryKey}`++`{entryValue}`",
 			"summaryPattern": "{entryKey} - {entryValue}",
 			"type": "object",
 			"version": "0",
@@ -1538,7 +1685,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -1856,7 +2003,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2019,7 +2166,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2182,7 +2329,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2271,7 +2418,7 @@
 					"documentation": "",
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
-					"nullable": true,
+					"nullable": false,
 					"type": {
 						"$ref": "#/types/GenericValueAssignment"
 					}
@@ -2351,7 +2498,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -2468,48 +2615,54 @@
 							"type": "NOT_BLANK"
 						},
 						{
-							"maxLength": 32,
-							"type": "LENGTH"
+							"customMessage": "Must not start with '._ :/\\'",
+							"pattern": "^[^._ :/\\\\].*$",
+							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'name'",
-							"pattern": "^(?i)(?!name$).*$",
+							"pattern": "^(?![Nn][Aa][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'lifetime'",
-							"pattern": "^(?i)(?!lifetime$).*$",
+							"pattern": "^(?![Ll][Ii][Ff][Ee][Tt][Ii][Mm][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'type'",
-							"pattern": "^(?i)(?!type$).*$",
+							"pattern": "^(?![Tt][Yy][Pp][Ee]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'id'",
-							"pattern": "^(?i)(?!id$).*$",
+							"pattern": "^(?![Ii][Dd]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'tags'",
-							"pattern": "^(?i)(?!tags$).*$",
+							"pattern": "^(?![Tt][Aa][Gg][Ss]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not be 'dt.security_context'",
-							"pattern": "^(?i)(?!dt\\.security_context$).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Ee][Cc][Uu][Rr][Ii][Tt][Yy]_[Cc][Oo][Nn][Tt][Ee][Xx][Tt]$).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.system.'",
-							"pattern": "^(?i)(?!dt\\.system\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Yy][Ss][Tt][Ee][Mm]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
 							"customMessage": "Must not start with 'dt.smartscape.'",
-							"pattern": "^(?i)(?!dt\\.smartscape\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.[Ss][Mm][Aa][Rr][Tt][Ss][Cc][Aa][Pp][Ee]\\.).*$",
 							"type": "PATTERN"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
 						}
 					],
 					"default": "",
@@ -2773,7 +2926,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3050,7 +3203,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.'",
-							"pattern": "^(?i)(?!dt\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.).*$",
 							"type": "PATTERN"
 						},
 						{
@@ -3085,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.user.events.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineUserEventsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/bizevent_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/bizevent_attributes.go
@@ -23,9 +23,9 @@ import (
 )
 
 type BizeventAttributes struct {
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
@@ -41,7 +41,7 @@ func (me *BizeventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/enums.go
@@ -51,6 +51,26 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
+type GroupRole string
+
+var GroupRoles = struct {
+	Compositionpipeline GroupRole
+	Memberpipeline      GroupRole
+}{
+	"compositionPipeline",
+	"memberPipeline",
+}
+
 type Measurement string
 
 var Measurements = struct {
@@ -113,6 +133,16 @@ var ProcessorTypes = struct {
 	"smartscapeNode",
 	"technology",
 	"valueMetric",
+}
+
+type Routing string
+
+var Routings = struct {
+	Notroutable Routing
+	Routable    Routing
+}{
+	"notRoutable",
+	"routable",
 }
 
 type Sampling string

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sdlc_event_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/sdlc_event_attributes.go
@@ -23,11 +23,11 @@ import (
 )
 
 type SdlcEventAttributes struct {
-	EventCategory   *GenericValueAssignment `json:"eventCategory"`       // Event category
-	EventProvider   *GenericValueAssignment `json:"eventProvider"`       // Event provider
-	EventStatus     *GenericValueAssignment `json:"eventStatus"`         // Event status
-	EventType       *GenericValueAssignment `json:"eventType,omitempty"` // Event type
-	FieldExtraction *FieldExtraction        `json:"fieldExtraction"`     // Field extraction
+	EventCategory   *GenericValueAssignment `json:"eventCategory"`   // Event category
+	EventProvider   *GenericValueAssignment `json:"eventProvider"`   // Event provider
+	EventStatus     *GenericValueAssignment `json:"eventStatus"`     // Event status
+	EventType       *GenericValueAssignment `json:"eventType"`       // Event type
+	FieldExtraction *FieldExtraction        `json:"fieldExtraction"` // Field extraction
 }
 
 func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
@@ -59,7 +59,7 @@ func (me *SdlcEventAttributes) Schema() map[string]*schema.Schema {
 		"event_type": {
 			Type:        schema.TypeList,
 			Description: "Event type",
-			Optional:    true, // nullable
+			Required:    true,
 			Elem:        &schema.Resource{Schema: new(GenericValueAssignment).Schema()},
 			MinItems:    1,
 			MaxItems:    1,

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/settings.go
@@ -28,10 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -74,6 +76,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Display name",
 			Required:    true,
 		},
+		"group_role": {
+			Type:        schema.TypeString,
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			Optional:    true, // nullable
+		},
 		"metadata_list": {
 			Type:        schema.TypeList,
 			Description: "Pipeline metadata list",
@@ -105,6 +112,11 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Stage).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
+		},
+		"routing": {
+			Type:        schema.TypeString,
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			Optional:    true, // nullable
 		},
 		"security_context": {
 			Type:        schema.TypeList,
@@ -148,10 +160,12 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"data_extraction":            me.DataExtraction,
 		"davis":                      me.Davis,
 		"display_name":               me.DisplayName,
+		"group_role":                 me.GroupRole,
 		"metadata_list":              me.MetadataList,
 		"metric_extraction":          me.MetricExtraction,
 		"processing":                 me.Processing,
 		"product_allocation":         me.ProductAllocation,
+		"routing":                    me.Routing,
 		"security_context":           me.SecurityContext,
 		"smartscape_edge_extraction": me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": me.SmartscapeNodeExtraction,
@@ -166,10 +180,12 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"data_extraction":            &me.DataExtraction,
 		"davis":                      &me.Davis,
 		"display_name":               &me.DisplayName,
+		"group_role":                 &me.GroupRole,
 		"metadata_list":              &me.MetadataList,
 		"metric_extraction":          &me.MetricExtraction,
 		"processing":                 &me.Processing,
 		"product_allocation":         &me.ProductAllocation,
+		"routing":                    &me.Routing,
 		"security_context":           &me.SecurityContext,
 		"smartscape_edge_extraction": &me.SmartscapeEdgeExtraction,
 		"smartscape_node_extraction": &me.SmartscapeNodeExtraction,

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -105,7 +106,7 @@
 						},
 						{
 							"customMessage": "Must not start with 'dt.' or 'dynatrace.'",
-							"pattern": "^(?i)(?!dt\\.|dynatrace\\.).*$",
+							"pattern": "^(?![Dd][Tt]\\.|[Dd][Yy][Nn][Aa][Tt][Rr][Aa][Cc][Ee]\\.).*$",
 							"type": "PATTERN"
 						}
 					],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.34.1"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.34.1"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.user.events.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/ingest-source-container-validator",
+			"customValidatorId": "ingest-source-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -67,6 +67,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -835,10 +851,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -849,14 +910,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -865,13 +934,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -881,10 +970,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3156,5 +3250,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.usersessions.ingest-sources"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineUsersessionsIngestSourcesUnmarshal(t *testing.T) {
 	entries := new(ingestsources.FieldExtractionEntries)
 	validEntries := []*ingestsources.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type IngestSourceType string
 
 var IngestSourceTypes = struct {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package ingestsources
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/settings.go
@@ -33,7 +33,7 @@ type Settings struct {
 	PathSegment   *string          `json:"pathSegment,omitempty"`   // Endpoint segment
 	Processing    *Stage           `json:"processing,omitempty"`    // Processing stage
 	Source        *string          `json:"source,omitempty"`        // Source
-	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible Values: `extension`, `http`
+	SourceType    IngestSourceType `json:"sourceType"`              // Source Type. Possible values: `extension`, `http`
 	StaticRouting *StaticRouting   `json:"staticRouting,omitempty"` // Static routing of endpoint
 }
 
@@ -82,7 +82,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"source_type": {
 			Type:        schema.TypeString,
-			Description: "Source Type. Possible Values: `extension`, `http`",
+			Description: "Source Type. Possible values: `extension`, `http`",
 			Optional:    true,
 			Default:     "http",
 		},

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/static_routing.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/static_routing.go
@@ -28,7 +28,7 @@ import (
 type StaticRouting struct {
 	BuiltinPipelineID *string      `json:"builtinPipelineId,omitempty"` // Builtin Pipeline ID
 	PipelineID        *string      `json:"pipelineId,omitempty"`        // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`                // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *StaticRouting) Schema() map[string]*schema.Schema {
@@ -45,7 +45,7 @@ func (me *StaticRouting) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/schema.json
@@ -4,7 +4,7 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/pipeline-container-validator",
+			"customValidatorId": "pipeline-container-validator",
 			"skipAsyncValidation": false,
 			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
@@ -77,6 +77,22 @@
 				{
 					"displayName": "Include all fields of the source record",
 					"value": "includeAll"
+				}
+			],
+			"type": "enum"
+		},
+		"FieldValueExtractionType": {
+			"description": "",
+			"displayName": "Field value extraction type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Constant literal will be assigned to destination field.",
+					"value": "constant"
+				},
+				{
+					"displayName": "Dynamic value from field or default will be assigned to destination field.",
+					"value": "field"
 				}
 			],
 			"type": "enum"
@@ -339,7 +355,7 @@
 			"displayName": "Group role",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/GroupRole"
@@ -409,7 +425,7 @@
 			"displayName": "Routing",
 			"documentation": "",
 			"maxObjects": 1,
-			"modificationPolicy": "DEFAULT",
+			"modificationPolicy": "NEVER",
 			"nullable": true,
 			"type": {
 				"$ref": "#/enums/Routing"
@@ -884,10 +900,55 @@
 			"displayName": "FieldExtractionEntry",
 			"documentation": "",
 			"properties": {
+				"constantFieldName": {
+					"constraints": [
+						{
+							"maxLength": 350,
+							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Destination field name",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"constantValue": {
+					"constraints": [
+						{
+							"maxLength": 512,
+							"type": "LENGTH"
+						}
+					],
+					"default": "",
+					"description": "",
+					"displayName": "Constant value to be assigned to field",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "constant",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
 				"defaultValue": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 512,
 							"minLength": 1,
 							"type": "LENGTH"
 						}
@@ -898,14 +959,22 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				},
 				"destinationFieldName": {
 					"constraints": [
 						{
-							"maxLength": 500,
+							"maxLength": 350,
 							"minLength": 1,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"description": "",
@@ -914,13 +983,33 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": true,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
+				},
+				"extractionType": {
+					"default": "field",
+					"description": "",
+					"displayName": "Field value extraction type",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/FieldValueExtractionType"
+					}
 				},
 				"sourceFieldName": {
 					"constraints": [
 						{
 							"maxLength": 256,
 							"type": "LENGTH"
+						},
+						{
+							"type": "NOT_BLANK"
 						}
 					],
 					"default": "",
@@ -930,10 +1019,15 @@
 					"maxObjects": 1,
 					"modificationPolicy": "DEFAULT",
 					"nullable": false,
+					"precondition": {
+						"expectedValue": "field",
+						"property": "extractionType",
+						"type": "EQUALS"
+					},
 					"type": "text"
 				}
 			},
-			"summaryPattern": "{sourceFieldName} - {destinationFieldName} - {defaultValue}",
+			"summaryPattern": "{extractionType} - {sourceFieldName} - {destinationFieldName} - {defaultValue} - {constantFieldName} - {constantValue}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -3144,5 +3238,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.usersessions.pipelines"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service_unit_test.go
@@ -32,33 +32,24 @@ func TestOpenPipelineUsersessionsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue:         testing2.ToPointer("value"),
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			DefaultValue: testing2.ToPointer("value"),
 		},
 		{
-			DefaultValue:         nil,
 			DestinationFieldName: testing2.ToPointer("value"),
-			SourceFieldName:      "",
 		},
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "value",
+			SourceFieldName: testing2.ToPointer("value"),
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
-			SourceFieldName:      "value3",
+			SourceFieldName:      testing2.ToPointer("value3"),
 		},
-	}
-	validWithEmpty := pipelines.FieldExtractionEntries{
 		{
-			DefaultValue:         nil,
-			DestinationFieldName: nil,
-			SourceFieldName:      "",
+			ExtractionType: "field",
 		},
 	}
+	validWithEmpty := pipelines.FieldExtractionEntries{{}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/enums.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/enums.go
@@ -51,6 +51,16 @@ var FieldExtractionTypes = struct {
 	"includeAll",
 }
 
+type FieldValueExtractionType string
+
+var FieldValueExtractionTypes = struct {
+	Constant FieldValueExtractionType
+	Field    FieldValueExtractionType
+}{
+	"constant",
+	"field",
+}
+
 type GroupRole string
 
 var GroupRoles = struct {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction.go
@@ -25,7 +25,7 @@ import (
 type FieldExtraction struct {
 	Exclude []string               `json:"exclude,omitempty"` // Fields
 	Include FieldExtractionEntries `json:"include,omitempty"` // Fields
-	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`
+	Type    FieldExtractionType    `json:"type"`              // Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`
 }
 
 func (me *FieldExtraction) Schema() map[string]*schema.Schema {
@@ -46,7 +46,7 @@ func (me *FieldExtraction) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Fields Extraction type. Possible Values: `exclude`, `include`, `includeAll`",
+			Description: "Fields Extraction type. Possible values: `exclude`, `include`, `includeAll`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction_entry.go
@@ -18,6 +18,9 @@
 package pipelines
 
 import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -47,8 +50,9 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
 	newEntries := FieldExtractionEntries{}
+	var emptyItem FieldExtractionEntry
 	for _, entry := range *me {
-		if entry.SourceFieldName != "" || entry.DestinationFieldName != nil || entry.DefaultValue != nil {
+		if *entry != emptyItem {
 			newEntries = append(newEntries, entry)
 		}
 	}
@@ -57,43 +61,87 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 }
 
 type FieldExtractionEntry struct {
-	DefaultValue         *string `json:"defaultValue,omitempty"`         // Default value
-	DestinationFieldName *string `json:"destinationFieldName,omitempty"` // Destination field name
-	SourceFieldName      string  `json:"sourceFieldName"`                // Source field name
+	ConstantFieldName    *string                  `json:"constantFieldName,omitempty"`    // Destination field name
+	ConstantValue        *string                  `json:"constantValue,omitempty"`        // Constant value to be assigned to field
+	DefaultValue         *string                  `json:"defaultValue,omitempty"`         // Default value
+	DestinationFieldName *string                  `json:"destinationFieldName,omitempty"` // Destination field name
+	ExtractionType       FieldValueExtractionType `json:"extractionType"`                 // Field value extraction type. Possible values: `constant`, `field`
+	SourceFieldName      *string                  `json:"sourceFieldName,omitempty"`      // Source field name
 }
 
 func (me *FieldExtractionEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"constant_field_name": {
+			Type:        schema.TypeString,
+			Description: "Destination field name",
+			Optional:    true, // precondition
+		},
+		"constant_value": {
+			Type:        schema.TypeString,
+			Description: "Constant value to be assigned to field",
+			Optional:    true, // precondition
+		},
 		"default_value": {
 			Type:        schema.TypeString,
 			Description: "Default value",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
 		},
 		"destination_field_name": {
 			Type:        schema.TypeString,
 			Description: "Destination field name",
-			Optional:    true, // nullable
+			Optional:    true, // nullable & precondition
+		},
+		"extraction_type": {
+			Type:        schema.TypeString,
+			Description: "Field value extraction type. Possible values: `constant`, `field`",
+			Optional:    true,
+			Default:     "field", // new required attribute. Fallback to "field"
 		},
 		"source_field_name": {
 			Type:        schema.TypeString,
 			Description: "Source field name",
-			Required:    true,
+			Optional:    true, // precondition
 		},
 	}
 }
 
 func (me *FieldExtractionEntry) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
+		"constant_field_name":    me.ConstantFieldName,
+		"constant_value":         me.ConstantValue,
 		"default_value":          me.DefaultValue,
 		"destination_field_name": me.DestinationFieldName,
+		"extraction_type":        me.ExtractionType,
 		"source_field_name":      me.SourceFieldName,
 	})
 }
 
+func (me *FieldExtractionEntry) HandlePreconditions() error {
+	if (me.ConstantFieldName == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantFieldName = opt.NewString("")
+	}
+	if (me.ConstantValue == nil) && (string(me.ExtractionType) == "constant") {
+		me.ConstantValue = opt.NewString("")
+	}
+	if (me.SourceFieldName == nil) && (string(me.ExtractionType) == "field") {
+		me.SourceFieldName = opt.NewString("")
+	}
+	if (me.DefaultValue != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'default_value' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	if (me.DestinationFieldName != nil) && (string(me.ExtractionType) != "field") {
+		return fmt.Errorf("'destination_field_name' must not be specified if 'extraction_type' is set to '%v'", me.ExtractionType)
+	}
+	return nil
+}
+
 func (me *FieldExtractionEntry) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
+		"constant_field_name":    &me.ConstantFieldName,
+		"constant_value":         &me.ConstantValue,
 		"default_value":          &me.DefaultValue,
 		"destination_field_name": &me.DestinationFieldName,
+		"extraction_type":        &me.ExtractionType,
 		"source_field_name":      &me.SourceFieldName,
 	})
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/generic_value_assignment.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/generic_value_assignment.go
@@ -29,7 +29,7 @@ type GenericValueAssignment struct {
 	Constant           *string                        `json:"constant,omitempty"`           // Constant value
 	Field              *ValueAssignmentFromFieldEntry `json:"field,omitempty"`              // Value from field
 	MultiValueConstant []string                       `json:"multiValueConstant,omitempty"` // Constant multi value
-	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`
+	Type               AssignmentType                 `json:"type"`                         // Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`
 }
 
 func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
@@ -55,7 +55,7 @@ func (me *GenericValueAssignment) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Type of value assignment. Possible Values: `constant`, `field`, `multiValueConstant`",
+			Description: "Type of value assignment. Possible values: `constant`, `field`, `multiValueConstant`",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/processor.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/processor.go
@@ -75,7 +75,7 @@ type Processor struct {
 	SmartscapeEdge               *SmartscapeEdgeAttributes               `json:"smartscapeEdge,omitempty"`               // Smartscape edge extraction processor attributes
 	SmartscapeNode               *SmartscapeNodeAttributes               `json:"smartscapeNode,omitempty"`               // Smartscape node extraction processor attributes
 	Technology                   *TechnologyAttributes                   `json:"technology,omitempty"`                   // Technology processor attributes
-	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
+	Type                         ProcessorType                           `json:"type"`                                   // Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`
 	ValueMetric                  *ValueMetricAttributes                  `json:"valueMetric,omitempty"`                  // Value metric processor attributes
 }
 
@@ -276,7 +276,7 @@ func (me *Processor) Schema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: "Processor type. Possible Values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
+			Description: "Processor type. Possible values: `azureLogForwarding`, `bizevent`, `bucketAssignment`, `costAllocation`, `counterMetric`, `davis`, `dql`, `drop`, `fieldsAdd`, `fieldsRemove`, `fieldsRename`, `histogramMetric`, `noStorage`, `productAllocation`, `samplingAwareCounterMetric`, `samplingAwareHistogramMetric`, `samplingAwareValueMetric`, `sdlcEvent`, `securityContext`, `securityEvent`, `smartscapeEdge`, `smartscapeNode`, `technology`, `valueMetric`",
 			Required:    true,
 		},
 		"value_metric": {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_counter_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_counter_metric_attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type SamplingAwareCounterMetricAttributes struct {
-	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible Values: `disabled`, `enabled`
+	Aggregation *Aggregation           `json:"aggregation,omitempty"` // Possible values: `disabled`, `enabled`
 	Dimensions  FieldExtractionEntries `json:"dimensions,omitempty"`  // List of dimensions
 	MetricKey   string                 `json:"metricKey"`             // Metric key
-	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible Values: `disabled`, `enabled`
+	Sampling    *Sampling              `json:"sampling,omitempty"`    // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"dimensions": {
@@ -51,7 +51,7 @@ func (me *SamplingAwareCounterMetricAttributes) Schema() map[string]*schema.Sche
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_histogram_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_histogram_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareHistogramMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareHistogramMetricAttributes) Schema() map[string]*schema.Sc
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_value_metric_attributes.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/sampling_aware_value_metric_attributes.go
@@ -26,20 +26,20 @@ import (
 )
 
 type SamplingAwareValueMetricAttributes struct {
-	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible Values: `disabled`, `enabled`
+	Aggregation  *Aggregation           `json:"aggregation,omitempty"`  // Possible values: `disabled`, `enabled`
 	DefaultValue *string                `json:"defaultValue,omitempty"` // Default value with metric value
 	Dimensions   FieldExtractionEntries `json:"dimensions,omitempty"`   // List of dimensions
 	Field        *string                `json:"field,omitempty"`        // Field with metric value
-	Measurement  Measurement            `json:"measurement"`            // Possible Values: `duration`, `field`
+	Measurement  Measurement            `json:"measurement"`            // Possible values: `duration`, `field`
 	MetricKey    string                 `json:"metricKey"`              // Metric key
-	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible Values: `disabled`, `enabled`
+	Sampling     *Sampling              `json:"sampling,omitempty"`     // Possible values: `disabled`, `enabled`
 }
 
 func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"aggregation": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 		"default_value": {
@@ -62,7 +62,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"measurement": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `duration`, `field`",
+			Description: "Possible values: `duration`, `field`",
 			Required:    true,
 		},
 		"metric_key": {
@@ -72,7 +72,7 @@ func (me *SamplingAwareValueMetricAttributes) Schema() map[string]*schema.Schema
 		},
 		"sampling": {
 			Type:        schema.TypeString,
-			Description: "Possible Values: `disabled`, `enabled`",
+			Description: "Possible values: `disabled`, `enabled`",
 			Optional:    true, // nullable
 		},
 	}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
@@ -28,12 +28,12 @@ type Settings struct {
 	DataExtraction           *Stage          `json:"dataExtraction,omitempty"`           // Data extraction stage
 	Davis                    *Stage          `json:"davis,omitempty"`                    // Davis event extraction stage
 	DisplayName              string          `json:"displayName"`                        // Display name
-	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible Values: `compositionPipeline`, `memberPipeline`
+	GroupRole                *GroupRole      `json:"groupRole,omitempty"`                // Group role. Possible values: `compositionPipeline`, `memberPipeline`
 	MetadataList             MetadataEntries `json:"metadataList,omitempty"`             // Pipeline metadata list
 	MetricExtraction         *Stage          `json:"metricExtraction,omitempty"`         // Metrics extraction stage
 	Processing               *Stage          `json:"processing,omitempty"`               // Processing stage
 	ProductAllocation        *Stage          `json:"productAllocation,omitempty"`        // Product allocation stage
-	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible Values: `notRoutable`, `routable`
+	Routing                  *Routing        `json:"routing,omitempty"`                  // Routing. Possible values: `notRoutable`, `routable`
 	SecurityContext          *Stage          `json:"securityContext,omitempty"`          // Security context stage
 	SmartscapeEdgeExtraction *Stage          `json:"smartscapeEdgeExtraction,omitempty"` // Smartscape edge extraction stage
 	SmartscapeNodeExtraction *Stage          `json:"smartscapeNodeExtraction,omitempty"` // Smartscape node extraction stage
@@ -78,7 +78,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"group_role": {
 			Type:        schema.TypeString,
-			Description: "Group role. Possible Values: `compositionPipeline`, `memberPipeline`",
+			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -115,7 +115,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"routing": {
 			Type:        schema.TypeString,
-			Description: "Routing. Possible Values: `notRoutable`, `routable`",
+			Description: "Routing. Possible values: `notRoutable`, `routable`",
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/schema.json
@@ -4,8 +4,9 @@
 	],
 	"constraints": [
 		{
-			"customValidatorId": "ppx-management-service.ppx-management-service:8080/internal/settings-validation/v0.1/validate-container/routing-container-validator",
+			"customValidatorId": "routing-container-validator",
 			"skipAsyncValidation": false,
+			"timeout": 10,
 			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
@@ -182,5 +183,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.43"
+	"version": "1.51"
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.43"
+const SchemaVersion = "1.51"
 const SchemaID = "builtin:openpipeline.usersessions.routing"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/settings/routing_entry.go
@@ -53,7 +53,7 @@ type RoutingEntry struct {
 	Enabled           bool         `json:"enabled"`              // This setting is enabled (`true`) or disabled (`false`)
 	Matcher           string       `json:"matcher"`              // Query which determines whether the record should be routed to the target pipeline of this rule.
 	PipelineID        *string      `json:"pipelineId,omitempty"` // Pipeline ID
-	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible Values: `builtin`, `custom`
+	PipelineType      PipelineType `json:"pipelineType"`         // Pipeline Type. Possible values: `builtin`, `custom`
 }
 
 func (me *RoutingEntry) Schema() map[string]*schema.Schema {
@@ -85,7 +85,7 @@ func (me *RoutingEntry) Schema() map[string]*schema.Schema {
 		},
 		"pipeline_type": {
 			Type:        schema.TypeString,
-			Description: "Pipeline Type. Possible Values: `builtin`, `custom`",
+			Description: "Pipeline Type. Possible values: `builtin`, `custom`",
 			Required:    true,
 		},
 	}


### PR DESCRIPTION
#### **Why** this PR?
Some resources need to be updated.
Some were still on `1.34.1`, where they aren't compatible with pipeline groups

#### **What** has changed?
Resources are updated to match the current payload.

#### **How** does it do it?
- New properties for `field_extraction_entry` added
- New required property `extraction_type`. Fallback to the set default value added.
- New preconditions added for `field_extraction_entry` (due to the extraction_type and related conditional properties)
- Typo fixed for all resources (`Possible Values:...` => `Possible values:...`)
- Empty check for the empty-set-bug improved to be more future proof (if more attributes are added)

For the older resources that were still on `1.34.1`
- SDLC and bizevent attributes now require the `event_type` field to be set

#### How is it **tested**?
Existing tests for the empty-set-bug updated

#### How does it affect **users**?
They can now configure the resource to work with pipeline groups

**Issue:** CA-18100