### PR TITLE
feat(workflows): Adds `analysis_ready` field to `davis_problem` workflow triggers

### DIFF
--- a/dynatrace/api/automation/workflows/settings/davis_problem_config.go
+++ b/dynatrace/api/automation/workflows/settings/davis_problem_config.go
@@ -31,6 +31,7 @@ type DavisProblemConfig struct {
 	OnProblemClose  bool                    `json:"onProblemClose" default:"false"` //
 	Categories      *DavisProblemCategories `json:"categories"`                     //
 	CustomFilter    string                  `json:"customFilter,omitempty"`         //
+	AnalysisReady   bool                    `json:"analysisReady" default:"false"`  // If set to `true`, the workflow will only be triggered after the initial root cause analysis run is completed
 }
 
 func (me *DavisProblemConfig) Schema(prefix string) map[string]*schema.Schema {
@@ -66,6 +67,12 @@ func (me *DavisProblemConfig) Schema(prefix string) map[string]*schema.Schema {
 			Description: "Additional DQL matcher expression to further filter events to match",
 			Optional:    true,
 		},
+		"analysis_ready": {
+			Type:        schema.TypeBool,
+			Description: "If set to `true`, the workflow will only be triggered after the initial root cause analysis run is completed",
+			Optional:    true,
+			Default:     false,
+		},
 	}
 }
 
@@ -78,6 +85,7 @@ func (me *DavisProblemConfig) MarshalHCL(properties hcl.Properties) error {
 		"on_problem_close":  me.OnProblemClose,
 		"categories":        me.Categories,
 		"custom_filter":     me.CustomFilter,
+		"analysis_ready":    me.AnalysisReady,
 	})
 }
 
@@ -90,6 +98,7 @@ func (me *DavisProblemConfig) UnmarshalHCL(decoder hcl.Decoder) error {
 		"on_problem_close":  &me.OnProblemClose,
 		"categories":        &me.Categories,
 		"custom_filter":     &me.CustomFilter,
+		"analysis_ready":    &me.AnalysisReady,
 	})
 }
 

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-b.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-b.tf
@@ -1,0 +1,37 @@
+resource "dynatrace_automation_workflow" "#name#" {
+  description = "#name#"
+  actor       = "703d65c0-4aff-45d9-8b34-2c6f5f17bb8e"
+  owner       = "703d65c0-4aff-45d9-8b34-2c6f5f17bb8e"
+  private     = true
+  title       = "#name#"
+  tasks {
+    task {
+      name = "test_1"
+      action = "dynatrace.automations:execute-dql-query"
+      position {
+        x = 0
+        y = 1
+      }
+      description = "Dummy task"
+      active = false
+    }
+  }
+  trigger {
+    event {
+      # active = false
+      config {
+        davis_problem {
+          categories {
+            error = true
+          }
+          entity_tags = {
+            unknowntag = "this-tag-does-not-exist"
+          }
+          entity_tags_match  = "all"
+          custom_filter = "matchesPhrase(custom.event.type, \"DEPLOY\")"
+          analysis_ready = true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
We received feedback that a recently added field for Davis problem triggers for workflows has not yet been made available via the Terraform provider. This PR adds this field.

#### **What** has changed?
The `analysisReady` parameter can now be set via the Terraform provider.

#### **How** does it do it?
The optional boolean field with `false` default value is added to the HCL schema.

#### How is it **tested**?
An E2E test using the field is added.

#### How does it affect **users**?
Users can set the `analysisReady` parameter via the Terraform provider.

**Issue:** CA-18212
