### PR TITLE
fix(rum): unmarshalling of user_action_properties

### DIFF
--- a/dynatrace/api/v1/config/metrics/calculated/web/settings/user_action_filter.go
+++ b/dynatrace/api/v1/config/metrics/calculated/web/settings/user_action_filter.go
@@ -24,43 +24,43 @@ import (
 
 // User action filter of a calculated web metric.
 type UserActionFilter struct {
-	ActionDurationFromMilliseconds *int                  `json:"actionDurationFromMilliseconds,omitempty"` // Only actions with a duration more than or equal to this value (in milliseconds) are included in the metric calculation.
-	ActionDurationToMilliseconds   *int                  `json:"actionDurationToMilliseconds,omitempty"`   // Only actions with a duration less than or equal to this value (in milliseconds) are included in the metric calculation.
-	LoadAction                     *bool                 `json:"loadAction,omitempty"`                     // The status of load actions in the metric calculation: `true` or `false`
-	XHRAction                      *bool                 `json:"xhrAction,omitempty"`                      // The status of xhr actions in the metric calculation: `true` or `false`
-	XHRRouteChangeAction           *bool                 `json:"xhrRouteChangeAction,omitempty"`           // The status of route actions in the metric calculation: `true` or `false`
-	CustomAction                   *bool                 `json:"customAction,omitempty"`                   // The status of custom actions in the metric calculation: `true` or `false`
-	Apdex                          *string               `json:"apdex,omitempty"`                          // Only actions with the specified Apdex score are included in the metric calculation. Possible values: [ Frustrated, Satisfied, Tolerating, Unknown ]
-	Domain                         *string               `json:"domain,omitempty"`                         // Only user actions coming from the specified domain are included in the metric calculation.
-	UserActionName                 *string               `json:"userActionName,omitempty"`                 // Only actions with this name are included in the metric calculation.
-	RealUser                       *bool                 `json:"realUser,omitempty"`                       // The status of actions coming from real users in the metric calculation: `true` or `false`
-	Robot                          *bool                 `json:"robot,omitempty"`                          // The status of actions coming from robots in the metric calculation: `true` or `false`
-	Synthetic                      *bool                 `json:"synthetic,omitempty"`                      // The status of actions coming from synthetic monitors in the metric calculation: `true` or `false`
-	BrowserFamily                  *string               `json:"browserFamily,omitempty"`                  // Only user actions coming from the specified browser family are included in the metric calculation.
-	BrowserType                    *string               `json:"browserType,omitempty"`                    // Only user actions coming from the specified browser type are included in the metric calculation.
-	BrowserVersion                 *string               `json:"browserVersion,omitempty"`                 // Only user actions coming from the specified browser version are included in the metric calculation.
-	HasCustomErrors                *bool                 `json:"hasCustomErrors,omitempty"`                // The custom error status of the actions to be included in the metric calculation: `true` or `false`
-	HasAnyError                    *bool                 `json:"hasAnyError,omitempty"`                    // The error status of the actions to be included in the metric calculation: `true` or `false`
-	HasHttpErrors                  *bool                 `json:"hasHttpErrors,omitempty"`                  // The request error status of the actions to be included in the metric calculation: `true` or `false`
-	HasJavascriptErrors            *bool                 `json:"hasJavascriptErrors,omitempty"`            // The JavaScript error status of the actions to be included in the metric calculation: `true` or `false`
-	City                           *string               `json:"city,omitempty"`                           // Only actions of users from this city are included in the metric calculation. Specify geolocation ID here.
-	Continent                      *string               `json:"continent,omitempty"`                      // Only actions of users from this continent are included in the metric calculation. Specify geolocation ID here.
-	Country                        *string               `json:"country,omitempty"`                        // Only actions of users from this country are included in the metric calculation. Specify geolocation ID here.
-	Region                         *string               `json:"region,omitempty"`                         // Only actions of users from this region are included in the metric calculation. Specify geolocation ID here.
-	IP                             *string               `json:"ip,omitempty"`                             // Only actions coming from this IP address are included in the metric calculation.
-	IPV6Traffic                    *bool                 `json:"ipV6Traffic,omitempty"`                    // The IPv6 status of the actions to be included in the metric calculation: `true` or `false`
-	OSFamily                       *string               `json:"osFamily,omitempty"`                       // Only actions coming from this OS family are included in the metric calculation.
-	OSVersion                      *string               `json:"osVersion,omitempty"`                      // Only actions coming from this OS version are included in the metric calculation.
-	HTTPErrorCode                  *int                  `json:"httpErrorCode,omitempty"`                  // The HTTP error status code of the actions to be included in the metric calculation.
-	HTTPErrorCodeTo                *int                  `json:"httpErrorCodeTo,omitempty"`                // Can be used in combination with httpErrorCode to define a range of error codes that will be included in the metric calculation.
-	HTTPPath                       *string               `json:"httpPath,omitempty"`                       // The request path that has been determined to be the origin of an HTTP error of the actions to be included in the metric calculation.
-	CustomErrorType                *string               `json:"customErrorType,omitempty"`                // The custom error type of the actions to be included in the metric calculation.
-	CustomErrorName                *string               `json:"customErrorName,omitempty"`                // The custom error name of the actions to be included in the metric calculation.
-	UserActionProperties           *UserActionProperties `json:"userActionProperties,omitempty"`           // Only actions with the specified properties are included in the metric calculation.
-	TargetViewName                 *string               `json:"targetViewName,omitempty"`                 // Only actions on the specified view are included in the metric calculation.
-	TargetViewNameMatchType        *string               `json:"targetViewNameMatchType,omitempty"`        // Specifies the match type of the view name filter, e.g. using Contains or Equals. Defaults to Equals.
-	TargetViewGroup                *string               `json:"targetViewGroup,omitempty"`                // Only actions on the specified group of views are included in the metric calculation.
-	TargetViewGroupNameMatchType   *string               `json:"targetViewGroupNameMatchType,omitempty"`   // Specifies the match type of the view group filter, e.g. using Contains or Equals. Defaults to Equals.
+	ActionDurationFromMilliseconds *int                 `json:"actionDurationFromMilliseconds,omitempty"` // Only actions with a duration more than or equal to this value (in milliseconds) are included in the metric calculation.
+	ActionDurationToMilliseconds   *int                 `json:"actionDurationToMilliseconds,omitempty"`   // Only actions with a duration less than or equal to this value (in milliseconds) are included in the metric calculation.
+	LoadAction                     *bool                `json:"loadAction,omitempty"`                     // The status of load actions in the metric calculation: `true` or `false`
+	XHRAction                      *bool                `json:"xhrAction,omitempty"`                      // The status of xhr actions in the metric calculation: `true` or `false`
+	XHRRouteChangeAction           *bool                `json:"xhrRouteChangeAction,omitempty"`           // The status of route actions in the metric calculation: `true` or `false`
+	CustomAction                   *bool                `json:"customAction,omitempty"`                   // The status of custom actions in the metric calculation: `true` or `false`
+	Apdex                          *string              `json:"apdex,omitempty"`                          // Only actions with the specified Apdex score are included in the metric calculation. Possible values: [ Frustrated, Satisfied, Tolerating, Unknown ]
+	Domain                         *string              `json:"domain,omitempty"`                         // Only user actions coming from the specified domain are included in the metric calculation.
+	UserActionName                 *string              `json:"userActionName,omitempty"`                 // Only actions with this name are included in the metric calculation.
+	RealUser                       *bool                `json:"realUser,omitempty"`                       // The status of actions coming from real users in the metric calculation: `true` or `false`
+	Robot                          *bool                `json:"robot,omitempty"`                          // The status of actions coming from robots in the metric calculation: `true` or `false`
+	Synthetic                      *bool                `json:"synthetic,omitempty"`                      // The status of actions coming from synthetic monitors in the metric calculation: `true` or `false`
+	BrowserFamily                  *string              `json:"browserFamily,omitempty"`                  // Only user actions coming from the specified browser family are included in the metric calculation.
+	BrowserType                    *string              `json:"browserType,omitempty"`                    // Only user actions coming from the specified browser type are included in the metric calculation.
+	BrowserVersion                 *string              `json:"browserVersion,omitempty"`                 // Only user actions coming from the specified browser version are included in the metric calculation.
+	HasCustomErrors                *bool                `json:"hasCustomErrors,omitempty"`                // The custom error status of the actions to be included in the metric calculation: `true` or `false`
+	HasAnyError                    *bool                `json:"hasAnyError,omitempty"`                    // The error status of the actions to be included in the metric calculation: `true` or `false`
+	HasHttpErrors                  *bool                `json:"hasHttpErrors,omitempty"`                  // The request error status of the actions to be included in the metric calculation: `true` or `false`
+	HasJavascriptErrors            *bool                `json:"hasJavascriptErrors,omitempty"`            // The JavaScript error status of the actions to be included in the metric calculation: `true` or `false`
+	City                           *string              `json:"city,omitempty"`                           // Only actions of users from this city are included in the metric calculation. Specify geolocation ID here.
+	Continent                      *string              `json:"continent,omitempty"`                      // Only actions of users from this continent are included in the metric calculation. Specify geolocation ID here.
+	Country                        *string              `json:"country,omitempty"`                        // Only actions of users from this country are included in the metric calculation. Specify geolocation ID here.
+	Region                         *string              `json:"region,omitempty"`                         // Only actions of users from this region are included in the metric calculation. Specify geolocation ID here.
+	IP                             *string              `json:"ip,omitempty"`                             // Only actions coming from this IP address are included in the metric calculation.
+	IPV6Traffic                    *bool                `json:"ipV6Traffic,omitempty"`                    // The IPv6 status of the actions to be included in the metric calculation: `true` or `false`
+	OSFamily                       *string              `json:"osFamily,omitempty"`                       // Only actions coming from this OS family are included in the metric calculation.
+	OSVersion                      *string              `json:"osVersion,omitempty"`                      // Only actions coming from this OS version are included in the metric calculation.
+	HTTPErrorCode                  *int                 `json:"httpErrorCode,omitempty"`                  // The HTTP error status code of the actions to be included in the metric calculation.
+	HTTPErrorCodeTo                *int                 `json:"httpErrorCodeTo,omitempty"`                // Can be used in combination with httpErrorCode to define a range of error codes that will be included in the metric calculation.
+	HTTPPath                       *string              `json:"httpPath,omitempty"`                       // The request path that has been determined to be the origin of an HTTP error of the actions to be included in the metric calculation.
+	CustomErrorType                *string              `json:"customErrorType,omitempty"`                // The custom error type of the actions to be included in the metric calculation.
+	CustomErrorName                *string              `json:"customErrorName,omitempty"`                // The custom error name of the actions to be included in the metric calculation.
+	UserActionProperties           UserActionProperties `json:"userActionProperties,omitempty"`           // Only actions with the specified properties are included in the metric calculation.
+	TargetViewName                 *string              `json:"targetViewName,omitempty"`                 // Only actions on the specified view are included in the metric calculation.
+	TargetViewNameMatchType        *string              `json:"targetViewNameMatchType,omitempty"`        // Specifies the match type of the view name filter, e.g. using Contains or Equals. Defaults to Equals.
+	TargetViewGroup                *string              `json:"targetViewGroup,omitempty"`                // Only actions on the specified group of views are included in the metric calculation.
+	TargetViewGroupNameMatchType   *string              `json:"targetViewGroupNameMatchType,omitempty"`   // Specifies the match type of the view group filter, e.g. using Contains or Equals. Defaults to Equals.
 }
 
 func (me *UserActionFilter) Schema() map[string]*schema.Schema {
@@ -226,7 +226,7 @@ func (me *UserActionFilter) Schema() map[string]*schema.Schema {
 			Description: "The custom error name of the actions to be included in the metric calculation.",
 		},
 		"user_action_properties": {
-			Type:        schema.TypeSet,
+			Type:        schema.TypeList,
 			Optional:    true,
 			Description: "The definition of a calculated web metric.",
 			Elem:        &schema.Resource{Schema: new(UserActionProperties).Schema()},

--- a/dynatrace/api/v1/config/metrics/calculated/web/settings/user_action_properties.go
+++ b/dynatrace/api/v1/config/metrics/calculated/web/settings/user_action_properties.go
@@ -40,7 +40,20 @@ func (me UserActionProperties) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *UserActionProperties) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("property", me)
+	if err := decoder.DecodeSlice("property", me); err != nil {
+		return err
+	}
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+	// Only known workaround is to ignore these blocks
+	newEntries := UserActionProperties{}
+	emptyItem := UserActionProperty{}
+	for _, entry := range *me {
+		if *entry != emptyItem {
+			newEntries = append(newEntries, entry)
+		}
+	}
+	*me = newEntries
+	return nil
 }
 
 type UserActionProperty struct {

--- a/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-g.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/web/testdata/terraform/example-g.tf
@@ -1,0 +1,28 @@
+resource "dynatrace_calculated_web_metric" "#name#" {
+  name           = "#name#"
+  enabled        = true
+  app_identifier = "APPLICATION-EA7C4B59F27D43EB"
+  metric_key     = "calc:apps.web.#name#"
+  dimensions {
+    dimension {
+      dimension    = "StringProperty"
+      property_key = "web_utm_campaign"
+      top_x        = 10
+    }
+  }
+  metric_definition {
+    metric = "VisuallyComplete"
+  }
+  user_action_filter {
+    continent                         = "GEOLOCATION-970B6D0A98F55995"
+    target_view_group_name_match_type = "Equals"
+    target_view_name_match_type       = "Equals"
+    user_action_properties {
+      property {
+        key        = "manifest_fetch_status"
+        match_type = "Equals"
+        value      = "success"
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
The `user_action_properties` field of `dynatrace_calculated_web_metric` could not be unmarshalled.
The following error log occurred: 
`[WARN] **web.UserActionProperties user_action_properties NOT covered`

#### **What** has changed and **How**?
- `user_action_properties` changed from `TypeSet` to `TypeList`
- Receiver for `MarshalHCL` of `UserActionProperties` changed to pointer receiver
- `UserActionFilter` now has `UserActionProperties` instead of `*UserActionProperties`

#### How is it **tested**?
Manual testing and E2E test was added.

#### How does it affect **users**?
Users can use the `user_action_properties` field of the `dynatrace_calculated_web_metric` now.

**Issue:** CA-18231
