### PR TITLE
docs(openpipeline-v2): add pipeline-groups documentation

### DIFF
--- a/templates/resources/openpipeline_v2_bizevents_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_bizevents_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_bizevents_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_bizevents_pipelinegroups` covers configuration of OpenPipeline for bizevents pipeline groups
+---
+
+# dynatrace_openpipeline_v2_bizevents_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_bizevents_pipelinegroups` downloads all existing OpenPipeline definitions for bizevents pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/bizevents/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_davis_events_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_davis_events_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_davis_events_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_davis_events_pipelinegroups` covers configuration of OpenPipeline for davis events pipeline groups
+---
+
+# dynatrace_openpipeline_v2_davis_events_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_davis_events_pipelinegroups` downloads all existing OpenPipeline definitions for davis events pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_davis_problems_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_davis_problems_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_davis_problems_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_davis_problems_pipelinegroups` covers configuration of OpenPipeline for davis problems pipeline groups
+---
+
+# dynatrace_openpipeline_v2_davis_problems_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_davis_problems_pipelinegroups` downloads all existing OpenPipeline definitions for davis problems pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_events_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_events_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_events_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_events_pipelinegroups` covers configuration of OpenPipeline for events pipeline groups
+---
+
+# dynatrace_openpipeline_v2_events_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_events_pipelinegroups` downloads all existing OpenPipeline definitions for events pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/events/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_events_sdlc_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_events_sdlc_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_events_sdlc_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_events_sdlc_pipelinegroups` covers configuration of OpenPipeline for events sdlc pipeline groups
+---
+
+# dynatrace_openpipeline_v2_events_sdlc_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_events_sdlc_pipelinegroups` downloads all existing OpenPipeline definitions for events sdlc pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_events_security_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_events_security_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_events_security_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_events_security_pipelinegroups` covers configuration of OpenPipeline for events security pipeline groups
+---
+
+# dynatrace_openpipeline_v2_events_security_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_events_security_pipelinegroups` downloads all existing OpenPipeline definitions for events security pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/events/security/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_logs_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_logs_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_logs_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_logs_pipelinegroups` covers configuration of OpenPipeline for logs pipeline groups
+---
+
+# dynatrace_openpipeline_v2_logs_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_logs_pipelinegroups` downloads all existing OpenPipeline definitions for logs pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/logs/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_metrics_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_metrics_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_metrics_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_metrics_pipelinegroups` covers configuration of OpenPipeline for metrics pipeline groups
+---
+
+# dynatrace_openpipeline_v2_metrics_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_metrics_pipelinegroups` downloads all existing OpenPipeline definitions for metrics pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/metrics/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_security_events_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_security_events_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_security_events_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_security_events_pipelinegroups` covers configuration of OpenPipeline for security events pipeline groups
+---
+
+# dynatrace_openpipeline_v2_security_events_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_security_events_pipelinegroups` downloads all existing OpenPipeline definitions for security events pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_spans_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_spans_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_spans_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_spans_pipelinegroups` covers configuration of OpenPipeline for spans pipeline groups
+---
+
+# dynatrace_openpipeline_v2_spans_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_spans_pipelinegroups` downloads all existing OpenPipeline definitions for spans pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/spans/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_system_events_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_system_events_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_system_events_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_system_events_pipelinegroups` covers configuration of OpenPipeline for system events pipeline groups
+---
+
+# dynatrace_openpipeline_v2_system_events_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_system_events_pipelinegroups` downloads all existing OpenPipeline definitions for system events pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_user_events_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_user_events_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_user_events_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_user_events_pipelinegroups` covers configuration of OpenPipeline for user events pipeline groups
+---
+
+# dynatrace_openpipeline_v2_user_events_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_user_events_pipelinegroups` downloads all existing OpenPipeline definitions for user events pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/openpipeline_v2_usersessions_pipelinegroups.md.tmpl
+++ b/templates/resources/openpipeline_v2_usersessions_pipelinegroups.md.tmpl
@@ -1,0 +1,45 @@
+---
+layout: ""
+page_title: "dynatrace_openpipeline_v2_usersessions_pipelinegroups Resource - terraform-provider-dynatrace"
+subcategory: "OpenPipeline V2"
+description: |-
+  The resource `dynatrace_openpipeline_v2_usersessions_pipelinegroups` covers configuration of OpenPipeline for user sessions pipeline groups
+---
+
+# dynatrace_openpipeline_v2_usersessions_pipelinegroups (Resource)
+
+-> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
+
+-> This resource requires the OAuth scopes **Read settings** (`settings:objects:read`) and **Write settings** (`settings:objects:write`)
+
+## Limitations
+~> **Warning** If a resource is created using an API token or without setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true` (when both are used), the settings object's owner will remain empty.
+
+An empty owner implies:
+- The settings object becomes public, allowing other users with settings permissions to read and modify it.
+- Changing the settings object's permissions will have no effect, meaning the `dynatrace_settings_permissions` resource can't alter its access.
+
+When a settings object is created using platform credentials:
+- The owner is set to the owner of the OAuth client or platform token.
+- By default, the settings object is private; only the owner can read and modify it.
+- Access modifiers can be managed using the `dynatrace_settings_permissions` resource.
+
+We recommend using platform credentials to ensure a correct setup.
+In case an API token is needed, we recommend setting `DYNATRACE_HTTP_OAUTH_PREFERENCE=true`.
+
+## Dynatrace Documentation
+
+- OpenPipeline - https://docs.dynatrace.com/docs/platform/openpipeline
+- Pipeline groups - https://docs.dynatrace.com/docs/shortlink/openpipeline-pipeline-groups
+
+## Export Example Usage
+
+- `terraform-provider-dynatrace -export dynatrace_openpipeline_v2_usersessions_pipelinegroups` downloads all existing OpenPipeline definitions for user sessions pipeline groups
+
+The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
+
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/testdata/terraform/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
#### **Why** this PR?
We need to document the new `dynatrace_openpipeline_v2_*_pipelinegroups` resources.

#### **What** has changed?
Template files added for all `dynatrace_openpipeline_v2_*_pipelinegroups` resources.

#### **How** does it do it?
Each file is basically the same. Only the resource names and the example path differ.

#### How is it **tested**?
Generation of the md files is working; therefore, the paths are at least correct.

#### How does it affect **users**?
N/A (md files not generated yet)

**Issue:** CA-16608


### How to validate the md file
Simply run `go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs` and paste the md file into the [doc preview tool](https://registry.terraform.io/tools/doc-preview)