### PR TITLE
feat: add retry mechanism for OAuth 429

### DIFF
--- a/dynatrace/api/iam/iam_client.go
+++ b/dynatrace/api/iam/iam_client.go
@@ -58,7 +58,7 @@ func NewIAMClient(a Authenticator) IAMClient {
 		ClientSecret: a.ClientSecret(),
 		TokenURL:     a.TokenURL(),
 	}
-	httpClient := auth.NewOAuthClient(context.Background(), &oauthConfig)
+	httpClient := auth.NewOAuthClient(rest.NewContextWithOAuthRetryClient(context.Background()), &oauthConfig)
 
 	opts := []rest2.Option{
 		rest2.WithHTTPListener(logging.HTTPListener("iam")),

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -92,7 +92,7 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 	if credentials.ContainsPlatformToken() {
 		client, err = CreatePlatformTokenClient(platformURL, credentials)
 	} else if credentials.ContainsOAuth() {
-		client, err = CreatePlatformOAuthClient(ctx, platformURL, credentials)
+		client, err = CreatePlatformOAuthClient(NewContextWithOAuthRetryClient(ctx), platformURL, credentials)
 	} else {
 		return nil, NoPlatformCredentialsErr
 	}

--- a/dynatrace/rest/retry_transport.go
+++ b/dynatrace/rest/retry_transport.go
@@ -1,0 +1,193 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
+	"golang.org/x/oauth2"
+)
+
+const (
+	defaultMaxRetries  = 5
+	defaultBaseBackoff = 5 * time.Second
+	defaultMaxBackoff  = 60 * time.Second
+)
+
+// RetryTransport is an http.RoundTripper that automatically retries requests
+// when the server returns HTTP 429 (Too Many Requests) or HTTP 503 (Service Unavailable).
+// MaxRetries, BaseBackoff, and MaxBackoff can be set to non-zero values to override the
+// defaults, which is useful in tests to keep execution time short.
+type RetryTransport struct {
+	Transport   http.RoundTripper
+	MaxRetries  int
+	BaseBackoff time.Duration
+	MaxBackoff  time.Duration
+}
+
+// transport returns the configured RoundTripper, falling back to http.DefaultTransport when nil.
+func (t *RetryTransport) transport() http.RoundTripper {
+	if t.Transport != nil {
+		return t.Transport
+	}
+	return http.DefaultTransport
+}
+
+func (t *RetryTransport) maxRetries() int {
+	if t.MaxRetries > 0 {
+		return t.MaxRetries
+	}
+	return defaultMaxRetries
+}
+
+func (t *RetryTransport) baseBackoff() time.Duration {
+	if t.BaseBackoff > 0 {
+		return t.BaseBackoff
+	}
+	return defaultBaseBackoff
+}
+
+func (t *RetryTransport) maxBackoff() time.Duration {
+	if t.MaxBackoff > 0 {
+		return t.MaxBackoff
+	}
+	return defaultMaxBackoff
+}
+
+func isRetriableStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable
+}
+
+// bufferRequestBody reads and closes req.Body, returning its contents.
+// Returns nil, nil when the body is absent.
+func bufferRequestBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(req.Body)
+	if closeErr := req.Body.Close(); err == nil {
+		err = closeErr
+	}
+	return body, err
+}
+
+// drainAndClose drains body into /dev/null and closes it, allowing TCP
+// connection reuse. The drain error takes precedence over the close error.
+func drainAndClose(body io.ReadCloser) error {
+	_, copyErr := io.Copy(io.Discard, body)
+	closeErr := body.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Buffer the request body so it can be replayed on retries.
+	bodyBytes, err := bufferRequestBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	maxRetries := t.maxRetries()
+
+	for attempt := 0; ; attempt++ {
+		// Clone the request and restore the body for each attempt.
+		clone := req.Clone(req.Context())
+		if bodyBytes != nil {
+			clone.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		resp, err := t.transport().RoundTrip(clone)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isRetriableStatus(resp.StatusCode) || attempt >= maxRetries {
+			return resp, nil
+		}
+
+		ctx := clone.Context()
+		wait := t.sleepDuration(resp, attempt)
+		logging.Logger.Printf(ctx, "[RetryTransport] Received HTTP %d, retrying in %s (attempt %d/%d)", resp.StatusCode, wait, attempt+1, maxRetries)
+		if err := drainAndClose(resp.Body); err != nil {
+			return nil, err
+		}
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// getRetryAfterHeaderAsSleepTime parses the Retry-After response header and returns the
+// indicated wait duration. Returns 0 if the header is absent,
+// cannot be parsed, or indicates a non-positive delay.
+func getRetryAfterHeaderAsSleepTime(resp *http.Response) time.Duration {
+	ra := resp.Header.Get("Retry-After")
+	if ra == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(ra); err == nil && seconds > 0 {
+		d := time.Duration(seconds) * time.Second
+		return d
+	}
+	if t, err := http.ParseTime(ra); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// computeBackoffSleepTime returns the exponential back-off duration for the given attempt
+// using a 1.5× multiplier (base × 1.5^attempt), with up to 10%
+// random jitter to avoid thundering-herd problems.
+func computeBackoffSleepTime(base time.Duration, attempt int) time.Duration {
+	// random number between 1.0 and 1.1 to add up to 10% jitter
+	scale := 1 + 0.1*rand.Float64()
+	return time.Duration(float64(base) * scale * math.Pow(1.5, float64(attempt)))
+}
+
+// sleepDuration determines how long to wait before the next retry attempt.
+// It honours the Retry-After response header when present (capped at maxBackoff);
+// otherwise it falls back to exponential back-off with jitter.
+func (t *RetryTransport) sleepDuration(resp *http.Response, attempt int) time.Duration {
+	d := getRetryAfterHeaderAsSleepTime(resp)
+	if d <= 0 {
+		d = computeBackoffSleepTime(t.baseBackoff(), attempt)
+	}
+	if maxWait := t.maxBackoff(); d > maxWait {
+		return maxWait
+	}
+	return d
+}
+
+func NewContextWithOAuthRetryClient(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: &RetryTransport{},
+	})
+}

--- a/dynatrace/rest/retry_transport_test.go
+++ b/dynatrace/rest/retry_transport_test.go
@@ -1,0 +1,514 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// rtFunc lets an ordinary function act as an http.RoundTripper.
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// emptyResponse returns a minimal *http.Response with the given status and optional headers.
+func emptyResponse(status int, headers map[string]string) *http.Response {
+	h := make(http.Header)
+	for k, v := range headers {
+		h.Set(k, v)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+	}
+}
+
+// TestRetryTransport_SuccessOnFirstAttempt verifies that a successful response is
+// returned immediately without any retry.
+func TestRetryTransport_SuccessOnFirstAttempt(t *testing.T) {
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, calls)
+}
+
+// TestRetryTransport_NonRetriableStatusCodes verifies that every status code other
+// than 429 and 503 is returned on the very first attempt.
+func TestRetryTransport_NonRetriableStatusCodes(t *testing.T) {
+	nonRetryStatusCodes := []int{
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusNoContent,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	}
+	for _, status := range nonRetryStatusCodes {
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			calls := 0
+			tr := &rest.RetryTransport{
+				Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+					calls++
+					return emptyResponse(status, nil), nil
+				}),
+			}
+
+			req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+			resp, err := tr.RoundTrip(req)
+
+			require.NoError(t, err)
+			assert.Equal(t, status, resp.StatusCode)
+			assert.Equal(t, 1, calls, "expected exactly 1 call for non-retriable status %d", status)
+		})
+	}
+}
+
+// TestRetryTransport_TransportError verifies that an error from the underlying
+// transport is propagated immediately without retrying.
+func TestRetryTransport_TransportError(t *testing.T) {
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			return nil, assert.AnError
+		}),
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// TestRetryTransport_NilBody verifies that requests without a body are handled correctly.
+func TestRetryTransport_NilBody(t *testing.T) {
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestRetryTransport_BodyReadError verifies that an error while buffering the request
+// body is returned immediately without calling the underlying transport.
+func TestRetryTransport_BodyReadError(t *testing.T) {
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			t.Fatal("transport should not be called when the body cannot be read")
+			return nil, nil
+		}),
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, "https://dynatrace.com", &failReader{err: assert.AnError})
+	resp, err := tr.RoundTrip(req)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// TestRetryTransport_BodyReplayed verifies that the request body is replayed in full
+// on every retry attempt so that the upstream server always receives the same payload.
+func TestRetryTransport_BodyReplayed(t *testing.T) {
+	const payload = "hello-retry"
+	var receivedBodies []string
+
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Body != nil {
+				data, _ := io.ReadAll(req.Body)
+				receivedBodies = append(receivedBodies, string(data))
+			}
+			if len(receivedBodies) < 2 {
+				return emptyResponse(http.StatusTooManyRequests, nil), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: 10 * time.Millisecond,
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, "https://dynatrace.com", bytes.NewBufferString(payload))
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, receivedBodies, 2, "body must be delivered on every attempt")
+	assert.Equal(t, payload, receivedBodies[0])
+	assert.Equal(t, payload, receivedBodies[1])
+}
+
+// TestRetryTransport_RetriesOn429_EventualSuccess verifies that a 429 response triggers
+// a retry and that the eventual non-429 response is returned to the caller.
+// Uses Retry-After: 1 – test duration ~2 seconds.
+func TestRetryTransport_RetriesOn429_EventualSuccess(t *testing.T) {
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls < 3 {
+				return emptyResponse(http.StatusTooManyRequests, nil), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: 10 * time.Millisecond,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, calls)
+}
+
+// TestRetryTransport_RetriesOn503_EventualSuccess verifies that a 503 response triggers
+// a retry and that the eventual non-503 response is returned to the caller.
+// Uses Retry-After: 1 – test duration ~2 seconds.
+func TestRetryTransport_RetriesOn503_EventualSuccess(t *testing.T) {
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls < 3 {
+				return emptyResponse(http.StatusServiceUnavailable, nil), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: 10 * time.Millisecond,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, calls)
+}
+
+// TestRetryTransport_RetryAfterSeconds verifies that an integer Retry-After header value
+// is honored as a wait in seconds.
+// Test duration ~1 second.
+func TestRetryTransport_RetryAfterSeconds(t *testing.T) {
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": "1"}), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+	assert.GreaterOrEqual(t, elapsed, time.Second, "should have waited at least 1 s per Retry-After header")
+}
+
+// TestRetryTransport_RetryAfterHTTPDate verifies that an HTTP-date Retry-After header
+// value is parsed and honoured as a wait duration.
+// Test duration ~2 seconds.
+func TestRetryTransport_RetryAfterHTTPDate(t *testing.T) {
+	retryAfterDate := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
+
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": retryAfterDate}), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+	assert.GreaterOrEqual(t, elapsed, time.Second, "should have waited for the Retry-After date")
+}
+
+// TestRetryTransport_ExponentialBackoff verifies that when no Retry-After header is
+// present the transport falls back to exponential backoff (base × 1.5^attempt).
+func TestRetryTransport_ExponentialBackoff(t *testing.T) {
+	const base = 100 * time.Millisecond
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				// No Retry-After header → exponential backoff applies.
+				return emptyResponse(http.StatusTooManyRequests, nil), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: base,
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+	// base × 1.5^0 = base for the first retry.
+	assert.GreaterOrEqual(t, elapsed, base, "expected exponential backoff of at least %s", base)
+}
+
+// TestRetryTransport_MaxRetriesExhausted verifies that the transport stops after
+// MaxRetries attempts and returns the final retriable response to the caller.
+// Uses Retry-After: 1 – test duration ~10 seconds (10 retries × 1 s each).
+func TestRetryTransport_MaxRetriesExhausted(t *testing.T) {
+	const maxRetries = 3
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			return emptyResponse(http.StatusTooManyRequests, nil), nil
+		}),
+		MaxRetries:  maxRetries,
+		BaseBackoff: 10 * time.Millisecond,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	// MaxRetries = 3, so the loop runs for attempts 0..3 → 4 total calls.
+	assert.Equal(t, maxRetries+1, calls, "expected MaxRetries+1 = %d total attempts", maxRetries+1)
+}
+
+// NewContextWithOAuthRetryClient verifies that the context is enriched with an
+// HTTP client whose transport is a *RetryTransport.
+func TestNewContextWithOAuthRetryClient(t *testing.T) {
+	ctx := rest.NewContextWithOAuthRetryClient(t.Context())
+
+	client, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+	require.True(t, ok, "context should contain an *http.Client")
+	_, isRetry := client.Transport.(*rest.RetryTransport)
+	assert.True(t, isRetry, "the client's transport should be a *RetryTransport")
+}
+
+// TestRetryTransport_RetryAfterZero verifies that a Retry-After value of 0 is treated as
+// invalid and the transport falls back to exponential back-off instead.
+func TestRetryTransport_RetryAfterZero_FallsBackToBackoff(t *testing.T) {
+	const base = 30 * time.Millisecond
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": "0"}), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: base,
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+	assert.GreaterOrEqual(t, elapsed, base, "Retry-After: 0 should fall back to exponential backoff")
+}
+
+// TestRetryTransport_RetryAfterNegative verifies that a negative Retry-After value is
+// treated as invalid and the transport falls back to exponential back-off instead.
+func TestRetryTransport_RetryAfterNegative_FallsBackToBackoff(t *testing.T) {
+	const base = 30 * time.Millisecond
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": "-5"}), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: base,
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+	assert.GreaterOrEqual(t, elapsed, base, "negative Retry-After should fall back to exponential backoff")
+}
+
+// TestRetryTransport_RetryAfterPastDate verifies that a Retry-After HTTP-date in the past
+// is treated as invalid and the transport falls back to exponential back-off instead.
+func TestRetryTransport_RetryAfterPastDate_FallsBackToBackoff(t *testing.T) {
+	const base = 30 * time.Millisecond
+	pastDate := time.Now().Add(-10 * time.Second).UTC().Format(http.TimeFormat)
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": pastDate}), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: base,
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+	assert.GreaterOrEqual(t, elapsed, base, "past Retry-After date should fall back to exponential backoff")
+}
+
+// TestRetryTransport_RetryAfterCapped verifies that an excessively large Retry-After value
+// is capped at MaxBackoff rather than waited in full.
+func TestRetryTransport_RetryAfterCapped(t *testing.T) {
+	const cap = 50 * time.Millisecond
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": "99999"}), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		MaxBackoff: cap,
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+	assert.Less(t, elapsed, time.Second, "Retry-After of 99999 s should have been capped")
+	assert.GreaterOrEqual(t, elapsed, cap, "should have waited at least MaxBackoff")
+}
+
+// TestRetryTransport_BackoffCapped verifies that the exponential back-off is capped at
+// MaxBackoff when the computed value would otherwise exceed it.
+func TestRetryTransport_BackoffCapped(t *testing.T) {
+	const cap = 50 * time.Millisecond
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			return emptyResponse(http.StatusTooManyRequests, nil), nil
+		}),
+		MaxRetries:  3,
+		BaseBackoff: cap * 10, // base far exceeds cap → every wait should be capped
+		MaxBackoff:  cap,
+	}
+
+	start := time.Now()
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, 4, calls) // MaxRetries+1
+	// 3 waits each capped at ~55 ms (cap + ≤10 % jitter) → well under 1 s.
+	assert.Less(t, elapsed, time.Second, "backoff should have been capped at MaxBackoff")
+}
+
+// TestRetryTransport_ContextCancelled verifies that a context cancellation during the
+// retry wait is honoured immediately and the error is propagated to the caller.
+func TestRetryTransport_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			// Cancel the context so the upcoming retry wait fires the Done branch.
+			cancel()
+			return emptyResponse(http.StatusTooManyRequests, nil), nil
+		}),
+		BaseBackoff: time.Hour, // large enough that only context cancellation can unblock
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls, "should not retry after context is cancelled")
+}
+
+// failReader is an io.Reader that always returns an error.
+type failReader struct{ err error }
+
+func (f *failReader) Read(_ []byte) (int, error) { return 0, f.err }


### PR DESCRIPTION
#### **Why** this PR?
There may be 429 for every request to platform, which could break the whole Terraform plan/apply

#### **What** has changed?
429 returned by OAuth token requests are now retried

#### **How** does it do it?
This adds special handling for OAuth requests in case of 429. It now retries based on the set retry headers with a fallback to an exponential backoff with a maximum retry amount of 10

#### How is it **tested**?
Tests added and integration tests are still working

#### How does it affect **users**?
Less OAuth requests and less likely to run into 429

## Notes
V2 of https://github.com/dynatrace-oss/terraform-provider-dynatrace/pull/1041
Still, this one (with retry) doesn't solve the cause (too many not needed requests) and could lead to increasing execution times by a factor more than 10 compared to the cache.

**Issue:** CA-18762