### PR TITLE
test: re-enable pipeline groups tests

### DIFF
--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelinegroups/service_test.go
@@ -25,6 +25,5 @@ import (
 )
 
 func TestAccDavisEventsPipelineGroups(t *testing.T) {
-	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelinegroups/service_test.go
@@ -25,6 +25,5 @@ import (
 )
 
 func TestAccDavisProblemsPipelineGroups(t *testing.T) {
-	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelinegroups/service_test.go
@@ -25,6 +25,5 @@ import (
 )
 
 func TestAccEventsSDLCPipelineGroups(t *testing.T) {
-	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelinegroups/service_test.go
@@ -25,6 +25,5 @@ import (
 )
 
 func TestAccSecurityEventsPipelineGroups(t *testing.T) {
-	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelinegroups/service_test.go
@@ -25,6 +25,5 @@ import (
 )
 
 func TestAccSystemEventsPipelineGroups(t *testing.T) {
-	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelinegroups/service_test.go
@@ -25,6 +25,5 @@ import (
 )
 
 func TestAccUserEventsPipelineGroups(t *testing.T) {
-	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelinegroups/service_test.go
@@ -25,6 +25,5 @@ import (
 )
 
 func TestAccUserSessionsPipelineGroups(t *testing.T) {
-	t.Skip("temporarily skipping until the API is fixed")
 	api.TestAcc(t)
 }


### PR DESCRIPTION
#### **Why** this PR?
The pipeline group bug is resolved, and all pipeline-groups can now be created.

#### **What** has changed?
Tests for pipeline groups of davis.events, security.events, etc. are now enabled

#### **How** does it do it?
By removing the `t.Skip`

#### How is it **tested**?
This enables the actual tests

#### How does it affect **users**?
N/A

**Issue:** CA-18237
