### PR TITLE
fix(doc): Update linked documentation for `grail_security_context` re…

### DIFF
--- a/docs/resources/grail_security_context.md
+++ b/docs/resources/grail_security_context.md
@@ -12,7 +12,7 @@ description: |-
 
 ## Dynatrace Documentation
 
-- Security data on Grail - https://docs.dynatrace.com/docs/platform-modules/application-security/security-data-on-grail
+- Permissions in Grail - https://docs.dynatrace.com/docs/platform/grail/organize-data/assign-permissions-in-grail
 
 - Settings API - https://www.dynatrace.com/support/help/dynatrace-api/environment-api/settings (schemaId: `builtin:monitoredentities.grail.security.context`)
 

--- a/templates/resources/grail_security_context.md.tmpl
+++ b/templates/resources/grail_security_context.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 
 ## Dynatrace Documentation
 
-- Security data on Grail - https://docs.dynatrace.com/docs/platform-modules/application-security/security-data-on-grail
+- Permissions in Grail - https://docs.dynatrace.com/docs/platform/grail/organize-data/assign-permissions-in-grail
 
 - Settings API - https://www.dynatrace.com/support/help/dynatrace-api/environment-api/settings (schemaId: `builtin:monitoredentities.grail.security.context`)
 


### PR DESCRIPTION
#### **Why** this PR?

The previously linked documentation for the `grail_security_context` resource pointed to a page about "Security data on Grail" which is not the most relevant reference for this resource. The correct and more accurate documentation is the "Permissions in Grail" page.

#### **What** has changed?

Updated the Dynatrace Documentation link in both the template (`templates/resources/grail_security_context.md.tmpl`) and the generated doc (`docs/resources/grail_security_context.md`) for the `grail_security_context` resource:

- **Old:** `Security data on Grail` → `https://docs.dynatrace.com/docs/platform-modules/application-security/security-data-on-grail`
- **New:** `Permissions in Grail` → `https://docs.dynatrace.com/docs/platform/grail/organize-data/assign-permissions-in-grail`

#### **How** does it do it?

Directly updated the documentation link in the template file and regenerated the corresponding `docs/` output file.

#### How is it **tested**?

Documentation-only change — no functional code was modified.

#### How does it affect **users**?

Users following the documentation link from the Terraform Registry will now land on the correct "Permissions in Grail" page instead of the unrelated "Security data on Grail" page.
