### PR TITLE
refactor: Remove more unneeded code

### DIFF
--- a/dynatrace/rest/logging/http_listener.go
+++ b/dynatrace/rest/logging/http_listener.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2025 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,16 +18,10 @@
 package logging
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"strings"
-	"sync"
-
-	"github.com/google/uuid"
 
 	crest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
@@ -97,57 +91,4 @@ func HTTPListener(prefix string) *crest.HTTPListener {
 			logResponse(ctx, response.ID, response.Response)
 		},
 	}
-}
-
-type RoundTripper struct {
-	RoundTripper http.RoundTripper
-	lock         sync.Mutex
-}
-
-func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if !DYNATRACE_HTTP_OAUTH || !strings.Contains(req.URL.String(), "oauth2") {
-		return rt.RoundTripper.RoundTrip(req)
-	}
-	id := uuid.NewString()
-	if v := req.Context().Value("request.id"); v != nil {
-		if sv, ok := v.(string); ok {
-			id = sv
-		}
-	}
-	rt.lock.Lock()
-	ctx := req.Context()
-	category := ""
-	if strings.Contains(req.URL.String(), "oauth2") {
-		category = " [OAUTH]"
-	}
-
-	Logger.Println(ctx, fmt.Sprintf("[%s]%s %s %s", id, category, req.Method, req.URL.String()))
-	if req.Body != nil {
-		buf := new(bytes.Buffer)
-		io.Copy(buf, req.Body)
-		data := buf.Bytes()
-		Logger.Printf(ctx, "[%s]%s [PAYLOAD ] %s", id, category, string(data))
-		req.Body = io.NopCloser(bytes.NewBuffer(data))
-	}
-	rt.lock.Unlock()
-	resp, err := rt.RoundTripper.RoundTrip(req)
-	if err != nil {
-		Logger.Printf(ctx, "[%s]%s [ERROR   ] %s", id, category, err.Error())
-	}
-	if resp != nil {
-		if os.Getenv("DYNATRACE_HTTP_RESPONSE") == "true" {
-			if resp.Body != nil {
-				buf := new(bytes.Buffer)
-				io.Copy(buf, resp.Body)
-				data := buf.Bytes()
-				resp.Body = io.NopCloser(bytes.NewBuffer(data))
-				if os.Getenv("DT_DEBUG_IAM_BEARER") == "true" || category != " [OAUTH]" {
-					Logger.Printf(ctx, "[%s]%s [RESPONSE] %v %v", id, category, resp.Status, string(data))
-				}
-			} else {
-				Logger.Printf(ctx, "[%s]%s [RESPONSE] %s", id, category, resp.Status)
-			}
-		}
-	}
-	return resp, err
 }

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -73,18 +73,14 @@ func (me request) evalClassicURL() string {
 func PreRequest() {
 	preRequestMutex.Lock()
 	defer preRequestMutex.Unlock()
-	if _, ok := http.DefaultClient.Transport.(*RoundTripper); !ok {
-		if http.DefaultClient.Transport == nil {
-			http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultTransport}
-		} else {
-			http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultClient.Transport}
-		}
-	}
+
 	if strings.TrimSpace(os.Getenv("DYNATRACE_HTTP_INSECURE")) == "true" {
 		if transport, ok := http.DefaultTransport.(*http.Transport); ok {
 			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		}
 	}
+
+	InstallRoundTripper()
 }
 
 func readerFromPayload(payload any) (io.Reader, error) {

--- a/dynatrace/rest/round_tripper.go
+++ b/dynatrace/rest/round_tripper.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2025 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package rest
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,67 +26,8 @@ import (
 	"strings"
 	"sync"
 
-	crest "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/google/uuid"
 )
-
-func logResponse(ctx context.Context, id string, response *http.Response) {
-	if response == nil {
-		return
-	}
-
-	if response.Body == nil {
-		Logger.Printf(ctx, "[%s] [RESPONSE] %d", id, response.StatusCode)
-		return
-	}
-	if os.Getenv("DYNATRACE_HTTP_RESPONSE") != "true" {
-		Logger.Printf(ctx, "[%s] [RESPONSE] %d", id, response.StatusCode)
-		return
-	}
-	body, _ := io.ReadAll(response.Body)
-	if body != nil {
-		Logger.Printf(ctx, "[%s] [RESPONSE] %d %s", id, response.StatusCode, string(body))
-		return
-	}
-	Logger.Printf(ctx, "[%s] [RESPONSE] %d", id, response.StatusCode)
-}
-
-func requestContext(response crest.RequestResponse) context.Context {
-	if response.Request != nil {
-		return response.Request.Context()
-	}
-	if response.Response != nil && response.Response.Request != nil {
-		return response.Response.Request.Context()
-	}
-	return context.Background()
-}
-
-func HTTPListener(prefix string) *crest.HTTPListener {
-	logRequest := func(ctx context.Context, id string, request *http.Request) {
-		if request == nil {
-			return
-		}
-		if request.URL == nil {
-			return
-		}
-		if request.Body == nil {
-			Logger.Printf(ctx, "[%s] [%s] %s %s", prefix, id, request.Method, request.URL.String())
-			return
-		}
-
-		body, _ := io.ReadAll(request.Body)
-		Logger.Printf(ctx, "[%s] [%s] %s %s", prefix, id, request.Method, request.URL.String())
-		Logger.Printf(ctx, "[%s] [PAYLOAD] %s", id, string(body))
-	}
-
-	return &crest.HTTPListener{
-		Callback: func(response crest.RequestResponse) {
-			ctx := requestContext(response)
-			logRequest(ctx, response.ID, response.Request)
-			logResponse(ctx, response.ID, response.Response)
-		},
-	}
-}
 
 var lock sync.Mutex
 

--- a/dynatrace/rest/round_tripper.go
+++ b/dynatrace/rest/round_tripper.go
@@ -34,12 +34,16 @@ var lock sync.Mutex
 func InstallRoundTripper() {
 	lock.Lock()
 	defer lock.Unlock()
+
+	// Avoid installing this round tripper multiple times
 	if _, ok := http.DefaultClient.Transport.(*RoundTripper); !ok {
-		if http.DefaultClient.Transport == nil {
-			http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultTransport}
-		} else {
-			http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultClient.Transport}
-		}
+		return
+	}
+
+	if http.DefaultClient.Transport == nil {
+		http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultTransport}
+	} else {
+		http.DefaultClient.Transport = &RoundTripper{RoundTripper: http.DefaultClient.Transport}
 	}
 }
 


### PR DESCRIPTION
#### **Why** this PR?
The code is currently hard to understand as the two files are essentially the same, with some functions being used from one and some from the other. This minimal change should help.

#### **What** has changed and **how** does it do it?
- Unused code is removed from both files.
- The file `dynatrace/rest/http_listener.go` is renamed to `dynatrace/rest/round_tripper.go`, as now it only contains the round tripper.
- Logic is simplified in `InstallRoundTripper()` to make it more obvious that this custom round tripper will only be installed once, regardless of how often it is called.
- `InstallRoundTripper()` was previously unused with the logic duplicated in `request.go`.

#### How is it **tested**?
Existing tests

#### How does it affect **users**?
No effect

**Issue:** NO-ISSUE
