### PR TITLE
fix: additional new line during export

### DIFF
--- a/terraform/hclgen/primitive_entry.go
+++ b/terraform/hclgen/primitive_entry.go
@@ -109,7 +109,13 @@ func (me *primitiveEntry) Write(w *hclwrite.Body, indent string) error {
 	} else if strValP, ok := me.Value.(*string); ok && strValP != nil && isJSON(*strValP) {
 		w.SetAttributeRaw(me.Key, hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenStringLit, Bytes: []byte(toJSONencode(*strValP, indent))}})
 	} else if strVal, ok := me.Value.(string); ok && !preventHeredoc && strings.Contains(strVal, "\n") {
-		mlstr := "<<-EOT\n" + indent + "  " + finalizeString(strVal, indent) + "\n" + indent + "EOT"
+		var eotIndent string
+		// If we always add a newline before the EOT end, then we end up with an extra blank line at the end of the string if the string already ends with a newline.
+		// This would cause a non-empty terraform plan
+		if !strings.HasSuffix(strVal, "\n") {
+			eotIndent = "\n" + indent
+		}
+		mlstr := "<<-EOT\n" + indent + "  " + finalizeString(strVal, indent) + eotIndent + "EOT"
 		w.SetAttributeRaw(me.Key, hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenStringLit, Bytes: []byte(mlstr)}})
 	} else if strVal, ok := me.Value.(string); ok && !preventHeredoc && strings.Count(strVal, "\"") > 3 {
 		mlstr := "<<-EOT\n" + indent + "  " + finalizeString(strVal, indent) + "\n" + indent + "EOT"


### PR DESCRIPTION
#### **Why** this PR?
Fields that ended with a new line via `<<-EOT` had an additional new line added, leading to a non-empty terraform plan for the exported resources. 
e.g., 
When this is a resource that is applied
```hcl
resource "my_res" "name" {
  prop = <<-EOT
    something here
  EOT
}
```
The export of that resource looked like this
```hcl
resource "my_res" "name" {
  prop = <<-EOT
    something here
  
  EOT
}
```

#### **What** has changed?
The additional new line is removed.

#### **How** does it do it?
The new line that is required for closing the EOT syntax is only added if there isn't already one.

#### How is it **tested**?
Manual tests, using the workflows resource

#### How does it affect **users**?
The correct value is now set during export if a string contained new lines at the end.

**Issue:** CA-18459
