### PR TITLE
fix(dynatrace_iam_policy_bindings_v2): allow multiple policy bindings with the same policy ID

### DIFF
--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -20,6 +20,7 @@ package v2bindings
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -215,6 +216,13 @@ type bindingPayload = struct {
 }
 
 func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindings.PolicyBinding) error {
+	// Because a policy binding to a group is not unique (several policyIDs with different parameters can be assigned to a group)
+	// we are deleting everything first before adding new policies
+	// updating/deleting a policy binding would mean that we need to provide the whole parameters and metadata array
+	// the policy-binding identifier is basically the value (parameters and metadata) of the policy binding
+	if err := me.Delete(ctx, id); err != nil {
+		return err
+	}
 	groupID, levelType, levelID, err := splitID(id)
 	if err != nil {
 		return err
@@ -222,51 +230,15 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 
 	client := iam.NewIAMClient(me)
 
-	deployedBindings, err := me.getGroupPolicyBindingUUIDs(ctx, id)
-	if err != nil {
-		return err
-	}
-	existingPolicyBindings := map[string]struct{}{}
-	for _, desiredPolicy := range deployedBindings {
-		existingPolicyBindings[desiredPolicy] = struct{}{}
-	}
-	desiredPolicyBindings := map[string]*bindings.Policy{}
 	for _, desiredPolicy := range v.Policies {
 		policyUUID, _, _, _ := policies.SplitID(desiredPolicy.ID, levelType, levelID)
-		desiredPolicyBindings[policyUUID] = desiredPolicy
-	}
-
-	// update/delete
-	for existingPolicyID := range existingPolicyBindings {
-		if desiredPolicy, ok := desiredPolicyBindings[existingPolicyID]; ok {
-			// policy found that matches desired - update
-			payload := bindingPayload{
-				Parameters: desiredPolicy.Parameters,
-				Metadata:   desiredPolicy.Metadata,
-				Boundaries: desiredPolicy.Boundaries,
-			}
-			if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, existingPolicyID, groupID), payload, 204, false); err != nil {
-				return err
-			}
-		} else {
-			// There is an existing policy binding that is not desired anymore - delete
-			if _, err = client.DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, existingPolicyID, groupID), []int{204, 400, 404}, false); err != nil {
-				return err
-			}
+		payload := bindingPayload{
+			Parameters: desiredPolicy.Parameters,
+			Metadata:   desiredPolicy.Metadata,
+			Boundaries: desiredPolicy.Boundaries,
 		}
-	}
-
-	// If not found in existing bindings, create
-	for policyUUID, desiredPolicy := range desiredPolicyBindings {
-		if _, ok := existingPolicyBindings[policyUUID]; !ok {
-			payload := bindingPayload{
-				Parameters: desiredPolicy.Parameters,
-				Metadata:   desiredPolicy.Metadata,
-				Boundaries: desiredPolicy.Boundaries,
-			}
-			if _, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyUUID, groupID), payload, 204, false); err != nil {
-				return err
-			}
+		if _, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyUUID, groupID), payload, 204, false); err != nil {
+			return err
 		}
 	}
 
@@ -411,8 +383,11 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 		}
 		policyUUIDs[policyUUID] = policyUUID
 	}
+	queryParams := url.Values{
+		"forceMultiple": []string{"true"},
+	}
 	for policyUUID := range policyUUIDs {
-		if _, err = iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyUUID, groupID), 204, false); err != nil {
+		if _, err = iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s?%s", me.endpointURL, levelType, levelID, policyUUID, groupID, queryParams.Encode()), 204, false); err != nil {
 			return err
 		}
 	}

--- a/dynatrace/api/iam/v2bindings/testdata/create.tf
+++ b/dynatrace/api/iam/v2bindings/testdata/create.tf
@@ -37,4 +37,14 @@ resource "dynatrace_iam_policy_bindings_v2" "acc_bindings" {
       "prop-b" : "value-c"
     }
   }
+  # two policy bindings with the same policy ID but different parameters
+  policy {
+    id = dynatrace_iam_policy.acc_policy.id
+    parameters = {
+      "prop-b" : "value-c"
+    }
+    metadata = {
+      "prop-b" : "value-d"
+    }
+  }
 }

--- a/templates/resources/iam_policy_bindings_v2.md.tmpl
+++ b/templates/resources/iam_policy_bindings_v2.md.tmpl
@@ -14,6 +14,10 @@ description: |-
 
 -> This resource is excluded by default in the export utility, please explicitly specify the resource to retrieve existing configuration.
 
+-> This resource re-assigns all policies bound to a group, so every policy that should remain bound must be specified in the configuration; otherwise, it will be unbound.
+During this process, there is a brief window where the group has no policies assigned, which may temporarily cause permission issues for users in that group.
+Locking out the OAuth client through this resource is theoretically possible but very unlikely, as managing policies and groups requires account-level permissions. If account permissions are set on a group, policy boundaries can still be managed even when no policies are assigned.
+
 ## Dynatrace Documentation
 
 - Dynatrace IAM Group Permissions - https://docs.dynatrace.com/docs/manage/identity-access-management/permission-management/manage-user-permissions-policies


### PR DESCRIPTION
#### **Why** this PR?
It was no longer possible to have two policy bindings to a group with the same policy ID. This is possible via the API if the parameters/metadata differ. Now it deletes the policy first, as we can't provide a unique identifier for a policy

#### **What** has changed?
The same policy ID can now be used several times for bindings in `dynatrace_iam_policy_bindings_v2`

#### **How** does it do it?
By simply removing all existing bindings of a group and re-assigning the current set ones.

#### How is it **tested**?
A new test was added that checks if policy bindings with the same policy ID can be created.

#### How does it affect **users**?
They can now set the same policy ID with different parameters for a policy binding.

**Issue:** CA-19008

## Notes
It is possible to lock the OAuth client out through this resource but this is very unlikely because managing of policies and groups is on the account level and requires account permissions. If account permissions are set on a group, it also allows managing boundaries even if no policies are set.
