### PR TITLE
fix: execution time of IAM resources

### DIFF
--- a/dynatrace/api/iam/groups/service.go
+++ b/dynatrace/api/iam/groups/service.go
@@ -156,83 +156,34 @@ type ListGroupsResponse struct {
 	Items []*ListGroup `json:"items"`
 }
 
-var cachedGroupStubs []*ListGroup
-var groupStubMutex sync.Mutex
-
 func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	groupStubMutex.Lock()
-	defer groupStubMutex.Unlock()
-
-	if cachedGroupStubs != nil {
-		var stubs api.Stubs
-		for _, elem := range cachedGroupStubs {
-			stubs = append(stubs, &api.Stub{ID: elem.UUID, Name: elem.Name})
-		}
-		return stubs, nil
-	}
-
-	groupStubs, err := me.listUnguarded(ctx)
-	if err != nil {
+	client := iam.NewIAMClient(me)
+	var groupStubs ListGroupsResponse
+	accountID := me.AccountID()
+	if err := iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups", me.endpointURL, accountID), 200, false, &groupStubs); err != nil {
 		return nil, err
 	}
+
 	var stubs api.Stubs
-	for _, elem := range groupStubs {
+	for _, elem := range groupStubs.Items {
 		stubs = append(stubs, &api.Stub{ID: elem.UUID, Name: elem.Name})
 	}
 	return stubs, nil
 }
 
-func (me *GroupServiceClient) list(ctx context.Context) ([]*ListGroup, error) {
-	groupStubMutex.Lock()
-	defer groupStubMutex.Unlock()
-
-	// if cachedGroupStubs != nil {
-	// 	return cachedGroupStubs, nil
-	// }
-	groupStubs, err := me.listUnguarded(ctx)
-	if err != nil {
-		return nil, err
-	}
-	cachedGroupStubs = groupStubs
-	return cachedGroupStubs, nil
-}
-
-func (me *GroupServiceClient) listUnguarded(ctx context.Context) ([]*ListGroup, error) {
-	var err error
-
-	client := iam.NewIAMClient(me)
-	var response ListGroupsResponse
-	accountID := me.AccountID()
-	if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups", me.endpointURL, accountID), 200, false, &response); err != nil {
-		return nil, err
-	}
-	return response.Items, nil
-}
-
 func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Group) (err error) {
-	stubs, err := me.list(ctx)
-	if err != nil {
+	var groupStub ListGroup
+	accountID := me.AccountID()
+	client := iam.NewIAMClient(me)
+	if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, accountID, id), 200, false, &groupStub); err != nil {
 		return err
 	}
-	for _, listStub := range stubs {
-		if listStub.UUID == id {
-			accountID := me.AccountID()
-			client := iam.NewIAMClient(me)
-			var groupStub ListGroup
-			if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, accountID, id), 200, false, &groupStub); err != nil {
-				return err
-			}
 
-			v.Name = listStub.Name
-			v.Description = listStub.Description
-			v.FederatedAttributeValues = listStub.FederatedAttributeValues
-			// ddd, _ := json.MarshalIndent(groupStub.Permissions, "", "  ")
-			// logging.File.Println(string(ddd))
-			v.Permissions = groupStub.Permissions
-			return nil
-		}
-	}
-	return rest.Error{Code: 404, Message: fmt.Sprintf("no group with id `%s` found", id)}
+	v.Name = groupStub.Name
+	v.Description = groupStub.Description
+	v.FederatedAttributeValues = groupStub.FederatedAttributeValues
+	v.Permissions = groupStub.Permissions
+	return nil
 }
 
 func (me *GroupServiceClient) Delete(ctx context.Context, id string) error {

--- a/dynatrace/api/iam/iam_client.go
+++ b/dynatrace/api/iam/iam_client.go
@@ -25,11 +25,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"slices"
-	"strconv"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
@@ -41,16 +37,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/auth"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
-
-type IAMError struct {
-	BError  bool   `json:"error"`
-	Payload string `json:"payload"`
-	Message string `json:"message"`
-}
-
-func (me IAMError) Error() string {
-	return me.Message
-}
 
 type IAMClient interface {
 	POST(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
@@ -114,65 +100,7 @@ func (me *iamClient) DELETE_MULTI_RESPONSE(ctx context.Context, url string, expe
 	return me.request(ctx, url, http.MethodDelete, expectedResponseCodes, forceNewBearer, 0, nil, nil)
 }
 
-type RateLimiter struct {
-	lastCall time.Time
-	mutex    sync.Mutex
-}
-
-func NewRateLimiter() *RateLimiter {
-	return &RateLimiter{}
-}
-
-var DISABLE_RATE_LIMITER = (os.Getenv("DYNATRACE_DISABLE_IAM_RATE_LIMITER") == "true")
-
-const MAX_RATE_LIMITER_RATE = int64(5000)
-const DEFAULT_RATE_LIMITER_RATE = int64(1000)
-
-var rateLimiterRate = evalRateLimiterRate()
-
-func evalRateLimiterRate() int64 {
-	sRateLimiterRate := strings.TrimSpace(os.Getenv("DYNATRACE_IAM_RATE_LIMITER_RATE"))
-	if len(sRateLimiterRate) == 0 {
-		return DEFAULT_RATE_LIMITER_RATE
-	}
-	var err error
-	iRateLimiterRate := DEFAULT_RATE_LIMITER_RATE
-
-	if iRateLimiterRate, err = strconv.ParseInt(sRateLimiterRate, 10, 0); err != nil {
-		return DEFAULT_RATE_LIMITER_RATE
-	}
-	if iRateLimiterRate > MAX_RATE_LIMITER_RATE {
-		return MAX_RATE_LIMITER_RATE
-	}
-	return iRateLimiterRate
-}
-
-func (rl *RateLimiter) CanCall() bool {
-	rl.mutex.Lock()
-	defer rl.mutex.Unlock()
-	if rateLimiterRate <= 0 || DISABLE_RATE_LIMITER {
-		return true
-	}
-	now := time.Now()
-	if now.Sub(rl.lastCall) >= time.Duration(rateLimiterRate)*time.Millisecond {
-		rl.lastCall = now
-		return true
-	}
-	return false
-}
-
-var limiter = NewRateLimiter()
-
-func (me *iamClient) request(ctx context.Context, url string, method string, expectedResponseCodes []int, forceNewBearer bool, forceNewBearerRetryCount int, payload any, headers map[string]string) ([]byte, error) {
-	for {
-		if limiter.CanCall() {
-			return me._request(ctx, url, method, expectedResponseCodes, forceNewBearer, forceNewBearerRetryCount, payload, headers)
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
-func (me *iamClient) _request(ctx context.Context, u string, method string, expectedResponseCodes []int, forceNewBearer bool, forceNewBearerRetryCount int, payload any, headers map[string]string) ([]byte, error) {
+func (me *iamClient) request(ctx context.Context, u string, method string, expectedResponseCodes []int, forceNewBearer bool, forceNewBearerRetryCount int, payload any, headers map[string]string) ([]byte, error) {
 	id := uuid.NewString()
 
 	var err error


### PR DESCRIPTION
#### **Why** this PR?
At the moment, having many IAM resources results in long load times.
For example, with 150 groups, `terraform plan` alone takes about 5 minutes.

#### **What** has changed?
- The rate limiter for IAM resources is removed
- Removed one not needed API call for groups during GET

This also removes two env variables, as they are no longer in use: `DYNATRACE_DISABLE_IAM_RATE_LIMITER`, `DYNATRACE_IAM_RATE_LIMITER_RATE`.

A `terraform plan` with 150 groups now takes less than 10 seconds instead of 5 minutes.

#### **How** does it do it?
By removing the implemented rate limit and solely depending on the concurrent limit set by Terraform and on our implemented retry behavior

#### How is it **tested**?
Existing tests should still work
Manual tests: A `terraform plan` with 150 groups now takes less than 10 seconds instead of 5 minutes.


#### How does it affect **users**?
They will notice a huge improvement in execution time.

**Issue:** CA-18688