### PR TITLE
fix(dynatrace_automation_workflow): Fields could not be set to empty

### DIFF
--- a/dynatrace/api/automation/workflows/service_test.go
+++ b/dynatrace/api/automation/workflows/service_test.go
@@ -23,8 +23,35 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestAccWorkflows(t *testing.T) {
 	api.TestAcc(t)
+}
+
+// TestAccWorkflows_Update checks if set items can be updated to empty, like guide or description
+func TestAccWorkflows_Update(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	create, _ := api.ReadTfConfig(t, "testdata/create.tf")
+	update, _ := api.ReadTfConfig(t, "testdata/update.tf") // name change because of #name# doesn't matter here. Important is the non-empty plan for guide and description
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{Config: create},
+			{Config: update},
+		},
+	})
 }

--- a/dynatrace/api/automation/workflows/settings/workflow.go
+++ b/dynatrace/api/automation/workflows/settings/workflow.go
@@ -29,21 +29,21 @@ const SchemaVersion = 4
 
 type Workflow struct {
 	Title       string `json:"title" maxlength:"200"` // The title / name of the workflow
-	Description string `json:"description,omitempty"` // An optional description for the workflow
+	Description string `json:"description"`           // An optional description for the workflow
 
 	Actor                string         `json:"actor,omitempty" maxlength:"36" format:"uuid"` // The user context the executions of the workflow will happen with
 	Owner                string         `json:"owner,omitempty" format:"uuid"`                // The ID of the owner of this workflow
 	OwnerType            string         `json:"ownerType"`                                    // The type of the owner. Possible values: `USER` and `GROUP`
 	Private              bool           `json:"isPrivate"`                                    // Defines whether this workflow is private to the owner or not. Default is `true`
 	IsDeployed           bool           `json:"isDeployed"`                                   // Defines whether this workflow is deployed or kept as a draft. Default is `true`
-	SchemaVersion        int            `json:"schemaVersion,omitempty"`                      //
+	SchemaVersion        int            `json:"schemaVersion"`                                //
 	Trigger              *Trigger       `json:"trigger,omitempty"`                            // Configures how executions of the workflows are getting triggered. If no trigger is specified it means the workflow is getting manually triggered
 	Tasks                Tasks          `json:"tasks"`                                        // The tasks to run for every execution of this workflow
 	Type                 string         `json:"type"`
-	HourlyExecutionLimit *int           `json:"hourlyExecutionLimit,omitempty"` // Maximum number of executions per hour, default is 1000
-	Input                map[string]any `json:"input,omitempty"`                // Workflow-level input parameters
-	Guide                string         `json:"guide,omitempty"`                // Informational guide text for the workflow
-	Result               string         `json:"result,omitempty"`               // The result of the workflow
+	HourlyExecutionLimit *int           `json:"hourlyExecutionLimit"` // Maximum number of executions per hour, default is 1000
+	Input                map[string]any `json:"input"`                // Workflow-level input parameters
+	Guide                string         `json:"guide"`                // Informational guide text for the workflow
+	Result               string         `json:"result"`               // The result of the workflow
 }
 
 func (me *Workflow) Name() string {
@@ -62,6 +62,7 @@ func (me *Workflow) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "An optional description for the workflow",
 			Optional:    true,
+			Default:     "", // Sets a default because Workflows behaves like PATCH if not provided; ignoring an empty value
 		},
 
 		"actor": {
@@ -136,11 +137,13 @@ func (me *Workflow) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Informational guide text for the workflow",
 			Optional:    true,
+			Default:     "", // Sets a default because Workflows behaves like PATCH if not provided; ignoring an empty value
 		},
 		"result": {
 			Type:        schema.TypeString,
 			Description: "The result of the workflow",
 			Optional:    true,
+			Default:     "", // Sets a default because Workflows behaves like PATCH if not provided; ignoring an empty value
 		},
 	}
 }

--- a/dynatrace/api/automation/workflows/testdata/create.tf
+++ b/dynatrace/api/automation/workflows/testdata/create.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_automation_workflow" "empty_values" {
+  description            = "my-description"
+  guide                  = "my-guide"
+  result                 = jsonencode({ "myprop" : "myValue" })
+  type                   = "STANDARD"
+  hourly_execution_limit = 1000
+  owner_type             = "USER"
+  private                = false
+  title                  = "#name#"
+  tasks {
+    task {
+      name = "test_1"
+      action = "dynatrace.automations:execute-dql-query"
+      input = jsonencode({})
+      position {
+        x = 0
+        y = 1
+      }
+      description = "Dummy task"
+      active = false
+    }
+  }
+  trigger {}
+}

--- a/dynatrace/api/automation/workflows/testdata/update.tf
+++ b/dynatrace/api/automation/workflows/testdata/update.tf
@@ -1,0 +1,22 @@
+resource "dynatrace_automation_workflow" "empty_values" {
+  // description, guide, result not set
+  type                   = "STANDARD"
+  hourly_execution_limit = 1000
+  owner_type             = "USER"
+  private                = false
+  title                  = "#name#"
+  tasks {
+    task {
+      name = "test_1"
+      action = "dynatrace.automations:execute-dql-query"
+      input = jsonencode({})
+      position {
+        x = 0
+        y = 1
+      }
+      // no description
+      active = false
+    }
+  }
+  trigger {}
+}


### PR DESCRIPTION
#### **Why** this PR?
It's not possible to set the `guide`, `description` and `result` of a workflow to empty string

#### **What** has changed?
It's now possible to set them to empty string

#### **How** does it do it?
By setting them to empty string by default and not removing them in the request if they are empty.
The workflow PUT API behaves like PATCH on root level, meaning that not provided fields are not updated. Therefore, we must set them to empty string to update them.

#### How is it **tested**?
New integration test added that sets a guide, description, result and updates them with empty/not set.

#### How does it affect **users**?
They're able to set the `guide`, `description` and `result` to empty string

**Issue:** CA-19023
