### PR TITLE
test: add integration setup step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,9 +65,33 @@ jobs:
           name: lint-report
           path: lint-report.xml
 
+  run-setup:
+    name: Run Integration Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
+      - name: 🛠️ Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4.0.0
+        with:
+          terraform_wrapper: false
+
+      - name: 🚀 Integration Setup - Terraform Init
+        working-directory: ./testsetup
+        run: terraform init
+
+      - name: 🚀 Integration Setup - Terraform Apply
+        working-directory: ./testsetup
+        env:
+          TF_VAR_DYNATRACE_ENV_URL: ${{ secrets.DYNATRACE_ENV_URL }}
+          TF_VAR_DYNATRACE_API_TOKEN: ${{ secrets.DYNATRACE_API_TOKEN }}
+        run: terraform apply -auto-approve
+
   integration-tests:
     name: Integration Tests - ${{ matrix.config.name }}
     runs-on: ubuntu-latest
+    needs: [ run-setup ]
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +126,7 @@ jobs:
         with:
           go-version-file: ./go.mod
 
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4.0.0
         with:
           terraform_wrapper: false
 

--- a/testsetup/mobile_application.tf
+++ b/testsetup/mobile_application.tf
@@ -1,0 +1,30 @@
+locals {
+    mobile_application_name = "Application"
+}
+
+data "dynatrace_mobile_application" "setup_application" {
+  name = local.mobile_application_name
+}
+
+import {
+  to = dynatrace_mobile_application.application
+  for_each = try(data.dynatrace_mobile_application.setup_application.id, null) == null ? [] : [data.dynatrace_mobile_application.setup_application.id]
+  id = each.value
+}
+
+resource "dynatrace_mobile_application" "application" {
+  name = local.mobile_application_name
+  beacon_endpoint_type    = "INSTRUMENTED_WEB_SERVER"
+  beacon_endpoint_url     = "https://dynatrace.com/dtmb"
+  application_type         = "MOBILE_APPLICATION"
+  user_session_percentage = 100
+  apdex {
+    frustrated          = 12000
+    frustrated_on_error = true
+    tolerable           = 3000
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/testsetup/provider.tf
+++ b/testsetup/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    dynatrace = {
+      source  = "dynatrace-oss/dynatrace"
+      version = ">=1.90.0"
+    }
+  }
+}
+
+provider "dynatrace" {
+  dt_env_url       = var.DYNATRACE_ENV_URL
+  dt_api_token     = var.DYNATRACE_API_TOKEN
+}

--- a/testsetup/synthetic_location.tf
+++ b/testsetup/synthetic_location.tf
@@ -1,0 +1,28 @@
+locals {
+  location_name = "Location"
+}
+
+data "dynatrace_synthetic_location" "location" {
+  name = local.location_name
+}
+
+import {
+  to = dynatrace_synthetic_location.location
+  for_each = try(data.dynatrace_synthetic_location.location.id, null) == null ? [] : [data.dynatrace_synthetic_location.location.id]
+  id = each.value
+}
+
+resource "dynatrace_synthetic_location" "location" {
+  name                                  = local.location_name
+  city                                  = "San Francisco de Asis"
+  country_code                          = "VE"
+  region_code                           = "04"
+  deployment_type                       = "STANDARD"
+  latitude                              = 10.0756
+  location_node_outage_delay_in_minutes = 3
+  longitude                             = -67.5442
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/testsetup/variables.tf
+++ b/testsetup/variables.tf
@@ -1,0 +1,10 @@
+variable "DYNATRACE_API_TOKEN" {
+  type        = string
+  description = "Dynatrace API Token with appropriate permissions."
+  sensitive   = true
+}
+
+variable "DYNATRACE_ENV_URL" {
+  type        = string
+  description = "Dynatrace Environment URL."
+}


### PR DESCRIPTION
This adds a setup step to the pipeline before the integration tests are executed, ensuring that long-running resources are created before the tests run.

#### **Why** this PR?
Some E2E tests (e.g., examples) refer to existing objects (e.g., management zones, request attributes, process groups, etc.). As this can easily break if someone just deletes something in the environment, we need to remove hardcoded IDs and create the needed dependencies on demand.
Because some resources take a long time to create, it's not feasible to create them in each example/test.
Therefore ,we need a setup that creates them once, before the actual tests run.

#### **What** has changed?
Required resources are created before the integration tests start.

#### **How** does it do it?
By using our the latest published provider to create the needed resources on demand.
If they don't exist, they will be created and if they exist, the step will be ignored.
The current implementation doesn't need a state file. It's either "import" or "create".

#### How is it **tested**?
Manual tests and verified the pipeline

#### How does it affect **users**?
N/A

**Issue:** CA-18113
