### PR TITLE
fix: correctly set workflow task `failed_loop_iterations_only` option

### DIFF
--- a/dynatrace/api/automation/workflows/settings/task_retry_option.go
+++ b/dynatrace/api/automation/workflows/settings/task_retry_option.go
@@ -23,9 +23,9 @@ import (
 )
 
 type TaskRetryOption struct {
-	Count                    VarInt  `json:"count" minimum:"0" maximum:"99"`                    // Specifies a maximum number of times that a task can be repeated in case it fails on execution
-	Delay                    *VarInt `json:"delay,omitempty" minimum:"0" maximum:"3600"`        // Specifies a delay in seconds between subsequent task retries
-	FailedLoopIterationsOnly *bool   `json:"failedLoopIterationsOnly,omitempty" default:"true"` // Specifies whether retrying the failed iterations or the whole loop. Default: True
+	Count                    VarInt  `json:"count" minimum:"0" maximum:"99"`             // Specifies a maximum number of times that a task can be repeated in case it fails on execution
+	Delay                    *VarInt `json:"delay,omitempty" minimum:"0" maximum:"3600"` // Specifies a delay in seconds between subsequent task retries
+	FailedLoopIterationsOnly bool    `json:"failedLoopIterationsOnly"`                   // Specifies whether retrying the failed iterations or the whole loop. Default: True
 }
 
 func (me *TaskRetryOption) Schema(prefix string) map[string]*schema.Schema {

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-a.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-a.tf
@@ -23,6 +23,11 @@ resource "dynatrace_automation_workflow" "workflow_with_davis_event_trigger" {
         x = 0
         y = 1
       }
+      retry {
+        count = "3"
+        delay = "1000"
+        failed_loop_iterations_only = false
+      }
     }
     task {
       name        = "http_request_2"


### PR DESCRIPTION
#### **Why** this PR?
It wasn't possible to set the `failed_loop_iterations_only` retry option of a task to `false`.

#### **What** has changed?
The `failed_loop_iterations_only` option can now be set to `false`

#### **How** does it do it?
By using `bool` instead of `*bool`.
Our provider transformed `false` to `undefined` and the API treats `undefined` as `true` (it doesn't actually set it). Because our provider formats `false` to `undefined` and the API returns `undefined` if not set, an integration test would not have caught it (no "changes after apply" problem).
This has/had the same problems as this one https://github.com/dynatrace-oss/terraform-provider-dynatrace/pull/1012

I haven't seen other affected fields. This should only occur for `*int` and `*bool` if the default/undefined value of the API is different from the zero value of the type (`0` and `false`)

#### How is it **tested**?
Manual tests. If wanted, I could restructure and extend the test file so that we assert the state to have the correct value

#### How does it affect **users**?
They can now set the `failed_loop_iterations_only` task retry option to `false`.


**Issue:** Done as a follow-up to CA-18418