### PR TITLE
fix(dynatrace_webhook_notification): remove empty item for headers 

### DIFF
--- a/dynatrace/api/builtin/problem/notifications/http/header.go
+++ b/dynatrace/api/builtin/problem/notifications/http/header.go
@@ -52,16 +52,7 @@ func (me *Headers) UnmarshalHCL(decoder hcl.Decoder) error {
 	if err := decoder.DecodeSlice("header", me); err != nil {
 		return err
 	}
-	// slice may contain empty values because of SDK bug
-	hdrs := Headers{}
-	for _, header := range *me {
-		// empty value
-		if len(header.Name) == 0 && header.SecretValue == nil && header.Value == nil && !header.Secret {
-			continue
-		}
-		hdrs = append(hdrs, header)
-	}
-	*me = hdrs
+	*me = hcl.FilterEmpty(*me, Header{})
 	return nil
 }
 

--- a/dynatrace/api/builtin/problem/notifications/webhook/service_test.go
+++ b/dynatrace/api/builtin/problem/notifications/webhook/service_test.go
@@ -23,8 +23,35 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestAccWebHookNotifications(t *testing.T) {
 	api.TestAcc(t)
+}
+
+func TestAccWebHookHeaderUpdate(t *testing.T) {
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	identifier := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	createConfig := api.ReadTfConfigWithIdentifier(t, "testdata/create.tf", identifier)
+	updateConfig := api.ReadTfConfigWithIdentifier(t, "testdata/update.tf", identifier)
+
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{Config: createConfig},
+			{Config: updateConfig},
+		},
+	})
 }

--- a/dynatrace/api/builtin/problem/notifications/webhook/testdata/create.tf
+++ b/dynatrace/api/builtin/problem/notifications/webhook/testdata/create.tf
@@ -1,0 +1,28 @@
+resource "dynatrace_webhook_notification" "notification" {
+  active                 = false
+  name                   = "#name#"
+  profile                = dynatrace_alerting.Default.id
+  url                    = "https://webhook.site/#name#"
+  insecure               = true
+  notify_event_merges    = true
+  notify_closed_problems = true
+  payload                = "web-hook-payload"
+  headers {
+    header {
+      name  = "http-header-name-01"
+      value = "http-header-value-01"
+    }
+    header {
+      name         = "http-header-name-02"
+      secret_value = "http-header-value-02"
+    }
+    header {
+      name  = "http-header-name-03"
+      value = "http-header-value-03"
+    }
+  }
+}
+
+resource "dynatrace_alerting" "Default" {
+  name = "#name#"
+}

--- a/dynatrace/api/builtin/problem/notifications/webhook/testdata/update.tf
+++ b/dynatrace/api/builtin/problem/notifications/webhook/testdata/update.tf
@@ -1,0 +1,29 @@
+resource "dynatrace_webhook_notification" "notification" {
+  active                 = false
+  name                   = "#name#"
+  profile                = dynatrace_alerting.Default.id
+  url                    = "https://webhook.site/#name#"
+  insecure               = true
+  notify_event_merges    = true
+  notify_closed_problems = true
+  payload                = "web-hook-payload"
+  headers {
+    # removing and adding headers
+    header {
+      name  = "http-header-name-01"
+      value = "http-header-value-01"
+    }
+    header {
+      name         = "http-header-name-02"
+      secret_value = "http-header-value-02"
+    }
+    header {
+      name  = "http-header-name-new"
+      value = "http-header-value-new"
+    }
+  }
+}
+
+resource "dynatrace_alerting" "Default" {
+  name = "#name#"
+}

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -50,14 +50,10 @@ func AccEnvsGiven(t *testing.T) bool {
 	return true
 }
 
-// RandomizeResource replaces "#name#" and "${randomize}" with a random string
-// Returns:
-// 	- The replaced config
-//  - The random string that was used
-func RandomizeResource(config string) (replacedConfig string, identifier string) {
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	config = strings.ReplaceAll(config, "#name#", name)
-	return strings.ReplaceAll(config, "${randomize}", name), name
+// replaceWithIdentifier replaces "#name#" and "${randomize}" with a given identifier
+func replaceWithIdentifier(config string, identifier string) string {
+	config = strings.ReplaceAll(config, "#name#", identifier)
+	return strings.ReplaceAll(config, "${randomize}", identifier)
 }
 
 // ReadTfConfig reads a config and replaces "#name#" and "${randomize}" with a random string
@@ -65,11 +61,17 @@ func RandomizeResource(config string) (replacedConfig string, identifier string)
 // 	- The replaced config
 //  - The random string that was used
 func ReadTfConfig(t *testing.T, file string) (config string, identifier string) {
+	identifier = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	return ReadTfConfigWithIdentifier(t, file, identifier), identifier
+}
+
+// ReadTfConfigWithIdentifier reads a config and replaces "#name#" and "${randomize}" with a given identifier
+func ReadTfConfigWithIdentifier(t *testing.T, file string, identifier string) string {
 	t.Helper()
 	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
-	return RandomizeResource(string(content))
+	return replaceWithIdentifier(string(content), identifier)
 }
 
 func readTestData(t *testing.T) []string {


### PR DESCRIPTION
#### **Why** this PR?
Removing/Adding header items in `dynatrace_webhook_notification` lead to an empty item (with conditional defaults applied), which resulted in an API error.

#### **What** has changed?
The empty item is now removed

#### **How** does it do it?
By using our existing utility to filter out empty items

#### How is it **tested**?
New tests added
Also added a new testing utility to read several configs with the same identifier instead of always generating a new one (`#name#` => random string)

#### How does it affect **users**?
They can now properly add/remove header items in `dynatrace_webhook_notification`

**Issue:** CA-18992