### PR TITLE
chore: align workflow with the API

### DIFF
--- a/dynatrace/api/automation/workflows/settings/schedule_filter_parameters.go
+++ b/dynatrace/api/automation/workflows/settings/schedule_filter_parameters.go
@@ -40,13 +40,13 @@ func (me *ScheduleFilterParameters) Schema(prefix string) map[string]*schema.Sch
 		},
 		"earliest_start": {
 			Type:        schema.TypeString,
-			Description: "If specified, the schedule won't trigger executions before the given date",
+			Description: "If specified, the schedule won't trigger executions before the given date. Format: `yyyy-MM-dd`",
 			Optional:    true,
 			// TODO: ValidateDiag 2023-07-01
 		},
 		"earliest_start_time": {
 			Type:        schema.TypeString,
-			Description: "If specified, the schedule won't trigger executions before the given time",
+			Description: "If specified, the schedule won't trigger executions before the given time. Format: `HH:mm`",
 			Optional:    true,
 			// TODO: ValidateDiag 22:32:22
 		},
@@ -58,7 +58,7 @@ func (me *ScheduleFilterParameters) Schema(prefix string) map[string]*schema.Sch
 		},
 		"include_dates": {
 			Type:        schema.TypeSet,
-			Description: "If specified, the schedule will trigger executions on the given dates, even if the main configuration prohibits it",
+			Description: "If specified, the schedule will trigger executions on the given dates, even if the main configuration prohibits it. Format: `yyyy-MM-dd`",
 			Optional:    true,
 			MinItems:    1,
 			Elem:        &schema.Schema{Type: schema.TypeString},
@@ -66,7 +66,7 @@ func (me *ScheduleFilterParameters) Schema(prefix string) map[string]*schema.Sch
 		},
 		"exclude_dates": {
 			Type:        schema.TypeSet,
-			Description: "If specified, the schedule won't trigger exeuctions on the given dates",
+			Description: "If specified, the schedule won't trigger exeuctions on the given dates. Format: `yyyy-MM-dd`",
 			Optional:    true,
 			MinItems:    1,
 			Elem:        &schema.Schema{Type: schema.TypeString},

--- a/dynatrace/api/automation/workflows/settings/schedule_trigger.go
+++ b/dynatrace/api/automation/workflows/settings/schedule_trigger.go
@@ -18,8 +18,6 @@
 package workflows
 
 import (
-	"regexp"
-
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -42,11 +40,11 @@ type ScheduleTrigger struct {
 func (me *ScheduleTrigger) Schema(prefix string) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"time": {
-			Type:             schema.TypeString,
-			Description:      "Specifies a fixed time the schedule will trigger at in 24h format (e.g. `14:23:59`). Conflicts with `cron`, `interval_minutes`, `between_start` and `between_end`",
-			Optional:         true,
-			ValidateDiagFunc: ValidateRegex(regexp.MustCompile("^([0-1]{1}[0-9]|2[0-3]):[0-5][0-9]$"), "Example: 14:23:59"),
-			ConflictsWith:    []string{prefix + ".0.cron", prefix + ".0.interval_minutes", prefix + ".0.between_start", prefix + ".0.between_end"},
+			Type:          schema.TypeString,
+			Description:   "Specifies a fixed time the schedule will trigger at in 24h format (e.g. `14:23`). Conflicts with `cron`, `interval_minutes`, `between_start` and `between_end`",
+			Optional:      true,
+			ConflictsWith: []string{prefix + ".0.cron", prefix + ".0.interval_minutes", prefix + ".0.between_start", prefix + ".0.between_end"},
+			// Regex: ^([0-1]\d|2[0-3]):[0-5]\d$
 		},
 		"cron": {
 			Type:          schema.TypeString,
@@ -62,13 +60,13 @@ func (me *ScheduleTrigger) Schema(prefix string) map[string]*schema.Schema {
 		},
 		"between_start": {
 			Type:          schema.TypeString,
-			Description:   "Triggers the schedule every n minutes within a given time frame - specifying the start time on any valid day in 24h format (e.g. 13:22:44). Conflicts with `cron` and `time`. Required with `interval_minutes` and `between_end`",
+			Description:   "Triggers the schedule every n minutes within a given time frame - specifying the start time on any valid day in 24h format (e.g. 13:22). Conflicts with `cron` and `time`. Required with `interval_minutes` and `between_end`",
 			Optional:      true,
 			ConflictsWith: []string{prefix + ".0.time", prefix + ".0.cron"},
 		},
 		"between_end": {
 			Type:          schema.TypeString,
-			Description:   "Triggers the schedule every n minutes within a given time frame - specifying the end time on any valid day in 24h format (e.g. 14:22:44). Conflicts with `cron` and `time`. Required with `interval_minutes` and `between_start`",
+			Description:   "Triggers the schedule every n minutes within a given time frame - specifying the end time on any valid day in 24h format (e.g. 14:22). Conflicts with `cron` and `time`. Required with `interval_minutes` and `between_start`",
 			Optional:      true,
 			ConflictsWith: []string{prefix + ".0.time", prefix + ".0.cron"},
 		},

--- a/dynatrace/api/automation/workflows/settings/workflow.go
+++ b/dynatrace/api/automation/workflows/settings/workflow.go
@@ -42,7 +42,6 @@ type Workflow struct {
 	Type                 string         `json:"type"`
 	HourlyExecutionLimit *int           `json:"hourlyExecutionLimit,omitempty"` // Maximum number of executions per hour, default is 1000
 	Input                map[string]any `json:"input,omitempty"`                // Workflow-level input parameters
-	TaskDefaults         map[string]any `json:"taskDefaults,omitempty"`         // Default settings applied to all tasks
 	Guide                string         `json:"guide,omitempty"`                // Informational guide text for the workflow
 	Result               string         `json:"result,omitempty"`               // The result of the workflow
 }
@@ -133,13 +132,6 @@ func (me *Workflow) Schema() map[string]*schema.Schema {
 			DiffSuppressFunc: hcl.SuppressJSONorEOT,
 			Default:          "{}",
 		},
-		"task_defaults": {
-			Type:             schema.TypeString,
-			Description:      "Default task settings as JSON. These defaults are applied to all tasks in the workflow",
-			Optional:         true,
-			DiffSuppressFunc: hcl.SuppressJSONorEOT,
-			Default:          "{}",
-		},
 		"guide": {
 			Type:        schema.TypeString,
 			Description: "Informational guide text for the workflow",
@@ -155,11 +147,6 @@ func (me *Workflow) Schema() map[string]*schema.Schema {
 
 func (me *Workflow) MarshalHCL(properties hcl.Properties) error {
 	inputJSON, err := stringifyMap(me.Input)
-	if err != nil {
-		return err
-	}
-
-	taskDefaultsJSON, err := stringifyMap(me.TaskDefaults)
 	if err != nil {
 		return err
 	}
@@ -186,7 +173,6 @@ func (me *Workflow) MarshalHCL(properties hcl.Properties) error {
 		"type":                   me.Type,
 		"hourly_execution_limit": me.HourlyExecutionLimit,
 		"input":                  inputJSON,
-		"task_defaults":          taskDefaultsJSON,
 		"guide":                  me.Guide,
 		"result":                 me.Result,
 	})
@@ -194,7 +180,6 @@ func (me *Workflow) MarshalHCL(properties hcl.Properties) error {
 
 func (me *Workflow) UnmarshalHCL(decoder hcl.Decoder) error {
 	var inputStr string
-	var taskDefaultsStr string
 	if err := decoder.DecodeAll(map[string]any{
 		"title":       &me.Title,
 		"description": &me.Description,
@@ -209,7 +194,6 @@ func (me *Workflow) UnmarshalHCL(decoder hcl.Decoder) error {
 		"type":                   &me.Type,
 		"hourly_execution_limit": &me.HourlyExecutionLimit,
 		"input":                  &inputStr,
-		"task_defaults":          &taskDefaultsStr,
 		"guide":                  &me.Guide,
 		"result":                 &me.Result,
 	}); err != nil {
@@ -218,11 +202,6 @@ func (me *Workflow) UnmarshalHCL(decoder hcl.Decoder) error {
 
 	if len(inputStr) > 0 {
 		if err := json.Unmarshal([]byte(inputStr), &me.Input); err != nil {
-			return err
-		}
-	}
-	if len(taskDefaultsStr) > 0 {
-		if err := json.Unmarshal([]byte(taskDefaultsStr), &me.TaskDefaults); err != nil {
 			return err
 		}
 	}

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-c.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-c.tf
@@ -1,5 +1,5 @@
 # Exercises the new fields: hourly_execution_limit, analysis_ready,
-# is_deployed, owner_type, input, task_defaults, guide, and result
+# is_deployed, owner_type, input, guide, and result
 
 resource "dynatrace_iam_group" "group" {
   name = "#name#"
@@ -17,9 +17,6 @@ resource "dynatrace_automation_workflow" "with_group_owner" {
   input = jsonencode({
     "environment" : "production",
     "threshold" : 42
-  })
-  task_defaults = jsonencode({
-    "timeout" : 3600
   })
   guide = "##My Guide"
   result = "deployment_status"

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-e.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-e.tf
@@ -3,7 +3,6 @@ resource "dynatrace_automation_workflow" "workflow_with_empty_json_encode" {
   private     = true
   title       = "#name#"
   input = jsonencode({})
-  task_defaults = jsonencode({})
   tasks {
     task {
       name = "test_1"

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-f.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-f.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_automation_workflow" "workflow_with_interval_schedule" {
+  description = "#name#"
+  private     = true
+  title       = "#name#"
+  tasks {}
+  trigger {
+    schedule {
+      trigger {
+        between_end = "23:59"
+        between_start = "23:59"
+        interval_minutes = "15"
+      }
+      active = true
+      filter_parameters {
+        earliest_start_time = "00:00"
+        earliest_start = "2023-07-01"
+        count = "1"
+        exclude_dates = ["2023-07-02"]
+        include_dates = ["2100-01-01"]
+        until = "2100-01-02"
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
- `task_defaults` don't have any use
- For some time fields the format is unclear

#### **What** has changed?
- Description updated for all time-related fields to show the expected format.
- Removed the `task_defaults` field. This isn't a breaking change, as there wasn't a release yet.

#### **How** does it do it?
By removing the `task_defaults` field and updating the descriptions of time related fields.

#### How is it **tested**?
- New test added for time related fields
- Removed the task_defaults property from examples.

#### How does it affect **users**?
Better documentation for time related fields.

**Issue:** CA-18196