### PR TITLE
fix: OpenPipeline resources incorrectly added an empty item

### DIFF
--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineBizeventsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/service_unit_test.go
@@ -32,24 +32,28 @@ func TestOpenPipelineBizeventsPipelinesUnmarshal(t *testing.T) {
 	entries := new(pipelines.FieldExtractionEntries)
 	validEntries := []*pipelines.FieldExtractionEntry{
 		{
-			DefaultValue: testing2.ToPointer("value"),
+			DefaultValue:   testing2.ToPointer("value"),
+			ExtractionType: "field",
 		},
 		{
 			DestinationFieldName: testing2.ToPointer("value"),
+			ExtractionType:       "field",
 		},
 		{
 			SourceFieldName: testing2.ToPointer("value"),
+			ExtractionType:  "field",
 		},
 		{
 			DefaultValue:         testing2.ToPointer("value1"),
 			DestinationFieldName: testing2.ToPointer("value2"),
 			SourceFieldName:      testing2.ToPointer("value3"),
+			ExtractionType:       "field",
 		},
 		{
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineDavisEventsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineDavisEventsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineDavisProblemsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineDavisProblemsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineEventsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineEventsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineEventsSdlcIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineEventsSdlcPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineEventsSecurityIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineEventsSecurityPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineLogsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineLogsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/logs/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineMetricsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineMetricsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineSecurityEventsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineSecurityEventsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineSpansIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineSpansPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/spans/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineSystemEventsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineSystemEventsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineUserEventsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"field_extraction_entry": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineUserEventsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineUsersessionsIngestSourcesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := ingestsources.FieldExtractionEntries{{}}
+	validWithEmpty := ingestsources.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/ingestsources/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service_unit_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/service_unit_test.go
@@ -49,7 +49,7 @@ func TestOpenPipelineUsersessionsPipelinesUnmarshal(t *testing.T) {
 			ExtractionType: "field",
 		},
 	}
-	validWithEmpty := pipelines.FieldExtractionEntries{{}}
+	validWithEmpty := pipelines.FieldExtractionEntries{{ExtractionType: "field", SourceFieldName: testing2.ToPointer("")}, {}}
 	validWithEmpty = append(validWithEmpty, validEntries...)
 	err := entries.UnmarshalHCL(testing2.MockDecoder{Elements: map[string]any{"dimension": validWithEmpty}})
 	require.NoError(t, err)

--- a/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction_entry.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/pipelines/settings/field_extraction_entry.go
@@ -49,14 +49,7 @@ func (me *FieldExtractionEntries) UnmarshalHCL(decoder hcl.Decoder) error {
 	}
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 	// Only known workaround is to ignore these blocks
-	newEntries := FieldExtractionEntries{}
-	var emptyItem FieldExtractionEntry
-	for _, entry := range *me {
-		if *entry != emptyItem {
-			newEntries = append(newEntries, entry)
-		}
-	}
-	*me = newEntries
+	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"})
 	return nil
 }
 

--- a/terraform/hcl/filter.go
+++ b/terraform/hcl/filter.go
@@ -1,0 +1,58 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hcl
+
+import "reflect"
+
+// FilterEmpty removes entries from a slice that match the provided default value and also the zero value of the provided struct.
+// This is a generic workaround for https://github.com/hashicorp/terraform-plugin-sdk/issues/895
+// which creates phantom empty entries in TypeSet blocks during updates.
+// There may occur two different types of empty set items.
+// 1. A zero value (e.g. FieldExtractionEntry)
+// 2. A default value with all default fields set (e.g. FieldExtractionEntry{ExtractionType: "field"}) including values set by `HandlePreconditions`
+//
+// Usage example:
+//
+//	*me = hcl.FilterEmpty(*me, FieldExtractionEntry{ExtractionType: "field"}) // contains "Default: ..." values
+func FilterEmpty[T any](entries []*T, defaultValue T) []*T {
+	result := make([]*T, 0, len(entries))
+	var zeroValue T
+	defaultValues := []T{zeroValue}
+	pointVal := &defaultValue
+
+	if v, ok := any(pointVal).(Preconditioner); ok {
+		// if the value with the defaults is in the state file, it also went through `HandlePreconditions`
+		_ = v.HandlePreconditions()
+		defaultValues = append(defaultValues, *pointVal)
+	} else {
+		defaultValues = append(defaultValues, defaultValue)
+	}
+
+	for _, entry := range entries {
+		isEmpty := false
+		for _, possibleDefault := range defaultValues {
+			if reflect.DeepEqual(*entry, possibleDefault) {
+				isEmpty = true
+				break
+			}
+		}
+		if !isEmpty {
+			result = append(result, entry)
+		}
+	}
+	return result
+}

--- a/terraform/hcl/filter_test.go
+++ b/terraform/hcl/filter_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /*
  * @license
  * Copyright 2026 Dynatrace LLC

--- a/terraform/hcl/filter_test.go
+++ b/terraform/hcl/filter_test.go
@@ -1,0 +1,162 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hcl_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/stretchr/testify/assert"
+)
+
+// simpleEntry is a plain struct with no Preconditioner implementation.
+type simpleEntry struct {
+	Name  string
+	Value int
+}
+
+// preconditionEntry implements Preconditioner and sets a default field on HandlePreconditions.
+type preconditionEntry struct {
+	Name  string
+	Value int
+}
+
+func (p *preconditionEntry) HandlePreconditions() error {
+	if p.Name == "" {
+		p.Name = "default-name"
+	}
+	return nil
+}
+
+// preconditionErrorEntry implements Preconditioner and sets a default field on HandlePreconditions and always returns an error
+type preconditionErrorEntry struct {
+	Name  string
+	Value int
+}
+
+func (p *preconditionErrorEntry) HandlePreconditions() error {
+	if p.Name == "" {
+		p.Name = "default-name"
+	}
+	return assert.AnError
+}
+
+func TestFilterEmpty_RemovesDefaultValue(t *testing.T) {
+	defaultVal := simpleEntry{Name: "phantom", Value: 0}
+	entries := []*simpleEntry{
+		{Name: "phantom", Value: 0},
+		{Name: "real", Value: 42},
+	}
+
+	result := hcl.FilterEmpty(entries, defaultVal)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "real", result[0].Name)
+}
+
+func TestFilterEmpty_RemovesZeroValue(t *testing.T) {
+	defaultVal := simpleEntry{Name: "phantom"}
+	entries := []*simpleEntry{
+		{}, // zero value — should be removed
+		{Name: "real", Value: 1},
+	}
+
+	result := hcl.FilterEmpty(entries, defaultVal)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "real", result[0].Name)
+}
+
+func TestFilterEmpty_KeepsAllWhenNoneMatchDefault(t *testing.T) {
+	defaultVal := simpleEntry{Name: "phantom"}
+	entries := []*simpleEntry{
+		{Name: "a", Value: 1},
+		{Name: "b", Value: 2},
+	}
+
+	result := hcl.FilterEmpty(entries, defaultVal)
+
+	assert.Len(t, result, 2)
+}
+
+func TestFilterEmpty_RemovesAllWhenAllMatchDefault(t *testing.T) {
+	defaultVal := simpleEntry{Name: "phantom"}
+	entries := []*simpleEntry{
+		{Name: "phantom"},
+		{},
+	}
+
+	result := hcl.FilterEmpty(entries, defaultVal)
+
+	assert.Empty(t, result)
+}
+
+func TestFilterEmpty_WithPreconditioner_RemovesPostPreconditionDefault(t *testing.T) {
+	// defaultValue has empty Name; after HandlePreconditions Name becomes "default-name"
+	defaultVal := preconditionEntry{Name: "", Value: 0}
+
+	entries := []*preconditionEntry{
+		{Name: "default-name", Value: 0}, // matches post-precondition default → removed
+		{Name: "custom", Value: 5},       // kept
+	}
+
+	result := hcl.FilterEmpty(entries, defaultVal)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "custom", result[0].Name)
+}
+
+func TestFilterEmpty_WithPreconditioner_RemovesZeroValue(t *testing.T) {
+	defaultVal := preconditionEntry{Name: "", Value: 0}
+
+	entries := []*preconditionEntry{
+		{},                        // zero value → removed
+		{Name: "real", Value: 99}, // kept
+	}
+
+	result := hcl.FilterEmpty(entries, defaultVal)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "real", result[0].Name)
+}
+
+func TestFilterEmpty_WithPreconditioner_KeepsNonDefaultEntries(t *testing.T) {
+	defaultVal := preconditionEntry{Name: "", Value: 0}
+
+	entries := []*preconditionEntry{
+		{Name: "alpha", Value: 1},
+		{Name: "beta", Value: 2},
+	}
+
+	result := hcl.FilterEmpty(entries, defaultVal)
+
+	assert.Len(t, result, 2)
+}
+
+func TestFilterEmpty_IgnoresErrors(t *testing.T) {
+	defaultVal := preconditionErrorEntry{Name: "", Value: 0}
+
+	entries := []*preconditionErrorEntry{
+		{},                        // zero value → removed
+		{Name: "real", Value: 99}, // kept
+	}
+
+	result := hcl.FilterEmpty(entries, defaultVal)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "real", result[0].Name)
+}


### PR DESCRIPTION
#### **Why** this PR?
Seems like https://github.com/hashicorp/terraform-plugin-sdk/issues/895, https://github.com/hashicorp/terraform-plugin-sdk/issues/652 got a level up.
For our OpenPipeline resources, starting with v1.91.0, which introduced new fields and a default value, not only are zero items incorrectly added to `TypeSet` arrays, but also empty items when set defaults are applied. Having a default like `field` for `extraction_type` would result in an extra empty item containing `field` instead of an empty string.
Manual execution confirmed that the state has different "phantom" items.

#### **What** has changed?
Modifying the affected items like `metric_extration -> counter_metric -> dimensions -> dimension` now also correctly removes the additional "phantom" item.
Now the API doesn't break anymore because it gets empty values.

#### **How** does it do it?
By generically removing empty-default and zero values from Sets.

#### How is it **tested**?
That's the funny part: the Terraform testing utilities have a bug too.
If a resource is created and in the next step we want to add and remove items of the Set, the testing lib will result in an error that the plan after update is non-empty, BUT setting `ExpectNonEmptyPlan: true` will also fail, because here it suddenly tells `Expected non-empty plan but got empty`. Manual execution of terraform apply and plan is working without a problem.
The generic empty-set-item removal is unit tested, though.

Create and update set items
<img width="1374" height="948" alt="image" src="https://github.com/user-attachments/assets/2df01456-4777-43e0-af2b-1de4019b8139" />

Even with ExpectNonEmptyPlan:
<img width="1260" height="853" alt="image" src="https://github.com/user-attachments/assets/9e605e56-d0d9-44a2-8160-47348b3bfdb8" />


#### How does it affect **users**?
They won't get any errors from the API anymore, rejecting empty items that weren't actually added by the user.
They'll still get an incorrect Terraform plan showing added items.

## Open for discussion
~~We can also decide to deviate from the API (schema) specs and use TypeList instead of TypeSet. With this change, we would not have any issues with "phantom" items, as this only occurs in TypeSet.~~

~~Pros:~~
- ~~No workarounds needed (empty item removal)~~
- ~~Minimal effort~~
- ~~Less maintenance (aligning the empty-default item with the schema defaults)~~
- ~~TypeList has the benefit, if an item gets updated, it won't show it as deleted and new one added but only the changed property (unless there are order changes done)~~

~~Cons:~~
- ~~Consumers will see a non-empty plan, even if nothing changed, because the unsorted Set is then a sorted list. Still, we should validate the behavior if there is actually a non-empty plan.
  This should not cause any issues with the API, as the array order doesn't seem to change on GET calls.~~
- ~~Re-ordering of items is detected as a change and would show a change for all (existing) items after the inserted one~~
- ~~If the API doesn't return them ordered we have a problem (always non-empty plan). This is something that we need to double check.~~

If the API specifies `Set`, the order is inconsistent. Therefore, keeping the TypeSet, as the order can't be guaranteed.

**Issue:** CA-18766