### PR TITLE
feat: correctly set ForceNew for dynatrace_openpipeline_v2_* resources

### DIFF
--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/settings.go
@@ -65,6 +65,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"path_segment": {
 			Type:        schema.TypeString,
 			Description: "Endpoint segment",
+			ForceNew:    true,
 			Optional:    true, // precondition
 		},
 		"processing": {

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/settings.go
@@ -53,6 +53,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"custom_id": {
 			Type:        schema.TypeString,
 			Description: "Custom pipeline id",
+			ForceNew:    true,
 			Required:    true,
 		},
 		"data_extraction": {
@@ -79,6 +80,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"group_role": {
 			Type:        schema.TypeString,
 			Description: "Group role. Possible values: `compositionPipeline`, `memberPipeline`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"metadata_list": {
@@ -116,6 +118,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"routing": {
 			Type:        schema.TypeString,
 			Description: "Routing. Possible values: `notRoutable`, `routable`",
+			ForceNew:    true,
 			Optional:    true, // nullable
 		},
 		"security_context": {


### PR DESCRIPTION
#### **Why** this PR?
Some fields of `dynatrace_openpipeline_v2_*` resources can't be changed. Like custom_id, group_role, and routing of pipelines and path_segment of ingest sources. When they are changed in TF, the API returns an error.

#### **What** has changed?
Changing non-modifiable fields does not result in the resource being recreated.
Affected fields:
- `dynatrace_openpipeline_v2_*_ingestsources`: `path_segment`
- `dynatrace_openpipeline_v2_*_pipelines`: `custom_id`, `group_role`, `routing`

#### **How** does it do it?
By adding `ForceNew: true` to affected fields.

#### How is it **tested**?
Manual tests

#### How does it affect **users**?
They can now modify non-modifiable fields

**Issue:** CA-18100