### PR TITLE
fix: correctly set workflow task active state

### DIFF
--- a/dynatrace/api/automation/workflows/settings/task.go
+++ b/dynatrace/api/automation/workflows/settings/task.go
@@ -99,7 +99,7 @@ type Task struct {
 	Action       string               `json:"action" pattern:"^.+:.+$"`
 	Description  *string              `json:"description,omitempty"` // A description for this task
 	Input        map[string]any       `json:"input"`
-	Active       *bool                `json:"active,omitempty" default:"true"` // Specifies whether a task should be skipped as a no operation or not
+	Active       bool                 `json:"active"` // Specifies whether a task should be skipped as a no operation or not
 	Position     *TaskPosition        `json:"position"`
 	Predecessors []string             `json:"predecessors,omitempty"`
 	Conditions   *TaskConditionOption `json:"conditions,omitempty"`


### PR DESCRIPTION
#### **Why** this PR?
The `active` field of a task isn't considered if set to `false`

#### **What** has changed?
It's now considered

#### **How** does it do it?
For a task, the `active` field was never set to `false`. Reason: Within `d.GetOk`, if the set value matches the "zero" value, it's seen as "doesn't exist". The zero value of `schema.TypeBool` is `false`. Because of that, our decode function didn't set the value because we only set it if it exists. Therefore, the struct default value "nil" was taken instead of `false`.

Aligning the default struct value with the default `schema.TypeBool` value fixes the problem (`*bool` to `bool`)

This means, whenever we have `*bool` as a type, `false` leads to `nil` (undefined / not set)


#### How is it **tested**?
Manual tests. The API got `undefined`, which is considered `true`, and our state was set to nil. The diff matched actually.

#### How does it affect **users**?
They are now able to set the active state of a task to `false`.

**Issue:** CA-18418
