### PR TITLE
fix: not-found behavior for core clients

### DIFF
--- a/dynatrace/rest/error.go
+++ b/dynatrace/rest/error.go
@@ -25,6 +25,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	api2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 )
 
 type errorEnvelope struct {
@@ -45,6 +47,13 @@ type Error struct {
 	ConstraintViolations []ConstraintViolation `json:"constraintViolations,omitempty"`
 	URL                  string                `json:"-"`
 	Method               string                `json:"-"`
+}
+
+// IsNotFoundError checks if an error is a 404 error
+// api_token_client client, hybrid_client, etc. are using Error while core clients like automation use api2.APIError
+func IsNotFoundError(err error) bool {
+	var restErr Error
+	return errors.As(err, &restErr) && restErr.Code == http.StatusNotFound || api2.IsNotFoundError(err)
 }
 
 func ConstraintViolations(err error) []ConstraintViolation {

--- a/dynatrace/rest/error_test.go
+++ b/dynatrace/rest/error_test.go
@@ -1,0 +1,94 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/stretchr/testify/assert"
+
+	api2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+)
+
+type testCase struct {
+	Name string
+	Err  error
+}
+
+func TestError_IsNotFoundError_True(t *testing.T) {
+	testCases := []testCase{
+		{
+			Name: "Not found error",
+			Err:  rest.Error{Code: http.StatusNotFound},
+		},
+		{
+			Name: "Nested not found error",
+			Err:  fmt.Errorf("not found error: %w", rest.Error{Code: http.StatusNotFound}),
+		},
+		{
+			Name: "Core not found error",
+			Err:  api2.APIError{StatusCode: http.StatusNotFound},
+		},
+		{
+			Name: "Core nested not found error",
+			Err:  fmt.Errorf("not found error: %w", api2.APIError{StatusCode: http.StatusNotFound}),
+		},
+	}
+
+	for _, tcs := range testCases {
+		t.Run(tcs.Name, func(t *testing.T) {
+			assert.True(t, rest.IsNotFoundError(tcs.Err))
+		})
+	}
+}
+
+func TestError_IsNotFoundError_False(t *testing.T) {
+	testCases := []testCase{
+		{
+			Name: "Nil error",
+			Err:  nil,
+		},
+		{
+			Name: "Different error",
+			Err:  rest.Error{Code: http.StatusBadRequest},
+		},
+		{
+			Name: "Nested different error",
+			Err:  fmt.Errorf("not found error: %w", errors.New("not found error")),
+		},
+		{
+			Name: "Different core error",
+			Err:  api2.APIError{StatusCode: http.StatusBadRequest},
+		},
+		{
+			Name: "Core nested different error",
+			Err:  fmt.Errorf("not found error: %w", api2.APIError{StatusCode: http.StatusBadRequest}),
+		},
+	}
+
+	for _, tcs := range testCases {
+		t.Run(tcs.Name, func(t *testing.T) {
+			assert.False(t, rest.IsNotFoundError(tcs.Err))
+		})
+	}
+}

--- a/resources/generic.go
+++ b/resources/generic.go
@@ -473,22 +473,12 @@ func (me *Generic) Read(ctx context.Context, d *schema.ResourceData, m any) diag
 				ctx = context.WithValue(ctx, settings.ContextKeyStateConfig, tfConfig)
 			}
 			err = service.Get(ctx, d.Id(), sttngs)
-		} else {
-			if restError, ok := err.(rest.Error); ok {
-				if restError.Code == 404 {
-					d.SetId("")
-					return diag.Diagnostics{}
-				}
-			}
-			return diag.FromErr(err)
 		}
 	}
 	if err != nil {
-		if restError, ok := err.(rest.Error); ok {
-			if restError.Code == 404 {
-				d.SetId("")
-				return diag.Diagnostics{}
-			}
+		if rest.IsNotFoundError(err) {
+			d.SetId("")
+			return diag.Diagnostics{}
 		}
 		return diag.FromErr(err)
 	}
@@ -539,11 +529,9 @@ func (me *Generic) Delete(ctx context.Context, d *schema.ResourceData, m any) di
 		if restWarning, ok := err.(rest.Warning); ok {
 			return diag.Diagnostics{diag.Diagnostic{Severity: diag.Warning, Summary: restWarning.Message}}
 		}
-		if restError, ok := err.(rest.Error); ok {
-			if restError.Code == 404 {
-				d.SetId("")
-				return diag.Diagnostics{}
-			}
+		if rest.IsNotFoundError(err) {
+			d.SetId("")
+			return diag.Diagnostics{}
 		}
 		return diag.FromErr(err)
 	}

--- a/resources/generic_test.go
+++ b/resources/generic_test.go
@@ -1,0 +1,134 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resources_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/resources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+)
+
+func TestGeneric_Read(t *testing.T) {
+	t.Run("resource not found error should set the ID to empty", func(t *testing.T) {
+		gen := resources.Generic{
+			Descriptor: export.NewResourceDescriptor(MockService(nil, rest.Error{Code: http.StatusNotFound})),
+		}
+		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
+		d.SetId("test")
+		m := &config.ProviderConfiguration{
+			EnvironmentURL: "https://dynatrace.com",
+		}
+
+		diags := gen.Read(t.Context(), d, m)
+		assert.False(t, diags.HasError())
+		assert.Empty(t, d.Id())
+	})
+
+	t.Run("resource not found core error should set the ID to empty", func(t *testing.T) {
+		gen := resources.Generic{
+			Descriptor: export.NewResourceDescriptor(MockService(nil, api.APIError{StatusCode: http.StatusNotFound})),
+		}
+		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
+		d.SetId("test")
+		m := &config.ProviderConfiguration{
+			EnvironmentURL: "https://dynatrace.com",
+		}
+
+		diags := gen.Read(t.Context(), d, m)
+		assert.False(t, diags.HasError())
+		assert.Empty(t, d.Id())
+	})
+
+	t.Run("Non not found errors should error", func(t *testing.T) {
+		gen := resources.Generic{
+			Descriptor: export.NewResourceDescriptor(MockService(nil, rest.Error{Code: http.StatusBadRequest, Message: "badRequest"})),
+		}
+		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
+		d.SetId("test")
+		m := &config.ProviderConfiguration{
+			EnvironmentURL: "https://dynatrace.com",
+		}
+
+		diags := gen.Read(t.Context(), d, m)
+		assert.True(t, diags.HasError())
+		require.GreaterOrEqual(t, 1, len(diags))
+		el := diags[0]
+		assert.Equal(t, "badRequest", el.Summary)
+		assert.NotEmpty(t, d.Id())
+	})
+}
+
+func TestGeneric_Delete(t *testing.T) {
+	t.Run("resource not found error should set the ID to empty", func(t *testing.T) {
+		gen := resources.Generic{
+			Descriptor: export.NewResourceDescriptor(MockService(nil, rest.Error{Code: http.StatusNotFound})),
+		}
+		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
+		d.SetId("test")
+		m := &config.ProviderConfiguration{
+			EnvironmentURL: "https://dynatrace.com",
+		}
+
+		diags := gen.Delete(t.Context(), d, m)
+		assert.False(t, diags.HasError())
+		assert.Empty(t, d.Id())
+	})
+
+	t.Run("resource not found core error should set the ID to empty", func(t *testing.T) {
+		gen := resources.Generic{
+			Descriptor: export.NewResourceDescriptor(MockService(nil, api.APIError{StatusCode: http.StatusNotFound})),
+		}
+		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
+		d.SetId("test")
+		m := &config.ProviderConfiguration{
+			EnvironmentURL: "https://dynatrace.com",
+		}
+
+		diags := gen.Delete(t.Context(), d, m)
+		assert.False(t, diags.HasError())
+		assert.Empty(t, d.Id())
+	})
+
+	t.Run("Non not found errors should error", func(t *testing.T) {
+		gen := resources.Generic{
+			Descriptor: export.NewResourceDescriptor(MockService(nil, rest.Error{Code: http.StatusBadRequest, Message: "badRequest"})),
+		}
+		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
+		d.SetId("test")
+		m := &config.ProviderConfiguration{
+			EnvironmentURL: "https://dynatrace.com",
+		}
+
+		diags := gen.Delete(t.Context(), d, m)
+		assert.True(t, diags.HasError())
+		require.GreaterOrEqual(t, 1, len(diags))
+		el := diags[0]
+		assert.Equal(t, "badRequest", el.Summary)
+		assert.NotEmpty(t, d.Id())
+	})
+}

--- a/resources/mockservice_test.go
+++ b/resources/mockservice_test.go
@@ -1,0 +1,91 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resources_test
+
+import (
+	"context"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type service struct {
+	Stub *api.Stub
+	Err  error
+}
+
+func (me *service) List(ctx context.Context) (api.Stubs, error) {
+	return nil, nil
+}
+
+func (me *service) Get(ctx context.Context, id string, v *mockSchema) error {
+	return me.Err
+}
+
+func (me *service) SchemaID() string {
+	return "mock"
+}
+
+func (me *service) Create(ctx context.Context, v *mockSchema) (*api.Stub, error) {
+	return me.Stub, me.Err
+}
+
+func (me *service) Update(ctx context.Context, id string, v *mockSchema) error {
+	return me.Err
+}
+
+func (me *service) Delete(ctx context.Context, id string) error {
+	return me.Err
+}
+
+type mockSchema struct {
+	Name string
+}
+
+func (me *mockSchema) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func (me *mockSchema) SchemaId() string {
+	return "mock"
+}
+func (me *mockSchema) MarshalHCL(properties hcl.Properties) error {
+	return properties.Encode("name", me.Name)
+}
+
+func (me *mockSchema) UnmarshalHCL(properties hcl.Decoder) error {
+	return properties.Decode("name", &me.Name)
+}
+
+func MockService(stub *api.Stub, err error) func(credentials *rest.Credentials) settings.CRUDService[*mockSchema] {
+	return func(credentials *rest.Credentials) settings.CRUDService[*mockSchema] {
+		return &service{
+			Err:  err,
+			Stub: stub,
+		}
+	}
+}


### PR DESCRIPTION
#### **Why** this PR?
For core clients such as automation or segments, 404 errors during get and delete are treated as errors. This is not the Terraform way and should be changed so that Terraform correctly sees it as `needs creation` or `ignore 404 on delete`.

#### **What** has changed?
Core 404 errors are not correctly handled. Get shows "needs creation" and delete ignores 404

#### **How** does it do it?
By not just asserting on our own Error struct but also on the apiError of the core clients.

#### How is it **tested**?
Manual tests.

#### How does it affect **users**?
Better error handling for 404. Terraform plan will show the correct plan and not error out if a resource was deleted via the UI.

**Issue:** Follow-up based on CA-18640

### Out of scope
There are more places, where just `Error` is checked and not `apiError`. This PR fixes the GET/DELETE behavior.
Others are not that important for now and would require more refactoring work
