### PR TITLE
test: sanitize app example (tests)

### DIFF
--- a/dynatrace/api/app/dynatrace/azure/connector/microsoftentraidentitydeveloperconnection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/azure/connector/microsoftentraidentitydeveloperconnection/testdata/terraform/example_a.tf
@@ -1,6 +1,6 @@
-resource "dynatrace_msentraid_connection" "#name#"{
+resource "dynatrace_msentraid_connection" "connection" {
   name    = "#name#"
-  directory_id = "123e4567-e89b-12d3-a456-426614174000"
-  application_id = "123e4567-e89b-12d3-a456-426614174000"
+  directory_id = "00000000-0000-0000-0000-000000000000"
+  application_id = "00000000-0000-0000-0000-000000000000"
   client_secret = "#######"
 }

--- a/dynatrace/api/app/dynatrace/devobs/debugger/gitonprem/service_test.go
+++ b/dynatrace/api/app/dynatrace/devobs/debugger/gitonprem/service_test.go
@@ -21,10 +21,10 @@ package gitonprem_test
 
 import (
 	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
 )
 
 func TestAccDevObsGitOnPrem(t *testing.T) {
-	// Temporarily disabled - not available on test tenant
-	// api.TestAcc(t)
-	t.Skip()
+	api.TestAcc(t)
 }

--- a/dynatrace/api/app/dynatrace/devobs/debugger/gitonprem/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/devobs/debugger/gitonprem/testdata/terraform/example_a.tf
@@ -1,4 +1,4 @@
-resource "dynatrace_devobs_git_onprem" "#name#" {
+resource "dynatrace_devobs_git_onprem" "onprem" {
   git_provider = "GithubOnPrem"
-  url          = "http://www.google.com/test/#name#"
+  url          = "https://example.com/test/#name#"
 }

--- a/dynatrace/api/app/dynatrace/gitlab/connector/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/gitlab/connector/connection/testdata/terraform/example_a.tf
@@ -1,5 +1,5 @@
-resource "dynatrace_gitlab_connection" "#name#"{
+resource "dynatrace_gitlab_connection" "connection" {
   name    = "#name#"
-  url     = "https://www.#name#.com"
+  url     = "https://www.example.com"
   token   = "#######"
 }

--- a/dynatrace/api/app/dynatrace/jenkins/connector/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/jenkins/connector/connection/testdata/terraform/example_a.tf
@@ -1,6 +1,6 @@
-resource "dynatrace_jenkins_connection" "#name#"{
+resource "dynatrace_jenkins_connection" "connection" {
   name    = "#name#"
-  url     = "https://www.#name#.com"
+  url     = "https://www.example.com"
   username    = "#name#"
   password   = "#######"
 }

--- a/dynatrace/api/app/dynatrace/kubernetes/connector/connection/service_test.go
+++ b/dynatrace/api/app/dynatrace/kubernetes/connector/connection/service_test.go
@@ -21,10 +21,10 @@ package connection_test
 
 import (
 	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
 )
 
 func TestAccK8sAutomationConnections(t *testing.T) {
-	// Temporarily disabled - not available on test tenant
-	// api.TestAcc(t)
-	t.Skip()
+	api.TestAcc(t)
 }

--- a/dynatrace/api/app/dynatrace/kubernetes/connector/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/kubernetes/connector/connection/testdata/terraform/example_a.tf
@@ -1,6 +1,6 @@
-resource "dynatrace_automation_workflow_k8s_connections" "#name#" {
+resource "dynatrace_automation_workflow_k8s_connections" "connection" {
   name      = "terraform1"
-  uid       = "c6a3798e-634e-49fd-a3ca-00e5c16a1bf3"
+  uid       = "00000000-0000-0000-0000-000000000000"
   namespace = "terraform1"
   token     = "dt0e01.000000000000000000000000.0000000000000000000000000000000000000000000000000000000000000000"
 }

--- a/dynatrace/api/app/dynatrace/launchpad/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/launchpad/testdata/terraform/example_a.tf
@@ -1,9 +1,9 @@
-resource "dynatrace_default_launchpad" "#name#" {
+resource "dynatrace_default_launchpad" "launchpad" {
   group_launchpads {
     group_launchpad {
       is_enabled = false
-      launchpad_id = "bbfbffa1-3cce-49a9-bc8f-c892c626f034"
-      user_group_id = "ed8db894-e13f-43e8-8916-dd30b8e37e92"
+      launchpad_id = "00000000-0000-0000-0000-000000000000"
+      user_group_id = "00000000-0000-0000-0000-000000000000"
     }
   }
 }

--- a/dynatrace/api/app/dynatrace/microsoft365/connector/mail/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/microsoft365/connector/mail/connection/testdata/terraform/example_a.tf
@@ -1,8 +1,8 @@
-resource "dynatrace_ms365_email_connection" "#name#"{
+resource "dynatrace_ms365_email_connection" "connection" {
   name     = "#name#"
   type     = "client_secret"
-  tenant_id     = "123e4567-e89b-12d3-a456-426614174000"
-  client_id     = "123e4567-e89b-12d3-a456-426614174000"
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
   client_secret   = "######"
   from_address    = "random.email@terraform.com"
 }

--- a/dynatrace/api/app/dynatrace/pagerduty/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/pagerduty/connection/testdata/terraform/example_a.tf
@@ -1,5 +1,5 @@
-resource "dynatrace_pagerduty_connection" "#name#"{
+resource "dynatrace_pagerduty_connection" "connection" {
   name    = "#name#"
-  url     = "https://www.#name#.com"
+  url     = "https://www.example.com/"
   token   = "#######"
-  }
+}

--- a/dynatrace/api/app/dynatrace/redhat/ansible/automationcontroller/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/redhat/ansible/automationcontroller/connection/testdata/terraform/example_a.tf
@@ -1,6 +1,6 @@
-resource "dynatrace_automation_controller_connections" "#name#"{
+resource "dynatrace_automation_controller_connections" "connection" {
   name    = "#name#"
-  url     = "https://www.google.com"
+  url     = "https://www.example.com"
   type    = "api-token"
   token   = "#######"
-  }
+}

--- a/dynatrace/api/app/dynatrace/redhat/ansible/edawebhook/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/redhat/ansible/edawebhook/connection/testdata/terraform/example_a.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_event_driven_ansible_connections" "#name#"{
+resource "dynatrace_event_driven_ansible_connections" "connection" {
   event_stream_enabled = true
   name    = "#name#"
-  url     = "https://www.google.com"
+  url     = "https://www.example.com"
   type    = "api-token"
   token   = "######"
-  }
+}

--- a/dynatrace/api/app/dynatrace/servicenow/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/servicenow/connection/testdata/terraform/example_a.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_servicenow_connection" "#name#"{
-  name    = "#name#"
-  url     = "https://www.#name#.com"
-  type    = "basic"
-  user    = "#name#"
-  password   = "#######"
-  }
+resource "dynatrace_servicenow_connection" "user_password" {
+  name     = "#name#"
+  url      = "https://www.example.com"
+  type     = "basic"
+  user     = "#name#"
+  password = "#######"
+}

--- a/dynatrace/api/app/dynatrace/servicenow/connection/testdata/terraform/example_b.tf
+++ b/dynatrace/api/app/dynatrace/servicenow/connection/testdata/terraform/example_b.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_servicenow_connection" "#name#"{
-  name    = "#name#"
-  url     = "https://www.#name#.com"
-  type    = "client-credentials"
-  client_id    = "#name#"
-  client_secret   = "#######"
-  }
+resource "dynatrace_servicenow_connection" "client_credentials" {
+  name          = "#name#"
+  url           = "https://www.example.com"
+  type          = "client-credentials"
+  client_id     = "#name#"
+  client_secret = "#######"
+}


### PR DESCRIPTION
#### **Why** this PR?
We have certain URLs generated and some UUIDs in place that look at least real.

#### **What** has changed?
Examples are aligned to point to example.com and align all set UUIDs.

#### **How** does it do it?
- `google.com` and `#name#.com` URLs are replaced with `example.com` (I didn't chose `dynatrace.com` as this may be confusing for the examples, like the Jenkins connector or GitLab, etc.)
- Set all UUIDs to `00000000-0000-0000-0000-000000000000`
- Because I was already touching some examples, I also changed the resource name from `#name#` to somelthing valid.
- Re-enbled the tests for `dynatrace_devobs_git_onprem` and `dynatrace_automation_workflow_k8s_connections`.

#### How is it **tested**?
These are examples, they are tested.

#### How does it affect **users**?
The documentation slightly changes for them.

**Issue:**  CA-17770