### PR TITLE
chore(deps): update core lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/dlclark/regexp2 v1.11.5
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20251212150514-9e1640896702
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260303141931-7f1b5ad0a3fb
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20251212150514-9e1640896702 h1:AVXMO2PVoL+xKaieQ+RfoXOsckYRFNsa6+26HoWrCcQ=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20251212150514-9e1640896702/go.mod h1:iEjAyUFUxfIY9pJz/4jW7MJyiummvpaKoo01yXDl74c=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260303141931-7f1b5ad0a3fb h1:lkdr2eM1IN/Zt65ye/wS1S8Cxs0hIgpCFExgyXoq5nc=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260303141931-7f1b5ad0a3fb/go.mod h1:3S3D4xkkkszznWNgEtORjRddfKQJiKZF9xPeGLKxnrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
#### **Why** this PR?
To switch from `workflows/{id}` to `workflows/{id}/export` for the workflows resource

#### **What** has changed?
GET for workflows changed form `workflows/{id}` to `workflows/{id}/export`

#### **How** does it do it?
By bumping the related library.

#### How is it **tested**?
Tests are still working

#### How does it affect **users**?
No real impact. The call might be a bit faster, as execution information is not needed/requested here.

**Issue:** CA-18196
