### PR TITLE
fix(dynatrace_automation_workflow): ignore computed task positions from API responses

### DIFF
--- a/dynatrace/api/automation/workflows/service.go
+++ b/dynatrace/api/automation/workflows/service.go
@@ -57,7 +57,33 @@ func (me *service) Get(ctx context.Context, id string, v *workflows.Workflow) er
 		return err
 	}
 
-	return json.Unmarshal(response.Data, &v)
+	if err := json.Unmarshal(response.Data, &v); err != nil {
+		return err
+	}
+	deComputeTaskPosition(ctx, v)
+
+	return nil
+}
+
+// deComputeTaskPosition removes API set defaults of task positions.
+// The reason here is simply because the TypeSet hash changes every time if a field of an item is set to computed even if nothing changed.
+// If the position is set by the user in the Terraform file, then it's correctly compared to the API set one.
+// DiffSuppress can't help here because even if the task doesn't change, the bug of TypeSet happens, which adds a new empty item which leads to a non-empty plan
+func deComputeTaskPosition(ctx context.Context, v *workflows.Workflow) {
+	positionTaskNames := map[string]bool{}
+	if stateConfig, ok := ctx.Value(settings.ContextKeyStateConfig).(*workflows.Workflow); ok {
+		for _, st := range stateConfig.Tasks {
+			if st.Position != nil {
+				positionTaskNames[st.Name] = true
+			}
+		}
+	}
+	for _, task := range v.Tasks {
+		if !positionTaskNames[task.Name] {
+			// => if not in state: set position (returned from API) to nil
+			task.Position = nil
+		}
+	}
 }
 
 func (me *service) SchemaID() string {

--- a/dynatrace/api/automation/workflows/settings/task.go
+++ b/dynatrace/api/automation/workflows/settings/task.go
@@ -153,8 +153,10 @@ func (me *Task) Schema(prefix string) map[string]*schema.Schema {
 			Description: "Layouting information about the task tile when visualized. If not specified Dynatrace will position the task tiles automatically",
 			MinItems:    1,
 			MaxItems:    1,
-			Optional:    true,
-			Elem:        &schema.Resource{Schema: new(TaskPosition).Schema(prefix + ".0.position")},
+			// Note: It's computed but don't set it to computed
+			// Look at ../service.go `deComputeTaskPosition` for the reason.
+			Optional: true,
+			Elem:     &schema.Resource{Schema: new(TaskPosition).Schema(prefix + ".0.position")},
 		},
 		"conditions": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-g.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-g.tf
@@ -1,0 +1,18 @@
+resource "dynatrace_automation_workflow" "task_without_position" {
+  description            = ""
+  type                   = "STANDARD"
+  hourly_execution_limit = 1000
+  owner_type             = "USER"
+  private                = false
+  title                  = "#name#"
+  tasks {
+    task {
+      name        = "http_request_1"
+      description = "Issue an HTTP request to any API change"
+      action      = "dynatrace.automations:http-function"
+      active      = true
+    }
+  }
+  trigger {
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
The position of a task is optional and the API returns a position. Therefore, the field is actually computed.
Applying a config without a position for a task, leads to a non-empty plan afterwards.

#### **What** has changed?
The position from the API is now ignored if it's not set in the state.

#### **How** does it do it?
After unmarshalling workflows in Get, it removes task positions that the API supplies by default, but the user didn't set in the state. This avoids TypeSet hash churn and spurious Terraform plan differences by preserving positions only when present in the state.

The reason here is simply that the TypeSet hash changes every time if a field of an item is set to computed, even if nothing has changed (current state with `position {x=...y = ..}`. => `known after apply`).
If the position is set by the user in the Terraform file, then it's correctly compared to the API set one.
DiffSuppress can't help here because even if the task doesn't change, the bug of TypeSet happens, which adds a new empty item, which leads to a non-empty plan.

#### How is it **tested**?
Nest test added that has a task without positions set. Applying this one should not lead to a non-empty plan anymore.

#### How does it affect **users**?
A task without `position` won't lead to a non-empty plan anymore.

### Limitation:
Minor: If the user updates a task and adds the position field with the actual values set by the API, this will lead to an update instead of an empty plan.

**Issue:** CA-19023