### PR TITLE
fix: `dynatrace_aws_connection_role_arn` creation not working

### DIFF
--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/service.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	awsconnection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/aws"
 	role_arn "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/role_arn/settings"
 	awsconnection_settings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings"
 	retrycommon "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/retry"
@@ -33,12 +32,13 @@ import (
 )
 
 const SchemaID = "builtin:hyperscaler-authentication.connections.aws"
-const SchemaVersion = "0.0.21"
+const SchemaVersion = "0.0.24"
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*role_arn.Settings] {
 	return &service{
-		service:     settings20.Service[*role_arn.Settings](credentials, SchemaID, SchemaVersion),
-		connService: awsconnection.Service(credentials),
+		service: settings20.Service[*role_arn.Settings](credentials, SchemaID, SchemaVersion),
+		// We don't reuse awsconnection.Service(credentials), as this one contains custom update logic
+		connService: settings20.Service[*awsconnection_settings.Settings](credentials, SchemaID, SchemaVersion),
 	}
 }
 


### PR DESCRIPTION
#### **Why** this PR?
It's no longer possible to use (create) the `dynatrace_aws_connection_role_arn` resource.

#### **What** has changed?
The create is working again

#### **How** does it do it?
By not using the custom update logic of the `dynatrace_aws_connection` resource and using the default one.

#### How is it **tested**?
Manual tests. apply (create), update (for the name), destroy is working

#### How does it affect **users**?
They can make use of the resource again

**Issue:** CA-18378