### PR TITLE
test: openpipeline pipeline groups E2E

### DIFF
--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccBizeventPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,156 @@
+resource "dynatrace_openpipeline_v2_bizevents_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "example-1#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_bizevents_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "example-2#name#"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_bizevents_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_bizevents_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_bizevents_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccDavisEventsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/service_test.go
@@ -25,5 +25,6 @@ import (
 )
 
 func TestAccDavisEventsPipelineGroups(t *testing.T) {
+	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,132 @@
+resource "dynatrace_openpipeline_v2_davis_events_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  security_context {
+    processors {
+      processor {
+        type        = "securityContext"
+        id          = "processor_Use_dt.security_context_if_set_1080"
+        description = "Use dt.security_context if set"
+        matcher     = "isNotNull(dt.security_context)"
+        security_context {
+          value {
+            type = "field"
+            field {
+              source_field_name = "dt.security_context"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "securityContext"
+        id          = "processor_Assign_warnings_to_ACME_teams_if_no_context_set_5465"
+        description = "Assign warnings to ACME teams if no context set"
+        matcher     = "isNull(dt.security_context)"
+        security_context {
+          value {
+            type = "multiValueConstant"
+            multi_value_constant = ["ACME1", "ACME2"]
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_davis_events_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_davis_events_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "securityContext"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_davis_events_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "securityContext"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_davis_events_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccDavisProblemsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/service_test.go
@@ -25,5 +25,6 @@ import (
 )
 
 func TestAccDavisProblemsPipelineGroups(t *testing.T) {
+	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,132 @@
+resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  security_context {
+    processors {
+      processor {
+        type        = "securityContext"
+        id          = "processor_Use_dt.security_context_if_set_1080"
+        description = "Use dt.security_context if set"
+        matcher     = "isNotNull(dt.security_context)"
+        security_context {
+          value {
+            type = "field"
+            field {
+              source_field_name = "dt.security_context"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "securityContext"
+        id          = "processor_Assign_warnings_to_ACME_teams_if_no_context_set_5465"
+        description = "Assign warnings to ACME teams if no context set"
+        matcher     = "isNull(dt.security_context)"
+        security_context {
+          value {
+            type = "multiValueConstant"
+            multi_value_constant = ["ACME1", "ACME2"]
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_davis_problems_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_davis_problems_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_davis_problems_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_davis_problems_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccEventsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/events/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,155 @@
+resource "dynatrace_openpipeline_v2_events_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+resource "dynatrace_openpipeline_v2_events_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_events_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_events_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_events_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/service_test.go
@@ -25,5 +25,6 @@ import (
 )
 
 func TestAccEventsSDLCPipelineGroups(t *testing.T) {
+	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccEventsSDLCPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,157 @@
+resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_events_sdlc_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+
+resource "dynatrace_openpipeline_v2_events_sdlc_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_events_sdlc_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_events_sdlc_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelinegroups/service_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccEventsSecurityPipelineGroups(t *testing.T) {
+	t.Skip("Feature not enabled")
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,156 @@
+resource "dynatrace_openpipeline_v2_events_security_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_events_security_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_events_sdlc_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_events_security_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_events_security_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccLogsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/logs/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,156 @@
+resource "dynatrace_openpipeline_v2_logs_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_logs_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_logs_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_logs_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_logs_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccMetricsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,132 @@
+resource "dynatrace_openpipeline_v2_metrics_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  security_context {
+    processors {
+      processor {
+        type        = "securityContext"
+        id          = "processor_Use_dt.security_context_if_set_1080"
+        description = "Use dt.security_context if set"
+        matcher     = "isNotNull(dt.security_context)"
+        security_context {
+          value {
+            type = "field"
+            field {
+              source_field_name = "dt.security_context"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "securityContext"
+        id          = "processor_Assign_warnings_to_ACME_teams_if_no_context_set_5465"
+        description = "Assign warnings to ACME teams if no context set"
+        matcher     = "isNull(dt.security_context)"
+        security_context {
+          value {
+            type = "multiValueConstant"
+            multi_value_constant = ["ACME1", "ACME2"]
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_metrics_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_metrics_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "securityContext"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_metrics_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "securityContext"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_metrics_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccSecurityEventsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/service_test.go
@@ -25,5 +25,6 @@ import (
 )
 
 func TestAccSecurityEventsPipelineGroups(t *testing.T) {
+	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,156 @@
+resource "dynatrace_openpipeline_v2_security_events_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_security_events_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_security_events_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_security_events_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_security_events_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelinegroups/service_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccSpansPipelineGroups(t *testing.T) {
+	t.Skip("Feature not enabled")
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/spans/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,156 @@
+resource "dynatrace_openpipeline_v2_spans_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_spans_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_spans_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_spans_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_spans_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/service_test.go
@@ -25,5 +25,6 @@ import (
 )
 
 func TestAccSystemEventsPipelineGroups(t *testing.T) {
+	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccSystemEventsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,118 @@
+resource "dynatrace_openpipeline_v2_system_events_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  davis {
+    processors {
+      processor {
+        type        = "davis"
+        id          = "processor_Create_warning_event_8226"
+        description = "Create warning event"
+        matcher     = "true"
+        davis {
+          properties {
+            property {
+              key = "event.type"
+              value = "CUSTOM_ALERT"
+            }
+            property {
+              key = "event.name"
+              value = "Warning detected"
+            }
+            property {
+              key = "event.description"
+              value = "Warning: {dims:record.summary}"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_system_events_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_system_events_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["davis", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_system_events_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["davis", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_system_events_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/service_test.go
@@ -25,5 +25,6 @@ import (
 )
 
 func TestAccUserEventsPipelineGroups(t *testing.T) {
+	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccUserEventsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,156 @@
+resource "dynatrace_openpipeline_v2_user_events_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_user_events_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_user_events_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_user_events_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_user_events_pipelines.example2.id]
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/service_test.go
@@ -25,5 +25,6 @@ import (
 )
 
 func TestAccUserSessionsPipelineGroups(t *testing.T) {
+	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/service_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipelinegroups_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccUserSessionsPipelineGroups(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/testdata/terraform/example.tf
@@ -1,0 +1,156 @@
+resource "dynatrace_openpipeline_v2_usersessions_pipelines" "example1" {
+  display_name = "#name#"
+  custom_id = "#name#"
+  group_role = "compositionPipeline"
+  routing = "notRoutable"
+  processing {
+    processors {
+      processor {
+        type        = "drop"
+        id          = "processor_Drop_unnecessary_records_3802"
+        description = "Drop unnecessary records"
+        matcher     = "not matchesPhrase(record.name, \"Warning\")"
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsAdd"
+        id          = "processor_Add_warning_flag_5434"
+        description = "Add warning flag"
+        matcher     = "matchesPhrase(record.name, \"Warning\")"
+        sample_data = "{\n  \"record.name\": \"Warning record\" \n}"
+        fields_add {
+          fields {
+            field {
+              name  = "is_warning"
+              value = "true"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "fieldsRemove"
+        id          = "processor_Remove_details_field_8539"
+        description = "Remove details field"
+        sample_data = "{\n  \"record.name\": \"Warning\",\n  \"record.details\": \"some record details\"\n}"
+        matcher     = "isNotNull(record.details)"
+        fields_remove {
+          fields = ["record.details"]
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "fieldsRename"
+        id          = "processor_Rename_name_to_title_8530"
+        description = "Rename name to title"
+        sample_data = "{\n  \"record.name\": \"Warning\"\n}"
+        matcher     = "true"
+        fields_rename {
+          fields {
+            field {
+              from_name = "record.name"
+              to_name   = "record.title"
+            }
+          }
+        }
+        enabled     = true
+      }
+      processor {
+        type        = "dql"
+        id          = "processor_Combine_title_and_summary_to_name_8808"
+        description = "Combine title and summary to name"
+        sample_data = "{\n  \"record.title\": \"Warning\",\n  \"record.summary\": \"Request failed\"\n}"
+        matcher     = "true"
+        dql {
+          script = "fieldsAdd record.name = concat(record.title, \" - \", record.summary)"
+        }
+        enabled     = true
+      }
+    }
+  }
+  metric_extraction {
+    processors {
+      processor {
+        type        = "counterMetric"
+        id          = "processor_Count_warning_events_6392"
+        description = "Count warnings"
+        matcher     = "true"
+        counter_metric {
+          metric_key = "warning.count"
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+      processor {
+        type        = "valueMetric"
+        id          = "processor_Warning_timeout_1990"
+        description = "Warning timeout"
+        matcher     = "true"
+        value_metric {
+          metric_key    = "warning.timeout"
+          field         = "recording.timeout_in_min"
+          default_value = 60
+          dimensions {
+            dimension {
+              source_field_name = "dt.cost.costcenter"
+            }
+            dimension {
+              source_field_name = "dt.cost.product"
+            }
+            dimension {
+              source_field_name = "dt.security_context"
+            }
+            dimension {
+              source_field_name      = "record.category"
+              destination_field_name = "warning_category"
+            }
+          }
+        }
+        enabled = true
+      }
+    }
+  }
+}
+
+
+resource "dynatrace_openpipeline_v2_usersessions_pipelines" "example2" {
+  display_name = "#name#-2"
+  custom_id = "#name#-2"
+  group_role = "memberPipeline"
+}
+
+resource "dynatrace_openpipeline_v2_usersessions_pipelinegroups" "example" {
+  display_name = "#name#"
+  composition {
+    pipeline_group_composition {
+      is_pipeline_placeholder = true
+    }
+    pipeline_group_composition {
+      is_pipeline_placeholder = false
+      stages {
+        type = "include"
+        include = ["processing", "metricExtraction"]
+      }
+      pipeline_id = dynatrace_openpipeline_v2_usersessions_pipelines.example1.id
+    }
+  }
+  member_stages {
+    include = ["processing", "metricExtraction"]
+    type = "include"
+  }
+  member_pipelines = [dynatrace_openpipeline_v2_usersessions_pipelines.example2.id]
+}


### PR DESCRIPTION
#### **Why** this PR?
The pipeline groups need to be tested, and there need to be some examples

#### **What** has changed?
This adds the E2E tests for the pipeline groups. The examples are mostly identical.
It's two pipelines, an empty one and one with davis/metricExtractions/securityContext defined, depending on whether it's enabled on that resource.
One pipeline group that creates a group with the stages of a pipeline (the second-mentioned one) and assigns it to another pipeline (the first-mentioned one)

#### **How** does it do it?
By adding examples to pipeline groups and tests that execute them.

#### How is it **tested**?
Every example is tested except the ones that are not enabled.

#### How does it affect **users**?
N/A

**Issue:** CA-16607


## Notes
Some tests are currently not working due to a bug. Follow-up for un-skipping them: CA-18237