### PR TITLE
fix: cache IAM and Platform REST clients to prevent OAuth 429

### DIFF
--- a/dynatrace/api/iam/iam_client.go
+++ b/dynatrace/api/iam/iam_client.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
@@ -52,7 +53,19 @@ type iamClient struct {
 	client *rest2.Client
 }
 
+// cachedRestClients caches clients for OAuth requests
+// The point of it is that there aren't x requests to get an access tokens as this could run into 429
+var cachedRestClients = map[string]*rest2.Client{}
+var clientMutex sync.Mutex
+
 func NewIAMClient(a Authenticator) IAMClient {
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
+
+	if client, exists := cachedRestClients[a.EndpointURL()]; exists {
+		return &iamClient{a, client}
+	}
+
 	oauthConfig := clientcredentials.Config{
 		ClientID:     a.ClientID(),
 		ClientSecret: a.ClientSecret(),
@@ -73,6 +86,7 @@ func NewIAMClient(a Authenticator) IAMClient {
 	}
 	eUrl, _ := url.Parse(a.EndpointURL())
 	client := rest2.NewClient(eUrl, httpClient, opts...)
+	cachedRestClients[a.EndpointURL()] = client
 	return &iamClient{a, client}
 }
 

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
@@ -38,6 +39,11 @@ var eligiblePlatformRequests = map[string]string{
 	"/api/v2/settings/objects": "/platform/classic/environment-api/v2/settings/objects",
 	"/api/v2/settings/schemas": "/platform/classic/environment-api/v2/settings/schemas",
 }
+
+// cachedPlatformClients caches clients for OAuth requests
+// The point of it is that there aren't x requests to get an access tokens as this could run into 429
+var cachedPlatformClients = map[string]*rest.Client{}
+var clientMutex sync.Mutex
 
 type platform_request request
 
@@ -84,15 +90,22 @@ func CreatePlatformTokenClient(u string, credentials *Credentials) (*rest.Client
 	return configureCommonRestClient(rest.NewClient(parsedURL, NewBearerTokenBasedClient(credentials.OAuth.PlatformToken), opts...))
 }
 
-func CreatePlatformClient(ctx context.Context, platformURL string, credentials *Credentials) (*rest.Client, error) {
+func CreatePlatformClient(_ context.Context, platformURL string, credentials *Credentials) (*rest.Client, error) {
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
 	PreRequest()
 
+	if platformClient, ok := cachedPlatformClients[platformURL]; ok {
+		return platformClient, nil
+	}
 	var client *rest.Client
 	var err error
 	if credentials.ContainsPlatformToken() {
 		client, err = CreatePlatformTokenClient(platformURL, credentials)
 	} else if credentials.ContainsOAuth() {
-		client, err = CreatePlatformOAuthClient(ctx, platformURL, credentials)
+		// This must be a new context
+		// If it's the same, one context of a resource will cancel the one of the next one because of the internal cleanup
+		client, err = CreatePlatformOAuthClient(context.Background(), platformURL, credentials)
 	} else {
 		return nil, NoPlatformCredentialsErr
 	}
@@ -100,6 +113,7 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 		return nil, err
 	}
 
+	cachedPlatformClients[platformURL] = client
 	return client, err
 }
 


### PR DESCRIPTION
#### **Why** this PR?
There may be 429 for every request to platform, which could break the whole Terraform plan/apply

#### **What** has changed?
Should not run into 429 errors anymore, as this changes from O(n) to 1 (within 5 minutes; token duration).

#### **How** does it do it?
Introduce caching for OAuth/rest clients to avoid repeated token requests and potential 429s.

#### How is it **tested**?
Tests should still work

#### How does it affect **users**?
Less OAuth requests and less likely to run into 429

**Issue:** CA-18762