### PR TITLE
feat(srg): Removes `MaxItems`, and API errors in the resource keep violation paths

### DIFF
--- a/dynatrace/api/app/dynatrace/sitereliabilityguardian/settings/objective_link.go
+++ b/dynatrace/api/app/dynatrace/sitereliabilityguardian/settings/objective_link.go
@@ -30,7 +30,6 @@ func (me *ObjectiveLinks) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
-			MaxItems:    5,
 			Description: "",
 			Elem:        &schema.Resource{Schema: new(ObjectiveLink).Schema()},
 		},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -554,7 +554,7 @@ func Provider() *schema.Provider {
 			"dynatrace_crashdump_analytics":                           resources.NewGeneric(export.ResourceTypes.CrashdumpAnalytics).Resource(),
 			"dynatrace_app_monitoring":                                resources.NewGeneric(export.ResourceTypes.AppMonitoring).Resource(),
 			"dynatrace_grail_security_context":                        resources.NewGeneric(export.ResourceTypes.GrailSecurityContext).Resource(),
-			"dynatrace_site_reliability_guardian":                     resources.NewGeneric(export.ResourceTypes.SiteReliabilityGuardian).Resource(),
+			"dynatrace_site_reliability_guardian":                     resources.NewGenericWithAlwaysPrintingViolationPath(export.ResourceTypes.SiteReliabilityGuardian).Resource(),
 			"dynatrace_automation_workflow_jira":                      resources.NewGeneric(export.ResourceTypes.JiraForWorkflows).Resource(),
 			"dynatrace_automation_workflow_slack":                     resources.NewGeneric(export.ResourceTypes.SlackForWorkflows).Resource(),
 			"dynatrace_kubernetes_app":                                resources.NewGeneric(export.ResourceTypes.KubernetesApp).Resource(),


### PR DESCRIPTION
#### **Why** this PR?
We want the API to validate the number of links.

#### **What** has changed?
`MaxItems: 5` is removed again from the links collection and API errors will contain the violation path, i.e. the path in the JSON payload which violates constraints.

#### **How** does it do it?
Example:
<img width="783" height="187" alt="image" src="https://github.com/user-attachments/assets/197eb426-222a-4659-bdba-df341d344a37" />

#### How is it **tested**?
E2E tests are in place and work

#### How does it affect **users**?
They will see a better error message, but it will not appear in `plan`, only in `apply`.

**Issue:** CA-17812
