### PR TITLE
refactor: Don't transform API errors to REST errors in services using core clients

### DIFF
--- a/dynatrace/api/automation/business_calendars/service.go
+++ b/dynatrace/api/automation/business_calendars/service.go
@@ -20,7 +20,6 @@ package business_calendars
 import (
 	"context"
 	"encoding/json"
-	"errors"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	business_calendars "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/automation/business_calendars/settings"
@@ -75,11 +74,6 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	listResponse, err := client.List(ctx, automation.BusinessCalendars)
 	if err != nil {
-		apiErr := cacapi.APIError{}
-		if errors.As(err, &apiErr) {
-			return nil, tfrest.Error{Code: apiErr.StatusCode, Message: string(apiErr.Body)}
-		}
-
 		return nil, err
 	}
 

--- a/dynatrace/api/automation/scheduling_rules/service.go
+++ b/dynatrace/api/automation/scheduling_rules/service.go
@@ -20,7 +20,6 @@ package scheduling_rules
 import (
 	"context"
 	"encoding/json"
-	"errors"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	scheduling_rules "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/automation/scheduling_rules/settings"
@@ -75,11 +74,6 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	listResponse, err := client.List(ctx, automation.SchedulingRules)
 	if err != nil {
-		apiErr := cacapi.APIError{}
-		if errors.As(err, &apiErr) {
-			return nil, tfrest.Error{Code: apiErr.StatusCode, Message: string(apiErr.Body)}
-		}
-
 		return nil, err
 	}
 	var stubs api.Stubs

--- a/dynatrace/api/automation/workflows/service.go
+++ b/dynatrace/api/automation/workflows/service.go
@@ -20,7 +20,6 @@ package workflows
 import (
 	"context"
 	"encoding/json"
-	"errors"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	workflows "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/automation/workflows/settings"
@@ -77,10 +76,6 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	listResponse, err := client.List(ctx, apiClient.Workflows)
 	if err != nil {
-		apiErr := cacapi.APIError{}
-		if errors.As(err, &apiErr) {
-			return nil, tfrest.Error{Code: apiErr.StatusCode, Message: string(apiErr.Body)}
-		}
 		return nil, err
 	}
 

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 
-	docapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	docclient "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 
 	documents "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/document/settings"
@@ -78,9 +77,6 @@ func (me *service) get(ctx context.Context, id string, v *documents.Document) (e
 	}
 	result, err := client.Get(ctx, id)
 	if err != nil {
-		if apiError, ok := err.(docapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return err
 	}
 
@@ -113,9 +109,6 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	listResponse, err := cl.List(ctx, "")
 	if err != nil {
-		if apiError, ok := err.(docapi.APIError); ok {
-			return nil, rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return nil, err
 	}
 	var stubs api.Stubs
@@ -133,9 +126,6 @@ func (me *service) Validate(_ *documents.Document) error {
 func (me *service) Create(ctx context.Context, v *documents.Document) (*api.Stub, error) {
 	stub, err := me.createPrivate(ctx, v)
 	if err != nil {
-		if apiError, ok := err.(docapi.APIError); ok {
-			return nil, rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return nil, err
 	}
 
@@ -154,9 +144,6 @@ func (me *service) createPrivate(ctx context.Context, v *documents.Document) (st
 	}
 	response, err := c.Create(ctx, v.Name, v.IsPrivate, v.ID, []byte(v.Content), docclient.DocumentType(v.Type))
 	if err != nil {
-		if apiError, ok := err.(docapi.APIError); ok {
-			return nil, rest.Error{Code: apiError.StatusCode, Message: string(apiError.Body)}
-		}
 		return nil, err
 	}
 
@@ -178,9 +165,6 @@ func (me *service) update(ctx context.Context, id string, v *documents.Document)
 	}
 	_, err = c.Update(ctx, id, v.Name, v.IsPrivate, []byte(v.Content), docclient.DocumentType(v.Type))
 	if err != nil {
-		if apiError, ok := err.(docapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: string(apiError.Body)}
-		}
 		return err
 	}
 
@@ -194,9 +178,6 @@ func (me *service) Delete(ctx context.Context, id string) error {
 	}
 	_, err = client.Delete(ctx, id)
 	if err != nil {
-		if apiError, ok := err.(docapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: string(apiError.Body)}
-		}
 		return err
 	}
 

--- a/dynatrace/api/grail/segments/service.go
+++ b/dynatrace/api/grail/segments/service.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 
-	segmentsapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	segmentsclient "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/segments"
 
 	segments "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/grail/segments/settings"
@@ -54,9 +53,6 @@ func (me *service) Get(ctx context.Context, id string, v *segments.Segment) (err
 	}
 	response, err := client.Get(ctx, id)
 	if err != nil {
-		if apiError, ok := err.(segmentsapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return err
 	}
 
@@ -80,9 +76,6 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	listResponse, err := client.List(ctx)
 	if err != nil {
-		if apiError, ok := err.(segmentsapi.APIError); ok {
-			return nil, rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return nil, err
 	}
 	var segments []SegmentStub
@@ -116,9 +109,6 @@ func (me *service) Create(ctx context.Context, v *segments.Segment) (stub *api.S
 	}
 	response, err := client.Create(ctx, data)
 	if err != nil {
-		if apiError, ok := err.(segmentsapi.APIError); ok {
-			return nil, rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return nil, err
 	}
 
@@ -142,9 +132,6 @@ func (me *service) Update(ctx context.Context, id string, v *segments.Segment) (
 
 	_, err = client.Update(ctx, id, data)
 	if err != nil {
-		if apiError, ok := err.(segmentsapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return err
 	}
 
@@ -158,9 +145,6 @@ func (me *service) Delete(ctx context.Context, id string) error {
 	}
 	_, err = client.Delete(ctx, id)
 	if err != nil {
-		if apiError, ok := err.(segmentsapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return err
 	}
 

--- a/dynatrace/api/slo/service.go
+++ b/dynatrace/api/slo/service.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
-	sloapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	sloclient "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/slo"
 
 	slo "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/slo/settings"
@@ -53,9 +52,6 @@ func (me *service) Get(ctx context.Context, id string, v *slo.SLO) (err error) {
 	}
 	response, err := client.Get(ctx, id)
 	if err != nil {
-		if apiError, ok := err.(sloapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return err
 	}
 
@@ -73,9 +69,6 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	listResponse, err := client.List(ctx)
 	if err != nil {
-		if apiError, ok := err.(sloapi.APIError); ok {
-			return nil, rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return nil, err
 	}
 	var stubs api.Stubs
@@ -105,9 +98,6 @@ func (me *service) Create(ctx context.Context, v *slo.SLO) (*api.Stub, error) {
 	}
 	response, err := client.Create(ctx, data)
 	if err != nil {
-		if apiError, ok := err.(sloapi.APIError); ok {
-			return nil, rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return nil, err
 	}
 
@@ -131,9 +121,6 @@ func (me *service) Update(ctx context.Context, id string, v *slo.SLO) (err error
 
 	_, err = client.Update(ctx, id, data)
 	if err != nil {
-		if apiError, ok := err.(sloapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return err
 	}
 
@@ -147,9 +134,6 @@ func (me *service) Delete(ctx context.Context, id string) error {
 	}
 	_, err = client.Delete(ctx, id)
 	if err != nil {
-		if apiError, ok := err.(sloapi.APIError); ok {
-			return rest.Error{Code: apiError.StatusCode, Message: apiError.Error()}
-		}
 		return err
 	}
 


### PR DESCRIPTION
#### **Why** this PR?
With changes introduced in #1027, the provider also correctly handles not-found errors represented as the core library's `APIError` type. Therefore, there is no advantage in transforming these errors into `rest.Error` errors. This change was done for direct shares in #1025 and in most places in automation resources in #1026. This PR handles the other resources that use core clients, and updates the list functions for thje automation resources.

#### **What** has changed and **how** does it do it?
The code transforming these errors is removed in:
- `dynatrace/api/documents/document/service.go`
- `dynatrace/api/grail/segments/service.go`
- `dynatrace/api/slo/service.go`

Furthermore, the list functions are updated in:
- `dynatrace/api/automation/workflows/service.go`
- `dynatrace/api/automation/scheduling_rules/service.go`
- `dynatrace/api/automation/business_calendars/service.go`


#### How is it **tested**?
Existing tests.

#### How does it affect **users**?
No effect.

**Issue:** NA
