### PR TITLE
refactor: propagate context to IAMClient

### DIFF
--- a/datasources/iam/environments/service.go
+++ b/datasources/iam/environments/service.go
@@ -82,7 +82,7 @@ func (ec *environmentsService) Get(ctx context.Context) ([]Environment, error) {
 		return nil, err
 	}
 
-	client := iam.NewIAMClient(ec)
+	client := iam.NewIAMClient(ctx, ec)
 	var result Response
 	err = iam.GET(client, ctx, u, 200, false, &result)
 	if err != nil {

--- a/dynatrace/api/iam/base_policy_service_client.go
+++ b/dynatrace/api/iam/base_policy_service_client.go
@@ -59,7 +59,7 @@ func (me *BasePolicyServiceClient) CREATE(ctx context.Context, level PolicyLevel
 	var err error
 	var responseBytes []byte
 
-	client := NewIAMClient(me)
+	client := NewIAMClient(ctx, me)
 	if responseBytes, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies", me.endpointURL, level, levelID), policy, 201, false); err != nil {
 		return "", err
 	}
@@ -75,7 +75,7 @@ func (me *BasePolicyServiceClient) GET(ctx context.Context, level PolicyLevel, l
 	var err error
 	var responseBytes []byte
 
-	client := NewIAMClient(me)
+	client := NewIAMClient(ctx, me)
 
 	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies/%s", me.endpointURL, level, levelID, uuid), 200, false); err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func (me *BasePolicyServiceClient) GET(ctx context.Context, level PolicyLevel, l
 func (me *BasePolicyServiceClient) UPDATE(ctx context.Context, level PolicyLevel, levelID string, policy *Policy, uuid string) error {
 	var err error
 
-	client := NewIAMClient(me)
+	client := NewIAMClient(ctx, me)
 
 	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies/%s", me.endpointURL, level, levelID, uuid), policy, 200, false); err != nil {
 		return err
@@ -113,7 +113,7 @@ func (me *BasePolicyServiceClient) List(ctx context.Context, level PolicyLevel, 
 	var err error
 	var responseBytes []byte
 
-	if responseBytes, err = NewIAMClient(me).GET(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies", me.endpointURL, level, levelID), 200, false); err != nil {
+	if responseBytes, err = NewIAMClient(ctx, me).GET(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies", me.endpointURL, level, levelID), 200, false); err != nil {
 		return nil, err
 	}
 
@@ -139,6 +139,6 @@ func (me *BasePolicyServiceClient) LIST(ctx context.Context, level PolicyLevel, 
 }
 
 func (me *BasePolicyServiceClient) DELETE(ctx context.Context, level PolicyLevel, levelID string, uuid string) error {
-	_, err := NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies/%s", me.endpointURL, level, levelID, uuid), 204, false)
+	_, err := NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies/%s", me.endpointURL, level, levelID, uuid), 204, false)
 	return err
 }

--- a/dynatrace/api/iam/bindings/service.go
+++ b/dynatrace/api/iam/bindings/service.go
@@ -95,7 +95,7 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 	}
 	var responseBytes []byte
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/groups/%s", me.endpointURL, levelType, levelID, groupID), 200, false); err != nil {
 		return err
@@ -121,7 +121,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, bindings 
 		return err
 	}
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	policyIDs := []string{}
 	for _, policyID := range bindings.PolicyIDs {
@@ -166,7 +166,7 @@ type ListPolicyUUIDsForGroupResponse struct {
 func (me *BindingServiceClient) GetPolicyUUIDsForGroup(ctx context.Context, groupID string, levelType string, levelID string) ([]string, error) {
 	var err error
 	var responseBytes []byte
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/groups/%s", me.endpointURL, levelType, levelID, groupID), 200, false); err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (me *BindingServiceClient) GetPolicyUUIDsForGroup(ctx context.Context, grou
 func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 	var responseBytes []byte
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/env/v2/accounts/%s/environments", me.endpointURL, me.AccountID()), 200, false); err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	for _, policyID := range binding.PolicyIDs {
-		if _, err = iam.NewIAMClient(me).DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyID, groupID), []int{204, 400}, false); err != nil {
+		if _, err = iam.NewIAMClient(ctx, me).DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s", me.endpointURL, levelType, levelID, policyID, groupID), []int{204, 400}, false); err != nil {
 			return err
 		}
 	}

--- a/dynatrace/api/iam/boundaries/service.go
+++ b/dynatrace/api/iam/boundaries/service.go
@@ -73,7 +73,7 @@ func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 	var responseBytes []byte
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries", me.endpointURL, me.AccountID()), 200, false); err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (me *BoundaryServiceClient) Get(ctx context.Context, id string, v *boundari
 	var err error
 	var responseBytes []byte
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id), 200, false); err != nil {
 		return err
@@ -117,7 +117,7 @@ func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.Polic
 	var err error
 	var responseBytes []byte
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if responseBytes, err = client.POST(
 		ctx,
@@ -144,7 +144,7 @@ func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.Polic
 func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
 	var err error
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if _, err = client.PUT_MULTI_RESPONSE(
 		ctx,
@@ -163,7 +163,7 @@ func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *bound
 func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
 	var err error
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if _, err = client.DELETE(
 		ctx,

--- a/dynatrace/api/iam/groups/service.go
+++ b/dynatrace/api/iam/groups/service.go
@@ -96,7 +96,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 	var err error
 	var responseBytes []byte
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	if responseBytes, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups", me.endpointURL, me.AccountID()), []*groups.Group{group}, 201, false); err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *groups.Group) error {
 	var err error
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s", me.endpointURL, me.AccountID(), uuid), group, 200, false); err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ type ListGroupsResponse struct {
 }
 
 func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	var groupStubs ListGroupsResponse
 	accountID := me.AccountID()
 	if err := iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups", me.endpointURL, accountID), 200, false, &groupStubs); err != nil {
@@ -174,7 +174,7 @@ func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
 func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Group) (err error) {
 	var groupStub ListGroup
 	accountID := me.AccountID()
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions", me.endpointURL, accountID, id), 200, false, &groupStub); err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Grou
 }
 
 func (me *GroupServiceClient) Delete(ctx context.Context, id string) error {
-	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s", me.endpointURL, me.AccountID(), id), 200, false)
+	_, err := iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s", me.endpointURL, me.AccountID(), id), 200, false)
 
 	// data sources MAY have cached a list of group IDs
 	// Updating the (publicly available) revision signals to them that either a CREATE or DELETE has happened since

--- a/dynatrace/api/iam/iam_client.go
+++ b/dynatrace/api/iam/iam_client.go
@@ -52,13 +52,13 @@ type iamClient struct {
 	client *rest2.Client
 }
 
-func NewIAMClient(a Authenticator) IAMClient {
+func NewIAMClient(ctx context.Context, a Authenticator) IAMClient {
 	oauthConfig := clientcredentials.Config{
 		ClientID:     a.ClientID(),
 		ClientSecret: a.ClientSecret(),
 		TokenURL:     a.TokenURL(),
 	}
-	httpClient := auth.NewOAuthClient(rest.NewContextWithOAuthRetryClient(context.Background()), &oauthConfig)
+	httpClient := auth.NewOAuthClient(rest.NewContextWithOAuthRetryClient(ctx), &oauthConfig)
 
 	opts := []rest2.Option{
 		rest2.WithHTTPListener(logging.HTTPListener("iam")),

--- a/dynatrace/api/iam/permissions/service.go
+++ b/dynatrace/api/iam/permissions/service.go
@@ -76,7 +76,7 @@ func (me *PermissionServiceClient) Name() string {
 func (me *PermissionServiceClient) Create(ctx context.Context, permission *permissions.Permission) (*api.Stub, error) {
 	var err error
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	scope := ""
 	scopeType := ""
 	if len(permission.Account) > 0 {
@@ -110,7 +110,7 @@ func (me *PermissionServiceClient) Get(ctx context.Context, id string, v *permis
 	var err error
 	var responseBytes []byte
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	parts := strings.Split(id, "#-#")
 	if len(parts) < 4 {
@@ -164,7 +164,7 @@ func (me *PermissionServiceClient) List(ctx context.Context) (api.Stubs, error) 
 
 	var stubs api.Stubs
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	for _, groupStub := range groupStubs {
 		groupID := groupStub.ID
 
@@ -196,7 +196,7 @@ func (me *PermissionServiceClient) Delete(ctx context.Context, id string) error 
 	scope := parts[2]
 	scopeType := parts[3]
 
-	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions?scope=%s&permission-name=%s&scope-type=%s", me.endpointURL, me.AccountID(), groupID, url.QueryEscape(scope), url.QueryEscape(name), url.QueryEscape(scopeType)), 200, false)
+	_, err := iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/groups/%s/permissions?scope=%s&permission-name=%s&scope-type=%s", me.endpointURL, me.AccountID(), groupID, url.QueryEscape(scope), url.QueryEscape(name), url.QueryEscape(scopeType)), 200, false)
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("Permission %s not found", id)) {
 		return nil
 	}

--- a/dynatrace/api/iam/policies/policy_level.go
+++ b/dynatrace/api/iam/policies/policy_level.go
@@ -53,7 +53,7 @@ func CheckPolicyExists(ctx context.Context, auth iam.Authenticator, levelType st
 		UUID string `json:"uuid"`
 		Name string `json:"name"`
 	}{}
-	client := iam.NewIAMClient(auth)
+	client := iam.NewIAMClient(ctx, auth)
 	if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies/%s", auth.EndpointURL(), levelType, levelID, policyUUID), 200, false, &response); err != nil {
 		// TODO: this is dirty. The IAM client unfortunately doesn't produce special kinds errors. string compare is the only option atm
 		if strings.HasPrefix(err.Error(), "response code 404") {
@@ -219,7 +219,7 @@ func FetchAllPolicyLevels(ctx context.Context, auth iam.Authenticator) (map[stri
 }
 
 func fetchGlobalPolicies(ctx context.Context, auth iam.Authenticator) (results chan *api.Stub) {
-	client := iam.NewIAMClient(auth)
+	client := iam.NewIAMClient(ctx, auth)
 	results = make(chan *api.Stub)
 	go func() {
 		defer func() {
@@ -305,7 +305,7 @@ func fetchAllPolicyLevels(ctx context.Context, auth iam.Authenticator) (m map[st
 // GetEnvironmentIDs retrieves all environmentIDs reachable via the given IAM Client
 // The operation is NOT guarded by a mutex. See `GetEnvironmentIDs` for a guarded version
 func getEnvironmentIDs(ctx context.Context, auth iam.Authenticator) ([]string, error) {
-	client := iam.NewIAMClient(auth)
+	client := iam.NewIAMClient(ctx, auth)
 
 	var err error
 

--- a/dynatrace/api/iam/policies/service.go
+++ b/dynatrace/api/iam/policies/service.go
@@ -91,7 +91,7 @@ func (me *PolicyServiceClient) Create(ctx context.Context, v *policies.Policy) (
 
 	levelType, levelID := getLevel(v)
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	if responseBytes, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies", me.endpointURL, levelType, levelID), v, 201, false); err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (me *PolicyServiceClient) get(ctx context.Context, id string, v *policies.P
 	if err != nil {
 		return err
 	}
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	var policyName string
 
 	levelType, levelID, policyName, err = ResolvePolicyLevel(ctx, me, uuid)
@@ -169,7 +169,7 @@ func (me *PolicyServiceClient) Update(ctx context.Context, id string, user *poli
 	if err != nil {
 		return err
 	}
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if _, err = client.PUT(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies/%s", me.endpointURL, levelType, levelID, uuid), user, 204, false); err != nil {
 		return err
@@ -199,7 +199,7 @@ func listForEnvironment(ctx context.Context, auth iam.Authenticator, environment
 	results = make(chan *api.Stub)
 	go func() {
 		defer close(results)
-		client := iam.NewIAMClient(auth)
+		client := iam.NewIAMClient(ctx, auth)
 
 		var response ListPoliciesResponse
 		if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/environment/%s/policies", auth.EndpointURL(), environmentID), 200, false, &response); err != nil {
@@ -245,7 +245,7 @@ func listForEnvironments(ctx context.Context, auth iam.Authenticator) (results c
 }
 
 func listForAccount(ctx context.Context, auth iam.Authenticator) (results chan *api.Stub, err error) {
-	client := iam.NewIAMClient(auth)
+	client := iam.NewIAMClient(ctx, auth)
 
 	results = make(chan *api.Stub)
 	go func() {
@@ -354,7 +354,7 @@ func (me *PolicyServiceClient) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	_, err = iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies/%s", me.endpointURL, levelType, levelID, uuid), 204, false)
+	_, err = iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/policies/%s", me.endpointURL, levelType, levelID, uuid), 204, false)
 	return err
 }
 

--- a/dynatrace/api/iam/serviceusers/service.go
+++ b/dynatrace/api/iam/serviceusers/service.go
@@ -35,7 +35,7 @@ type ServiceUserService interface {
 }
 
 type iamClientGetter interface {
-	New() iam.IAMClient
+	New(ctx context.Context) iam.IAMClient
 }
 
 type iamClientGetterImp struct {
@@ -66,8 +66,8 @@ func (me *iamClientGetterImp) EndpointURL() string {
 	return me.endpointURL
 }
 
-func (me *iamClientGetterImp) New() iam.IAMClient {
-	return iam.NewIAMClient(me)
+func (me *iamClientGetterImp) New(ctx context.Context) iam.IAMClient {
+	return iam.NewIAMClient(ctx, me)
 }
 
 type serviceUserServiceClient struct {
@@ -106,7 +106,7 @@ type createResponse struct {
 }
 
 func (me *serviceUserServiceClient) Create(ctx context.Context, serviceUser *serviceusers.ServiceUser) (*api.Stub, error) {
-	responseBytes, err := me.iamClientGetter.New().POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", me.endpointURL, me.accountID), serviceUser, 201, false)
+	responseBytes, err := me.iamClientGetter.New(ctx).POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", me.endpointURL, me.accountID), serviceUser, 201, false)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ type getServiceUserResponse struct {
 }
 
 func (me *serviceUserServiceClient) Get(ctx context.Context, id string, v *serviceusers.ServiceUser) error {
-	responseBytes, err := me.iamClientGetter.New().GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, id), 200, false)
+	responseBytes, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, id), 200, false)
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ type getUserPartialResponse struct {
 }
 
 func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email string) ([]string, error) {
-	responseBytes, err := me.iamClientGetter.New().GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, me.accountID, email), 200, false)
+	responseBytes, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, me.accountID, email), 200, false)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email str
 
 func (me *serviceUserServiceClient) Update(ctx context.Context, id string, serviceUser *serviceusers.ServiceUser) error {
 	// Update the service user details
-	if _, err := me.iamClientGetter.New().PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, id), serviceUser, 200, false); err != nil {
+	if _, err := me.iamClientGetter.New(ctx).PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, id), serviceUser, 200, false); err != nil {
 		return err
 	}
 
@@ -203,7 +203,7 @@ func (me *serviceUserServiceClient) updateGroupAssignments(ctx context.Context, 
 	if groups == nil {
 		groups = []string{}
 	}
-	_, err := me.iamClientGetter.New().PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, me.accountID, serviceUserEmail), groups, 200, false)
+	_, err := me.iamClientGetter.New(ctx).PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, me.accountID, serviceUserEmail), groups, 200, false)
 	return err
 }
 
@@ -223,7 +223,7 @@ type listServiceUsersResponse struct {
 }
 
 func (me *serviceUserServiceClient) GetAll(ctx context.Context) ([]ServiceUserStub, error) {
-	client := me.iamClientGetter.New()
+	client := me.iamClientGetter.New(ctx)
 
 	var stubs []ServiceUserStub
 	url := fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", me.endpointURL, me.accountID)
@@ -269,6 +269,6 @@ func (me *serviceUserServiceClient) List(ctx context.Context) (api.Stubs, error)
 }
 
 func (me *serviceUserServiceClient) Delete(ctx context.Context, uid string) error {
-	_, err := me.iamClientGetter.New().DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, uid), 200, false)
+	_, err := me.iamClientGetter.New(ctx).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", me.endpointURL, me.accountID, uid), 200, false)
 	return err
 }

--- a/dynatrace/api/iam/serviceusers/service_test.go
+++ b/dynatrace/api/iam/serviceusers/service_test.go
@@ -79,7 +79,7 @@ type mockIAMClientGetter struct {
 	client *mockIAMClient
 }
 
-func (me *mockIAMClientGetter) New() iam.IAMClient {
+func (me *mockIAMClientGetter) New(_ context.Context) iam.IAMClient {
 	return me.client
 }
 

--- a/dynatrace/api/iam/users/service.go
+++ b/dynatrace/api/iam/users/service.go
@@ -74,7 +74,7 @@ func (me *UserServiceClient) SchemaID() string {
 func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api.Stub, error) {
 	var err error
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 	if _, err = client.POST(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users", me.endpointURL, me.AccountID()), user, 201, false); err != nil {
 		if err.Error() == "User already exists" {
 			if err = me.Update(ctx, user.Email, user); err != nil {
@@ -110,7 +110,7 @@ func (me *UserServiceClient) Get(ctx context.Context, email string, v *users.Use
 	var err error
 	var responseBytes []byte
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, me.AccountID(), email), 200, false); err != nil {
 		if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
@@ -140,7 +140,7 @@ func (me *UserServiceClient) Update(ctx context.Context, email string, user *use
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err = iam.NewIAMClient(me).PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, me.AccountID(), user.Email), groups, 200, false); err != nil {
+	if _, err = iam.NewIAMClient(ctx, me).PUT(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s/groups", me.endpointURL, me.AccountID(), user.Email), groups, 200, false); err != nil {
 		return err
 	}
 
@@ -161,7 +161,7 @@ func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 	var responseBytes []byte
 
-	if responseBytes, err = iam.NewIAMClient(me).GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users", me.endpointURL, me.AccountID()), 200, false); err != nil {
+	if responseBytes, err = iam.NewIAMClient(ctx, me).GET(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users", me.endpointURL, me.AccountID()), 200, false); err != nil {
 		return nil, err
 	}
 
@@ -177,7 +177,7 @@ func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *UserServiceClient) Delete(ctx context.Context, email string) error {
-	_, err := iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, me.AccountID(), email), 200, false)
+	_, err := iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/accounts/%s/users/%s", me.endpointURL, me.AccountID(), email), 200, false)
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 		return nil
 	}

--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -126,7 +126,7 @@ func (me *BindingServiceClient) getGroupPolicyBindingUUIDs(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	type groupPolicyBindings struct {
 		PolicyUuids []string `json:"policyUuids"`
@@ -144,7 +144,7 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 	if err != nil {
 		return err
 	}
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	policyIDs, err := me.getGroupPolicyBindingUUIDs(ctx, id)
 	if err != nil {
@@ -228,7 +228,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 		return err
 	}
 
-	client := iam.NewIAMClient(me)
+	client := iam.NewIAMClient(ctx, me)
 
 	for _, desiredPolicy := range v.Policies {
 		policyUUID, _, _, _ := policies.SplitID(desiredPolicy.ID, levelType, levelID)
@@ -270,7 +270,7 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 
 		var err error
 		var response ListPolicyBindingsResponse
-		client := iam.NewIAMClient(me)
+		client := iam.NewIAMClient(ctx, me)
 
 		if err = iam.GET(client, ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/bindings", me.endpointURL, me.AccountID()), 200, false, &response); err != nil {
 			return
@@ -301,7 +301,7 @@ func (me *BindingServiceClient) FetchEnvironmentBindings(ctx context.Context) ch
 			close(results)
 		}()
 		var err error
-		client := iam.NewIAMClient(me)
+		client := iam.NewIAMClient(ctx, me)
 
 		var environmentIDs []string
 		if environmentIDs, err = policies.GetEnvironmentIDs(ctx, me); err != nil {
@@ -387,7 +387,7 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 		"forceMultiple": []string{"true"},
 	}
 	for policyUUID := range policyUUIDs {
-		if _, err = iam.NewIAMClient(me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s?%s", me.endpointURL, levelType, levelID, policyUUID, groupID, queryParams.Encode()), 204, false); err != nil {
+		if _, err = iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("%s/iam/v1/repo/%s/%s/bindings/%s/%s?%s", me.endpointURL, levelType, levelID, policyUUID, groupID, queryParams.Encode()), 204, false); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
#### **Why** this PR?
The IAM client uses a new context, which is decoupled from the main one. This means that deadlines and cancellations won't be propagated.

#### **What** has changed?
Deadlines and cancellations by Terraform are now correctly propagated to the client

#### **How** does it do it?
Changed the NewIAMClient to accept a `context.Context` and update all IAM client construction sites to pass ctx.

#### How is it **tested**?
N/A

#### How does it affect **users**?
Cancellations will now also cancel the SSO request.

**Issue:** NOISSUE
