### PR TITLE
fix: TypeSet maintenance part 2

### DIFF
--- a/dynatrace/api/builtin/dashboards/image/allowlist/service_test.go
+++ b/dynatrace/api/builtin/dashboards/image/allowlist/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccDashboardsAllowlist(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesDashboardsAllowlist(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/dashboards/image/allowlist/testcases/update-url-pattern-set/create.tf
+++ b/dynatrace/api/builtin/dashboards/image/allowlist/testcases/update-url-pattern-set/create.tf
@@ -1,0 +1,12 @@
+resource "dynatrace_dashboards_allowlist" "list" {
+  allowlist {
+    urlpattern {
+      rule     = "equals"
+      template = "https://www.dynatrace.com/"
+    }
+    urlpattern {
+      rule     = "startsWith"
+      template = "https://www.docs.dynatrace.com/"
+    }
+  }
+}

--- a/dynatrace/api/builtin/dashboards/image/allowlist/testcases/update-url-pattern-set/update.tf
+++ b/dynatrace/api/builtin/dashboards/image/allowlist/testcases/update-url-pattern-set/update.tf
@@ -1,0 +1,13 @@
+resource "dynatrace_dashboards_allowlist" "list" {
+  allowlist {
+    urlpattern {
+      rule     = "equals"
+      template = "https://www.dynatrace.com/"
+    }
+    # update => re-create due to set-hash change
+    urlpattern {
+      rule     = "equals"
+      template = "https://www.docs.dynatrace.com/"
+    }
+  }
+}

--- a/dynatrace/api/builtin/davis/anomalydetectors/service_test.go
+++ b/dynatrace/api/builtin/davis/anomalydetectors/service_test.go
@@ -34,3 +34,7 @@ func TestAccDavisAnomalyDetectorsWithPreferToken(t *testing.T) {
 	t.Setenv("DYNATRACE_HTTP_OAUTH_PREFERENCE", "false")
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesDavisAnomalyDetectors(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/davis/anomalydetectors/testcases/update-analyzer-input-field-set/create.tf
+++ b/dynatrace/api/builtin/davis/anomalydetectors/testcases/update-analyzer-input-field-set/create.tf
@@ -1,0 +1,41 @@
+resource "dynatrace_davis_anomaly_detectors" "detector" {
+  description = "Sample Description"
+  enabled     = false
+  source      = "Davis Anomaly Detection"
+  title       = "#name#"
+  analyzer {
+    name = "dt.statistics.ui.anomaly_detection.StaticThresholdAnomalyDetectionAnalyzer"
+    input {
+      analyzer_input_field {
+        key   = "query"
+        value = "fetch bizevents"
+      }
+      analyzer_input_field {
+        key   = "threshold"
+        value = "12345678"
+      }
+    }
+  }
+  event_template {
+    properties {
+      property {
+        key   = "dt.source_entity"
+        value = "{dims:dt.source_entity}"
+      }
+      property {
+        key   = "event.type"
+        value = "CUSTOM_ALERT"
+      }
+      property {
+        key   = "event.name"
+        value = "Event Name Example"
+      }
+      property {
+        key   = "event.description"
+        value = "Event Description Example"
+      }
+    }
+  }
+  execution_settings {
+  }
+}

--- a/dynatrace/api/builtin/davis/anomalydetectors/testcases/update-analyzer-input-field-set/update.tf
+++ b/dynatrace/api/builtin/davis/anomalydetectors/testcases/update-analyzer-input-field-set/update.tf
@@ -1,0 +1,42 @@
+resource "dynatrace_davis_anomaly_detectors" "detector" {
+  description = "Sample Description"
+  enabled     = false
+  source      = "Davis Anomaly Detection"
+  title       = "#name#"
+  analyzer {
+    name = "dt.statistics.ui.anomaly_detection.StaticThresholdAnomalyDetectionAnalyzer"
+    input {
+      analyzer_input_field {
+        key   = "query"
+        value = "fetch bizevents"
+      }
+      # update => re-create due to set-hash change
+      analyzer_input_field {
+        key   = "threshold"
+        value = "123456789"
+      }
+    }
+  }
+  event_template {
+    properties {
+      property {
+        key   = "dt.source_entity"
+        value = "{dims:dt.source_entity}"
+      }
+      property {
+        key   = "event.type"
+        value = "CUSTOM_ALERT"
+      }
+      property {
+        key   = "event.name"
+        value = "Event Name Example"
+      }
+      property {
+        key   = "event.description"
+        value = "Event Description Example"
+      }
+    }
+  }
+  execution_settings {
+  }
+}

--- a/dynatrace/api/builtin/deployment/oneagent/updates/service_test.go
+++ b/dynatrace/api/builtin/deployment/oneagent/updates/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccOneAgentUpdates(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesOneAgentUpdates(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/deployment/oneagent/updates/testcases/update-maintenance-window-set/create.tf
+++ b/dynatrace/api/builtin/deployment/oneagent/updates/testcases/update-maintenance-window-set/create.tf
@@ -1,0 +1,26 @@
+resource "dynatrace_update_windows" "window" {
+  count = 2
+  name       = "#name#-${count.index}"
+  enabled    = true
+  recurrence = "ONCE"
+  once_recurrence {
+    recurrence_range {
+      end   = "2023-02-15T04:00:00Z"
+      start = "2023-02-15T02:00:00Z"
+    }
+  }
+}
+
+resource "dynatrace_oneagent_updates" "update" {
+  scope          = "environment"
+  target_version = "latest"
+  update_mode    = "AUTOMATIC_DURING_MW"
+  maintenance_windows {
+    dynamic "maintenance_window" {
+      for_each = toset(dynatrace_update_windows.window.*.id)
+      content {
+        maintenance_window = maintenance_window.value
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/deployment/oneagent/updates/testcases/update-maintenance-window-set/create.tf
+++ b/dynatrace/api/builtin/deployment/oneagent/updates/testcases/update-maintenance-window-set/create.tf
@@ -1,0 +1,27 @@
+resource "dynatrace_update_windows" "window" {
+  count = 3
+  name       = "#name#-${count.index}"
+  enabled    = true
+  recurrence = "ONCE"
+  once_recurrence {
+    recurrence_range {
+      end   = "2023-02-15T04:00:00Z"
+      start = "2023-02-15T02:00:00Z"
+    }
+  }
+}
+
+resource "dynatrace_oneagent_updates" "update" {
+  scope          = "environment"
+  target_version = "latest"
+  update_mode    = "AUTOMATIC_DURING_MW"
+  maintenance_windows {
+    maintenance_window {
+      maintenance_window = dynatrace_update_windows.window[0].id
+    }
+    # to update
+    maintenance_window {
+      maintenance_window = dynatrace_update_windows.window[1].id
+    }
+  }
+}

--- a/dynatrace/api/builtin/deployment/oneagent/updates/testcases/update-maintenance-window-set/update.tf
+++ b/dynatrace/api/builtin/deployment/oneagent/updates/testcases/update-maintenance-window-set/update.tf
@@ -1,0 +1,41 @@
+# stays the same
+resource "dynatrace_update_windows" "window" {
+  count = 2
+  name       = "#name#-${count.index}"
+  enabled    = true
+  recurrence = "ONCE"
+  once_recurrence {
+    recurrence_range {
+      end   = "2023-02-15T04:00:00Z"
+      start = "2023-02-15T02:00:00Z"
+    }
+  }
+}
+
+# new window
+resource "dynatrace_update_windows" "window-update" {
+  name       = "#name#-new"
+  enabled    = true
+  recurrence = "ONCE"
+  once_recurrence {
+    recurrence_range {
+      end   = "2023-02-15T04:00:00Z"
+      start = "2023-02-15T02:00:00Z"
+    }
+  }
+}
+
+resource "dynatrace_oneagent_updates" "update" {
+  scope          = "environment"
+  target_version = "latest"
+  update_mode    = "AUTOMATIC_DURING_MW"
+  maintenance_windows {
+    # use one old and one new window
+    maintenance_window {
+      maintenance_window = dynatrace_update_windows.window[0].id
+    }
+    maintenance_window {
+      maintenance_window = dynatrace_update_windows.window-update.id
+    }
+  }
+}

--- a/dynatrace/api/builtin/deployment/oneagent/updates/testcases/update-maintenance-window-set/update.tf
+++ b/dynatrace/api/builtin/deployment/oneagent/updates/testcases/update-maintenance-window-set/update.tf
@@ -1,0 +1,28 @@
+# stays the same
+resource "dynatrace_update_windows" "window" {
+  count = 3
+  name       = "#name#-${count.index}"
+  enabled    = true
+  recurrence = "ONCE"
+  once_recurrence {
+    recurrence_range {
+      end   = "2023-02-15T04:00:00Z"
+      start = "2023-02-15T02:00:00Z"
+    }
+  }
+}
+
+resource "dynatrace_oneagent_updates" "update" {
+  scope          = "environment"
+  target_version = "latest"
+  update_mode    = "AUTOMATIC_DURING_MW"
+  maintenance_windows {
+    maintenance_window {
+      maintenance_window = dynatrace_update_windows.window[0].id
+    }
+    # updated
+    maintenance_window {
+      maintenance_window = dynatrace_update_windows.window[2].id
+    }
+  }
+}

--- a/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/service_test.go
+++ b/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccAppMonitoring(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesAppMonitoring(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/settings/app_monitoring.go
+++ b/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/settings/app_monitoring.go
@@ -65,7 +65,9 @@ func (me *AppMonitoring) Schema() map[string]*schema.Schema {
 		"custom_trace_level": {
 			Type:        schema.TypeString,
 			Description: "Possible Values: `off`, `on`, `useDefault`",
-			Optional:    true,
+			// new required property
+			Optional: true,
+			Default:  "useDefault",
 		},
 	}
 }

--- a/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/testcases/update-app-monitoring-set/create.tf
+++ b/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/testcases/update-app-monitoring-set/create.tf
@@ -1,0 +1,14 @@
+resource "dynatrace_app_monitoring" "monitor" {
+  default_log_level = "off"
+  default_trace_level = "off"
+  app_monitoring {
+    app_monitoring {
+      app_id           = "app:dynatrace.github.connector:connection"
+      custom_log_level = "info"
+    }
+    app_monitoring {
+      app_id           = "app:dynatrace.site.reliability.guardian:guardians"
+      custom_log_level = "debug"
+    }
+  }
+}

--- a/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/testcases/update-app-monitoring-set/update.tf
+++ b/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/testcases/update-app-monitoring-set/update.tf
@@ -1,0 +1,15 @@
+resource "dynatrace_app_monitoring" "monitor" {
+  default_log_level = "off"
+  default_trace_level = "off"
+  app_monitoring {
+    app_monitoring {
+      app_id           = "app:dynatrace.github.connector:connection"
+      custom_log_level = "info"
+    }
+    # update => re-create due to set-hash change
+    app_monitoring {
+      app_id           = "app:dynatrace.site.reliability.guardian:guardians"
+      custom_log_level = "error"
+    }
+  }
+}

--- a/dynatrace/api/builtin/failuredetection/environment/parameters/service_test.go
+++ b/dynatrace/api/builtin/failuredetection/environment/parameters/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccFailureDetectionParameters(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesFailureDetectionParameters(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/failuredetection/environment/parameters/settings/custom_error_rule.go
+++ b/dynatrace/api/builtin/failuredetection/environment/parameters/settings/custom_error_rule.go
@@ -41,7 +41,11 @@ func (me CustomErrorRules) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *CustomErrorRules) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("custom_error_rule", me)
+	if err := decoder.DecodeSlice("custom_error_rule", me); err != nil {
+		return err
+	}
+	*me = hcl.FilterEmpty(*me, CustomErrorRule{})
+	return nil
 }
 
 type CustomErrorRule struct {

--- a/dynatrace/api/builtin/failuredetection/environment/parameters/testcases/update-custom-rules-and-exception-set/create.tf
+++ b/dynatrace/api/builtin/failuredetection/environment/parameters/testcases/update-custom-rules-and-exception-set/create.tf
@@ -1,0 +1,61 @@
+resource "dynatrace_failure_detection_parameters" "params" {
+  name        = "#name#"
+  description = "Created by Terraform"
+  broken_links {
+    http_404_not_found_failures = false
+  }
+  exception_rules {
+    ignore_all_exceptions         = false
+    ignore_span_failure_detection = true
+    custom_error_rules {
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000000"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000001"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+    }
+    custom_handled_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      custom_handled_exception {
+        class_pattern   = "ClassPattern2"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+    ignored_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      custom_handled_exception {
+        class_pattern   = "ClassPattern2"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+    success_forcing_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      custom_handled_exception {
+        class_pattern   = "ClassPattern2"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+  }
+  http_response_codes {
+    client_side_errors                        = "400-599"
+    fail_on_missing_response_code_client_side = false
+    fail_on_missing_response_code_server_side = true
+    server_side_errors                        = "500-599"
+  }
+}

--- a/dynatrace/api/builtin/failuredetection/environment/parameters/testcases/update-custom-rules-and-exception-set/update.tf
+++ b/dynatrace/api/builtin/failuredetection/environment/parameters/testcases/update-custom-rules-and-exception-set/update.tf
@@ -1,0 +1,65 @@
+resource "dynatrace_failure_detection_parameters" "params" {
+  name        = "#name#"
+  description = "Created by Terraform"
+  broken_links {
+    http_404_not_found_failures = false
+  }
+  exception_rules {
+    ignore_all_exceptions         = false
+    ignore_span_failure_detection = true
+    custom_error_rules {
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000000"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+      # update => re-create due to set-hash change
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000002"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+    }
+    custom_handled_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      # update => re-create due to set-hash change
+      custom_handled_exception {
+        class_pattern   = "ClassPatternEdit"
+        message_pattern = "ExceptionPatternEdit"
+      }
+    }
+    ignored_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      # update => re-create due to set-hash change
+      custom_handled_exception {
+        class_pattern   = "ClassPatternEdit"
+        message_pattern = "ExceptionPatternEdit"
+      }
+    }
+    success_forcing_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      # update => re-create due to set-hash change
+      custom_handled_exception {
+        class_pattern   = "ClassPatternEdit"
+        message_pattern = "ExceptionPatternEdit"
+      }
+    }
+  }
+  http_response_codes {
+    client_side_errors                        = "400-599"
+    fail_on_missing_response_code_client_side = false
+    fail_on_missing_response_code_server_side = true
+    server_side_errors                        = "500-599"
+  }
+}

--- a/dynatrace/api/builtin/failuredetection/environment/rules/service_test.go
+++ b/dynatrace/api/builtin/failuredetection/environment/rules/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccFailureDetectionRules(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesFailureDetectionRules(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/failuredetection/environment/rules/testcases/update-condition-set/create.tf
+++ b/dynatrace/api/builtin/failuredetection/environment/rules/testcases/update-condition-set/create.tf
@@ -1,0 +1,66 @@
+resource "dynatrace_failure_detection_rules" "rule" {
+  name         = "#name#"
+  enabled      = true
+  parameter_id = dynatrace_failure_detection_parameters.parameter.id
+  conditions {
+    condition {
+      attribute = "SERVICE_NAME"
+      predicate {
+        case_sensitive = true
+        predicate_type = "STRING_EQUALS"
+        text_values    = [ "Terraform" ]
+      }
+    }
+    condition {
+      attribute = "SERVICE_TYPE"
+      predicate {
+        predicate_type = "SERVICE_TYPE_EQUALS"
+        service_type = ["WebRequest"]
+      }
+    }
+  }
+}
+
+resource "dynatrace_failure_detection_parameters" "parameter" {
+  name        = "#name#"
+  description = "Created by Terraform"
+  broken_links {
+    http_404_not_found_failures = false
+  }
+  exception_rules {
+    ignore_all_exceptions         = false
+    ignore_span_failure_detection = true
+    custom_error_rules {
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000000"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+    }
+    custom_handled_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+    ignored_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+    success_forcing_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+  }
+  http_response_codes {
+    client_side_errors                        = "400-599"
+    fail_on_missing_response_code_client_side = false
+    fail_on_missing_response_code_server_side = true
+    server_side_errors                        = "500-599"
+  }
+}

--- a/dynatrace/api/builtin/failuredetection/environment/rules/testcases/update-condition-set/update.tf
+++ b/dynatrace/api/builtin/failuredetection/environment/rules/testcases/update-condition-set/update.tf
@@ -1,0 +1,68 @@
+resource "dynatrace_failure_detection_rules" "rule" {
+  name         = "#name#"
+  enabled      = true
+  parameter_id = dynatrace_failure_detection_parameters.parameter.id
+  conditions {
+    condition {
+      attribute = "SERVICE_NAME"
+      predicate {
+        case_sensitive = true
+        predicate_type = "STRING_EQUALS"
+        text_values    = [ "Terraform" ]
+      }
+    }
+    # update => re-create due to set-hash change
+    condition {
+      attribute = "PG_NAME"
+      predicate {
+        case_sensitive = true
+        predicate_type = "STRING_EQUALS"
+        text_values    = [ "Terraform-Service" ]
+      }
+    }
+  }
+}
+
+resource "dynatrace_failure_detection_parameters" "parameter" {
+  name        = "#name#"
+  description = "Created by Terraform"
+  broken_links {
+    http_404_not_found_failures = false
+  }
+  exception_rules {
+    ignore_all_exceptions         = false
+    ignore_span_failure_detection = true
+    custom_error_rules {
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000000"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+    }
+    custom_handled_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+    ignored_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+    success_forcing_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+  }
+  http_response_codes {
+    client_side_errors                        = "400-599"
+    fail_on_missing_response_code_client_side = false
+    fail_on_missing_response_code_server_side = true
+    server_side_errors                        = "500-599"
+  }
+}

--- a/dynatrace/api/builtin/failuredetection/service/generalparameters/service_test.go
+++ b/dynatrace/api/builtin/failuredetection/service/generalparameters/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccServiceFailure(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesServiceFailure(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/failuredetection/service/generalparameters/settings/custom_error_rule.go
+++ b/dynatrace/api/builtin/failuredetection/service/generalparameters/settings/custom_error_rule.go
@@ -41,7 +41,11 @@ func (me CustomErrorRules) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *CustomErrorRules) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("custom_error_rule", me)
+	if err := decoder.DecodeSlice("custom_error_rule", me); err != nil {
+		return err
+	}
+	*me = hcl.FilterEmpty(*me, CustomErrorRule{})
+	return nil
 }
 
 type CustomErrorRule struct {

--- a/dynatrace/api/builtin/failuredetection/service/generalparameters/testcases/update-exception-and-custom-error-rule-set/create.tf
+++ b/dynatrace/api/builtin/failuredetection/service/generalparameters/testcases/update-exception-and-custom-error-rule-set/create.tf
@@ -1,0 +1,52 @@
+resource "dynatrace_service_failure" "failure" {
+  enabled    = true
+  service_id = "SERVICE-D892CFE7DFAB0D08"
+  exception_rules {
+    ignore_all_exceptions         = false
+    ignore_span_failure_detection = true
+    custom_error_rules {
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000000"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000001"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+    }
+    custom_handled_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      custom_handled_exception {
+        class_pattern   = "ClassPattern2"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+    ignored_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      custom_handled_exception {
+        class_pattern   = "ClassPattern2"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+    success_forcing_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      custom_handled_exception {
+        class_pattern   = "ClassPattern2"
+        message_pattern = "ExceptionPattern"
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/failuredetection/service/generalparameters/testcases/update-exception-and-custom-error-rule-set/update.tf
+++ b/dynatrace/api/builtin/failuredetection/service/generalparameters/testcases/update-exception-and-custom-error-rule-set/update.tf
@@ -1,0 +1,56 @@
+resource "dynatrace_service_failure" "failure" {
+  enabled    = true
+  service_id = "SERVICE-D892CFE7DFAB0D08"
+  exception_rules {
+    ignore_all_exceptions         = false
+    ignore_span_failure_detection = true
+    custom_error_rules {
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000000"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+      # update => re-create due to set-hash change
+      custom_error_rule {
+        request_attribute = "00000000-0000-0000-0000-000000000002"
+        condition {
+          compare_operation_type = "STRING_EXISTS"
+        }
+      }
+    }
+    custom_handled_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      # update => re-create due to set-hash change
+      custom_handled_exception {
+        class_pattern   = "ClassPatternEdit"
+        message_pattern = "ExceptionPatternEdit"
+      }
+    }
+    ignored_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      # update => re-create due to set-hash change
+      custom_handled_exception {
+        class_pattern   = "ClassPatternEdit"
+        message_pattern = "ExceptionPatternEdit"
+      }
+    }
+    success_forcing_exceptions {
+      custom_handled_exception {
+        class_pattern   = "ClassPattern"
+        message_pattern = "ExceptionPattern"
+      }
+      # update => re-create due to set-hash change
+      custom_handled_exception {
+        class_pattern   = "ClassPatternEdit"
+        message_pattern = "ExceptionPatternEdit"
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/failuredetectionrulesets/service_test.go
+++ b/dynatrace/api/builtin/failuredetectionrulesets/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccFailureDetectionRuleSets(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesFailureDetectionRuleSets(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/failuredetectionrulesets/testcases/update-single-exception-and-custom-rule-set/create.tf
+++ b/dynatrace/api/builtin/failuredetectionrulesets/testcases/update-single-exception-and-custom-rule-set/create.tf
@@ -1,0 +1,80 @@
+resource "dynatrace_failure_detection_rule_sets" "rule-set" {
+  enabled = true
+  scope   = "environment"
+  ruleset {
+    description  = "This is a sample description"
+    condition    = "matchesValue(k8s.cluster.name,\"#name#\")"
+    ruleset_name = "#name#-1"
+    fail_on_custom_rules {
+      fail_on_custom_rule {
+        enabled       = true
+        dql_condition = "matchesValue(terraform.test.2, \"#name#\")"
+        rule_name     = "Test 2"
+      }
+      fail_on_custom_rule {
+        enabled       = true
+        dql_condition = "matchesValue(terraform.test.1, \"#name#\")"
+        rule_name     = "Test 1"
+      }
+    }
+    fail_on_exceptions {
+      enabled = true
+      ignored_exceptions {
+        ignored_exception {
+          type    = "Terraform2"
+          enabled = true
+          message = "#name#"
+        }
+        ignored_exception {
+          type    = "Terraform1"
+          enabled = true
+          message = "#name#"
+        }
+      }
+    }
+    fail_on_grpc_status_codes {
+      status_codes = "2,4,12,13,14,15"
+    }
+    fail_on_http_response_status_codes {
+      status_codes = "500-599"
+    }
+    fail_on_span_status_error {
+      enabled = true
+    }
+    overrides {
+      force_success_on_exceptions {
+        ignored_exception {
+          type    = "Terraform2"
+          enabled = true
+          message = "#name#"
+        }
+        ignored_exception {
+          type    = "Terraform1"
+          enabled = true
+          message = "#name#"
+        }
+      }
+      force_success_on_grpc_response_status_codes {
+        status_codes = "20"
+      }
+      force_success_on_http_response_status_codes {
+        status_codes = "555"
+      }
+      force_success_on_span_status_ok {
+        enabled = true
+      }
+      force_success_with_custom_rules {
+        fail_on_custom_rule {
+          enabled       = true
+          dql_condition = "matchesValue(terraform.test.2, \"#name#\")"
+          rule_name     = "Test 2"
+        }
+        fail_on_custom_rule {
+          enabled       = true
+          dql_condition = "matchesValue(terraform.test.1, \"#name#\")"
+          rule_name     = "Test 1"
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/failuredetectionrulesets/testcases/update-single-exception-and-custom-rule-set/update.tf
+++ b/dynatrace/api/builtin/failuredetectionrulesets/testcases/update-single-exception-and-custom-rule-set/update.tf
@@ -1,0 +1,99 @@
+resource "dynatrace_failure_detection_rule_sets" "rule-set" {
+  enabled = true
+  scope   = "environment"
+  ruleset {
+    description  = "This is a sample description"
+    condition    = "matchesValue(k8s.cluster.name,\"#name#\")"
+    ruleset_name = "#name#-1"
+    fail_on_custom_rules {
+      fail_on_custom_rule {
+        enabled       = true
+        dql_condition = "matchesValue(terraform.test.2, \"#name#\")"
+        rule_name     = "Test 2"
+      }
+      # update => re-create due to set-hash change
+      fail_on_custom_rule {
+        enabled       = true
+        dql_condition = "matchesValue(terraform.test.1, \"#name#-edit\")"
+        rule_name     = "Test edit"
+      }
+      fail_on_custom_rule {
+        enabled       = true
+        dql_condition = "matchesValue(terraform.test.1, \"#name#-new\")"
+        rule_name     = "Test new"
+      }
+    }
+    fail_on_exceptions {
+      enabled = true
+      ignored_exceptions {
+        ignored_exception {
+          type    = "Terraform2"
+          enabled = true
+          message = "#name#"
+        }
+        # update => re-create due to set-hash change
+        ignored_exception {
+          type    = "Terraform1-edit"
+          enabled = true
+          message = "#name#-edit"
+        }
+        ignored_exception {
+          type    = "Terraform1-new"
+          enabled = true
+          message = "#name#-new"
+        }
+      }
+    }
+    fail_on_grpc_status_codes {
+      status_codes = "2,4,12,13,14,15"
+    }
+    fail_on_http_response_status_codes {
+      status_codes = "500-599"
+    }
+    fail_on_span_status_error {
+      enabled = true
+    }
+    overrides {
+      force_success_on_exceptions {
+        ignored_exception {
+          type    = "Terraform2"
+          enabled = true
+          message = "#name#"
+        }
+        # update => re-create due to set-hash change
+        ignored_exception {
+          type    = "TerraformEdit"
+          enabled = true
+          message = "#name#-edit"
+        }
+        ignored_exception {
+          type    = "TerraformNew"
+          enabled = true
+          message = "#name#-new"
+        }
+      }
+      force_success_on_grpc_response_status_codes {
+        status_codes = "20"
+      }
+      force_success_on_http_response_status_codes {
+        status_codes = "555"
+      }
+      force_success_on_span_status_ok {
+        enabled = true
+      }
+      force_success_with_custom_rules {
+        fail_on_custom_rule {
+          enabled       = true
+          dql_condition = "matchesValue(terraform.test.2, \"#name#\")"
+          rule_name     = "Test 2"
+        }
+        # update => re-create due to set-hash change
+        fail_on_custom_rule {
+          enabled       = true
+          dql_condition = "matchesValue(terraform.test.1, \"#name#-edit\")"
+          rule_name     = "Test edit"
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/service_test.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccDiskEdgeAnomalyDetectors(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesDiskEdgeAnomalyDetectors(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/testcases/update-metadata-item-and-alert-set/create.tf
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/testcases/update-metadata-item-and-alert-set/create.tf
@@ -1,0 +1,39 @@
+resource "dynatrace_disk_edge_anomaly_detectors" "detectors" {
+  enabled           = true
+  disk_name_filters = [ "$eq(/)" ]
+  operating_system  = [ "WINDOWS", "LINUX" ]
+  policy_name       = "#name#"
+  scope             = "environment"
+  alerts {
+    alert {
+      threshold_percent = 10
+      trigger           = "AVAILABLE_DISK_SPACE_PERCENT_BELOW"
+      sample_count_thresholds {
+        dealerting_evaluation_window = 30
+        dealerting_samples           = 24
+        violating_evaluation_window  = 30
+        violating_samples            = 18
+      }
+    }
+    alert {
+      threshold_milliseconds = 1000
+      trigger           = "READ_TIME_EXCEEDING"
+      sample_count_thresholds {
+        dealerting_evaluation_window = 30
+        dealerting_samples           = 24
+        violating_evaluation_window  = 30
+        violating_samples            = 18
+      }
+    }
+  }
+  event_properties {
+    event_propertie {
+      metadata_key   = "ExampleKey"
+      metadata_value = "ExampleValue"
+    }
+    event_propertie {
+      metadata_key   = "ExampleKey2"
+      metadata_value = "ExampleValue2"
+    }
+  }
+}

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/testcases/update-metadata-item-and-alert-set/update.tf
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/testcases/update-metadata-item-and-alert-set/update.tf
@@ -1,0 +1,41 @@
+resource "dynatrace_disk_edge_anomaly_detectors" "detectors" {
+  enabled           = true
+  disk_name_filters = [ "$eq(/)" ]
+  operating_system  = [ "WINDOWS", "LINUX" ]
+  policy_name       = "#name#"
+  scope             = "environment"
+  alerts {
+    alert {
+      threshold_percent = 10
+      trigger           = "AVAILABLE_DISK_SPACE_PERCENT_BELOW"
+      sample_count_thresholds {
+        dealerting_evaluation_window = 30
+        dealerting_samples           = 24
+        violating_evaluation_window  = 30
+        violating_samples            = 18
+      }
+    }
+    # update => re-create due to set-hash change
+    alert {
+      threshold_milliseconds = 1000
+      trigger           = "WRITE_TIME_EXCEEDING"
+      sample_count_thresholds {
+        dealerting_evaluation_window = 30
+        dealerting_samples           = 24
+        violating_evaluation_window  = 30
+        violating_samples            = 18
+      }
+    }
+  }
+  event_properties {
+    event_propertie {
+      metadata_key   = "ExampleKey"
+      metadata_value = "ExampleValue"
+    }
+    # update => re-create due to set-hash change
+    event_propertie {
+      metadata_key   = "ExampleKeyEdit"
+      metadata_value = "ExampleValueEdit"
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/customlogsourcesettings/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/customlogsourcesettings/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccLogCustomSource(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesLogCustomSource(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/logmonitoring/customlogsourcesettings/testcases/update-enrichment-context-log-source-set/create.tf
+++ b/dynatrace/api/builtin/logmonitoring/customlogsourcesettings/testcases/update-enrichment-context-log-source-set/create.tf
@@ -1,0 +1,61 @@
+resource "dynatrace_log_custom_source" "source" {
+  name    = "#name#"
+  enabled = false
+  scope   = "HOST_GROUP-0000000000000000"
+  context {
+    context {
+      attribute = "dt.entity.process_group"
+      values = ["PROCESS_GROUP-0000000000000000"]
+    }
+  }
+  custom_log_source {
+    type = "WINDOWS_EVENT_LOG"
+    values_and_enrichment {
+      custom_log_source_with_enrichment {
+        path = "/terraform1"
+        enrichment {
+          enrichment {
+            type  = "attribute"
+            key   = "key1"
+            value = "value1"
+          }
+          enrichment {
+            type  = "attribute"
+            key   = "key2"
+            value = "value2"
+          }
+        }
+      }
+      custom_log_source_with_enrichment {
+        path = "/terraform2"
+        enrichment {
+          enrichment {
+            type  = "attribute"
+            key   = "key1"
+            value = "value1"
+          }
+          enrichment {
+            type  = "attribute"
+            key   = "key2"
+            value = "value2"
+          }
+        }
+      }
+      custom_log_source_with_enrichment {
+        path = "/terraform3"
+        enrichment {
+          enrichment {
+            type  = "attribute"
+            key   = "key1"
+            value = "value1"
+          }
+          enrichment {
+            type  = "attribute"
+            key   = "key2"
+            value = "value2"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/customlogsourcesettings/testcases/update-enrichment-context-log-source-set/update.tf
+++ b/dynatrace/api/builtin/logmonitoring/customlogsourcesettings/testcases/update-enrichment-context-log-source-set/update.tf
@@ -1,0 +1,64 @@
+resource "dynatrace_log_custom_source" "source" {
+  name    = "#name#"
+  enabled = false
+  scope   = "HOST_GROUP-0000000000000000"
+  context {
+    # update => re-create due to set-hash change
+    context {
+      attribute = "dt.entity.process_group"
+      values = ["PROCESS_GROUP-0000000000000001"]
+    }
+  }
+  custom_log_source {
+    type = "WINDOWS_EVENT_LOG"
+    values_and_enrichment {
+      custom_log_source_with_enrichment {
+        path = "/terraform1"
+        enrichment {
+          enrichment {
+            type  = "attribute"
+            key   = "key1"
+            value = "value1"
+          }
+          enrichment {
+            type  = "attribute"
+            key   = "key2"
+            value = "value2"
+          }
+        }
+      }
+      # update => re-create due to set-hash change
+      custom_log_source_with_enrichment {
+        path = "/terraformEdit"
+        enrichment {
+          enrichment {
+            type  = "attribute"
+            key   = "key1"
+            value = "value1"
+          }
+          enrichment {
+            type  = "attribute"
+            key   = "key2"
+            value = "value2"
+          }
+        }
+      }
+      custom_log_source_with_enrichment {
+        path = "/terraform3"
+        enrichment {
+          enrichment {
+            type  = "attribute"
+            key   = "key1"
+            value = "value1"
+          }
+          # update => re-create due to set-hash change
+          enrichment {
+            type  = "attribute"
+            key   = "keyEdit"
+            value = "valueEdit"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/logevents/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/logevents/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccLogEvents(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesLogEvents(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/logmonitoring/logevents/testcases/update-metadata-item-set/create.tf
+++ b/dynatrace/api/builtin/logmonitoring/logevents/testcases/update-metadata-item-set/create.tf
@@ -1,0 +1,21 @@
+resource "dynatrace_log_events" "events" {
+  enabled = false
+  query   = "matchesPhrase(content, \"terratest\")"
+  summary = "Created by Terraform"
+  event_template {
+    description = "Created by Terraform"
+    event_type  = "INFO"
+    title       = "{content}"
+    metadata {
+      item {
+        metadata_key   = "terraform.key1"
+        metadata_value = "terraform.value1"
+      }
+      # to update
+      item {
+        metadata_key   = "terraform.key2"
+        metadata_value = "terraform.value2"
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/logevents/testcases/update-metadata-item-set/update.tf
+++ b/dynatrace/api/builtin/logmonitoring/logevents/testcases/update-metadata-item-set/update.tf
@@ -1,0 +1,21 @@
+resource "dynatrace_log_events" "events" {
+  enabled = false
+  query   = "matchesPhrase(content, \"terratest\")"
+  summary = "Created by Terraform"
+  event_template {
+    description = "Created by Terraform"
+    event_type  = "INFO"
+    title       = "{content}"
+    metadata {
+      item {
+        metadata_key   = "terraform.key1"
+        metadata_value = "terraform.value1"
+      }
+      # updated
+      item {
+        metadata_key   = "terraform.keyEdit"
+        metadata_value = "terraform.valueEdit"
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/logstoragesettings/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/logstoragesettings/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccLogStorage(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesLogStorage(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/logmonitoring/logstoragesettings/testcases/update-matcher-set/create.tf
+++ b/dynatrace/api/builtin/logmonitoring/logstoragesettings/testcases/update-matcher-set/create.tf
@@ -1,0 +1,18 @@
+resource "dynatrace_log_storage" "storage" {
+  name            = "#name#"
+  enabled         = false
+  scope           = "HOST_GROUP-0000000000000000"
+  send_to_storage = false
+  matchers {
+    matcher {
+      attribute = "container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+    matcher {
+      attribute = "k8s.container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/logstoragesettings/testcases/update-matcher-set/update.tf
+++ b/dynatrace/api/builtin/logmonitoring/logstoragesettings/testcases/update-matcher-set/update.tf
@@ -1,0 +1,19 @@
+resource "dynatrace_log_storage" "storage" {
+  name            = "#name#"
+  enabled         = false
+  scope           = "HOST_GROUP-0000000000000000"
+  send_to_storage = false
+  matchers {
+    matcher {
+      attribute = "container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+    # update => re-create due to set-hash change
+    matcher {
+      attribute = "k8s.namespace.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTestEdit" ]
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/sensitivedatamaskingsettings/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/sensitivedatamaskingsettings/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccLogSensitiveDataMasking(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesLogSensitiveDataMasking(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/logmonitoring/sensitivedatamaskingsettings/testcases/update-matcher-set/create.tf
+++ b/dynatrace/api/builtin/logmonitoring/sensitivedatamaskingsettings/testcases/update-matcher-set/create.tf
@@ -1,0 +1,21 @@
+resource "dynatrace_log_sensitive_data_masking" "masking" {
+  name    = "#name#"
+  enabled = true
+  scope   = "environment"
+  masking {
+    type = "SHA1"
+    expression  = "FOO"
+  }
+  matchers {
+    matcher {
+      attribute = "container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+    matcher {
+      attribute = "k8s.container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/sensitivedatamaskingsettings/testcases/update-matcher-set/update.tf
+++ b/dynatrace/api/builtin/logmonitoring/sensitivedatamaskingsettings/testcases/update-matcher-set/update.tf
@@ -1,0 +1,22 @@
+resource "dynatrace_log_sensitive_data_masking" "masking" {
+  name    = "#name#"
+  enabled = true
+  scope   = "environment"
+  masking {
+    type = "SHA1"
+    expression  = "FOO"
+  }
+  matchers {
+    matcher {
+      attribute = "container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+    # update => re-create due to set-hash change
+    matcher {
+      attribute = "k8s.namespace.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTestEdit" ]
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccLogTimestamp(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesLogTimestamp(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/testcases/update-matcher-set/create.tf
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/testcases/update-matcher-set/create.tf
@@ -1,0 +1,19 @@
+resource "dynatrace_log_timestamp" "timestamp" {
+  enabled               = false
+  config_item_title = "#name#"
+  date_time_pattern = "%m/%d/%Y %I:%M:%S %p"
+  scope                 = "environment"
+  timezone              = "America/Detroit"
+  matchers {
+    matcher {
+      attribute = "container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+    matcher {
+      attribute = "k8s.container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+  }
+}

--- a/dynatrace/api/builtin/logmonitoring/timestampconfiguration/testcases/update-matcher-set/update.tf
+++ b/dynatrace/api/builtin/logmonitoring/timestampconfiguration/testcases/update-matcher-set/update.tf
@@ -1,0 +1,20 @@
+resource "dynatrace_log_timestamp" "timestamp" {
+  enabled               = false
+  config_item_title = "#name#"
+  date_time_pattern = "%m/%d/%Y %I:%M:%S %p"
+  scope                 = "environment"
+  timezone              = "America/Detroit"
+  matchers {
+    matcher {
+      attribute = "container.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTest" ]
+    }
+    # update => re-create due to set-hash change
+    matcher {
+      attribute = "k8s.namespace.name"
+      operator  = "MATCHES"
+      values    = [ "TerraformTestEdit" ]
+    }
+  }
+}

--- a/dynatrace/api/builtin/managementzones/service_test.go
+++ b/dynatrace/api/builtin/managementzones/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccManagementZones(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesManagementZones(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/managementzones/testcases/update-rule-attribute-condition-dimension-conditon-set/create.tf
+++ b/dynatrace/api/builtin/managementzones/testcases/update-rule-attribute-condition-dimension-conditon-set/create.tf
@@ -1,0 +1,88 @@
+resource "dynatrace_management_zone_v2" "zone" {
+  name = "#name#"
+  rules {
+    # not updated
+    rule {
+      type            = "ME"
+      enabled         = true
+      entity_selector = ""
+      attribute_rule {
+        entity_type = "CLOUD_APPLICATION_NAMESPACE"
+        attribute_conditions {
+          condition {
+            case_sensitive = false
+            key            = "KUBERNETES_CLUSTER_NAME"
+            operator       = "EQUALS"
+            string_value   = "extensions"
+          }
+        }
+      }
+    }
+
+    # rule will be directly updated
+    rule {
+      type            = "ME"
+      enabled         = true
+      entity_selector = ""
+      attribute_rule {
+        entity_type = "CLOUD_APPLICATION"
+        attribute_conditions {
+          condition {
+            case_sensitive = false
+            key            = "KUBERNETES_CLUSTER_NAME"
+            operator       = "EQUALS"
+            string_value   = "linkerd"
+          }
+        }
+      }
+    }
+
+    # will be updated on attribute_rule
+    rule {
+      type            = "ME"
+      enabled         = true
+      entity_selector = ""
+      attribute_rule {
+        entity_type = "CUSTOM_DEVICE"
+        attribute_conditions {
+          condition {
+            case_sensitive = false
+            key            = "CUSTOM_DEVICE_NAME"
+            operator       = "CONTAINS"
+            string_value   = "gcp"
+          }
+          condition {
+            case_sensitive = true
+            key            = "CUSTOM_DEVICE_NAME"
+            operator       = "CONTAINS"
+            string_value   = "aws"
+          }
+        }
+      }
+    }
+
+    # will be updated on dimension_rule
+    rule {
+      type            = "DIMENSION"
+      enabled         = true
+      entity_selector = ""
+      dimension_rule {
+        applies_to = "ANY"
+        dimension_conditions {
+          condition {
+            condition_type = "DIMENSION"
+            key            = "cloud.gcp"
+            rule_matcher   = "BEGINS_WITH"
+            value          = "cloud.gcp."
+          }
+          condition {
+            condition_type = "DIMENSION"
+            key            = "cloud.aws"
+            rule_matcher   = "BEGINS_WITH"
+            value          = "cloud.aws."
+          }
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/managementzones/testcases/update-rule-attribute-condition-dimension-conditon-set/update.tf
+++ b/dynatrace/api/builtin/managementzones/testcases/update-rule-attribute-condition-dimension-conditon-set/update.tf
@@ -1,0 +1,75 @@
+resource "dynatrace_management_zone_v2" "zone" {
+  name = "#name#"
+  rules {
+    # not updated
+    rule {
+      type            = "ME"
+      enabled         = true
+      attribute_rule {
+        entity_type = "CLOUD_APPLICATION_NAMESPACE"
+        attribute_conditions {
+          condition {
+            case_sensitive = false
+            key            = "KUBERNETES_CLUSTER_NAME"
+            operator       = "EQUALS"
+            string_value   = "extensions"
+          }
+        }
+      }
+    }
+
+    # rule directly updated
+    rule {
+      type            = "SELECTOR"
+      enabled         = true
+      entity_selector = "type(\"HOST\")"
+    }
+
+    # updated attribute_rule
+    rule {
+      type            = "ME"
+      enabled         = true
+      attribute_rule {
+        entity_type = "CUSTOM_DEVICE"
+        attribute_conditions {
+          condition {
+            case_sensitive = false
+            key            = "CUSTOM_DEVICE_NAME"
+            operator       = "CONTAINS"
+            string_value   = "gcp"
+          }
+          condition {
+            case_sensitive = true
+            key            = "CUSTOM_DEVICE_NAME"
+            operator       = "CONTAINS"
+            string_value   = "aws.edit"
+          }
+        }
+      }
+    }
+
+    # updated dimension_rule
+    rule {
+      type            = "DIMENSION"
+      enabled         = true
+      entity_selector = ""
+      dimension_rule {
+        applies_to = "ANY"
+        dimension_conditions {
+          condition {
+            condition_type = "DIMENSION"
+            key            = "cloud.gcp"
+            rule_matcher   = "BEGINS_WITH"
+            value          = "cloud.gcp."
+          }
+          condition {
+            condition_type = "DIMENSION"
+            key            = "cloud.aws.edit"
+            rule_matcher   = "BEGINS_WITH"
+            value          = "cloud.aws.edit"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/service_test.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccGenericRelationships(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesGenericRelationships(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/settings/source_filter.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/settings/source_filter.go
@@ -19,6 +19,7 @@ package relation
 
 import (
 	"fmt"
+	"reflect"
 	"slices"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
@@ -44,7 +45,11 @@ func (me SourceFilters) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *SourceFilters) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("source", me)
+	if err := decoder.DecodeSlice("source", me); err != nil {
+		return err
+	}
+	*me = hcl.FilterEmpty(*me, SourceFilter{})
+	return nil
 }
 
 // Source filter. The source filter determines based on which data the relationship should be created. This way a subset of a specified data source can be used for creating the type.
@@ -86,6 +91,11 @@ func (me *SourceFilter) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *SourceFilter) HandlePreconditions() error {
+	var emptyItem SourceFilter
+	// ignore/don't throw on empty item that is coming from the TypeSet bug
+	if reflect.DeepEqual(*me, emptyItem) {
+		return nil
+	}
 	if (me.Condition == nil) && (!slices.Contains([]string{"Logs", "Spans", "Entities", "Topology", "Business Events"}, string(me.SourceType))) {
 		return fmt.Errorf("'condition' must be specified if 'source_type' is set to '%v'", me.SourceType)
 	}

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/testcases/update-mapping-rule-source-filter-set/create.tf
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/testcases/update-mapping-rule-source-filter-set/create.tf
@@ -1,0 +1,38 @@
+resource "dynatrace_generic_relationships" "relationship" {
+  enabled          = true
+  created_by       = "Terraform"
+  from_role        = "terraformrole"
+  from_type        = "os:service"
+  to_role          = "terraformrole"
+  to_type          = "terraformdestination"
+  type_of_relation = "PART_OF"
+  sources {
+    source {
+      condition   = "$eq(terraform)"
+      source_type = "Metrics"
+    }
+    # update source directly
+    source {
+      condition   = "$eq(terraform2)"
+      source_type = "Metrics"
+    }
+    # update mapping rules
+    source {
+      source_type = "Entities"
+      mapping_rules {
+        mapping_rule {
+          destination_property       = "dest1"
+          destination_transformation = "Leave text as-is"
+          source_property            = "source1"
+          source_transformation      = "Leave text as-is"
+        }
+        mapping_rule {
+          destination_property       = "dest2"
+          destination_transformation = "Leave text as-is"
+          source_property            = "source2"
+          source_transformation      = "Leave text as-is"
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/monitoredentities/generic/relation/testcases/update-mapping-rule-source-filter-set/update.tf
+++ b/dynatrace/api/builtin/monitoredentities/generic/relation/testcases/update-mapping-rule-source-filter-set/update.tf
@@ -1,0 +1,38 @@
+resource "dynatrace_generic_relationships" "relationship" {
+  enabled          = true
+  created_by       = "Terraform"
+  from_role        = "terraformrole"
+  from_type        = "os:service"
+  to_role          = "terraformrole"
+  to_type          = "terraformdestination"
+  type_of_relation = "PART_OF"
+  sources {
+    source {
+      condition   = "$eq(terraform)"
+      source_type = "Metrics"
+    }
+    # update source directly
+    source {
+      condition   = "$eq(terraformEdit)"
+      source_type = "Metrics"
+    }
+    # update mapping rules
+    source {
+      source_type = "Entities"
+      mapping_rules {
+        mapping_rule {
+          destination_property       = "dest1"
+          destination_transformation = "Leave text as-is"
+          source_property            = "source1"
+          source_transformation      = "Leave text as-is"
+        }
+        mapping_rule {
+          destination_property       = "destEdit"
+          destination_transformation = "Leave text as-is"
+          source_property            = "sourceEdit"
+          source_transformation      = "Leave text as-is"
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/monitoredentities/generic/type/service_test.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/type/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccGenericTypes(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesGenericTypes(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/monitoredentities/generic/type/settings/attribute_entry.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/type/settings/attribute_entry.go
@@ -41,7 +41,11 @@ func (me AttributeEntries) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *AttributeEntries) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("attribute", me)
+	if err := decoder.DecodeSlice("attribute", me); err != nil {
+		return err
+	}
+	*me = hcl.FilterEmpty(*me, AttributeEntry{})
+	return nil
 }
 
 // Attribute entry. Describe how an attribute is extracted from ingest data.

--- a/dynatrace/api/builtin/monitoredentities/generic/type/settings/dimension_filter.go
+++ b/dynatrace/api/builtin/monitoredentities/generic/type/settings/dimension_filter.go
@@ -41,7 +41,11 @@ func (me DimensionFilters) MarshalHCL(properties hcl.Properties) error {
 }
 
 func (me *DimensionFilters) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("required_dimension", me)
+	if err := decoder.DecodeSlice("required_dimension", me); err != nil {
+		return err
+	}
+	*me = hcl.FilterEmpty(*me, DimensionFilter{})
+	return nil
 }
 
 // Ingest dimension filter. A dimension describes a property key which is present in the ingest data.

--- a/dynatrace/api/builtin/monitoredentities/generic/type/testcases/update-filter-and-entry-sets/create.tf
+++ b/dynatrace/api/builtin/monitoredentities/generic/type/testcases/update-filter-and-entry-sets/create.tf
@@ -1,0 +1,44 @@
+resource "dynatrace_generic_types" "types" {
+  name         = "terraform:type"
+  enabled      = true
+  created_by   = "Terraform"
+  display_name = "TerraformTest"
+  rules {
+    rule {
+      icon_pattern          = "{TerraformIcon}"
+      id_pattern            = "{TerraformPlaceholder}"
+      instance_name_pattern = "{TerraformInstance}"
+      # update sources set
+      sources {
+        source {
+          condition   = "$eq(TerraformCondition1)"
+          source_type = "Events"
+        }
+        source {
+          condition   = "$eq(TerraformCondition2)"
+          source_type = "Events"
+        }
+      }
+      # update attributes set
+      attributes {
+        attribute {
+          key     = "TerraformAttribute1"
+          pattern = "{TerraformExtraction1}"
+        }
+        attribute {
+          key     = "TerraformAttribute2"
+          pattern = "{TerraformExtraction2}"
+        }
+      }
+      # update required dimensions set
+      required_dimensions {
+        required_dimension {
+          key = "TerraformDimension1"
+        }
+        required_dimension {
+          key = "TerraformDimension2"
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/builtin/monitoredentities/generic/type/testcases/update-filter-and-entry-sets/update.tf
+++ b/dynatrace/api/builtin/monitoredentities/generic/type/testcases/update-filter-and-entry-sets/update.tf
@@ -1,0 +1,44 @@
+resource "dynatrace_generic_types" "types" {
+  name         = "terraform:type"
+  enabled      = true
+  created_by   = "Terraform"
+  display_name = "TerraformTest"
+  rules {
+    rule {
+      icon_pattern          = "{TerraformIcon}"
+      id_pattern            = "{TerraformPlaceholder}"
+      instance_name_pattern = "{TerraformInstance}"
+      # update sources set
+      sources {
+        source {
+          condition   = "$eq(TerraformCondition1)"
+          source_type = "Events"
+        }
+        source {
+          condition   = "$eq(TerraformConditionEdit)"
+          source_type = "Events"
+        }
+      }
+      # update attributes set
+      attributes {
+        attribute {
+          key     = "TerraformAttribute1"
+          pattern = "{TerraformExtraction1}"
+        }
+        attribute {
+          key     = "TerraformEdit"
+          pattern = "{TerraformExtraction2}"
+        }
+      }
+      # update required dimensions set
+      required_dimensions {
+        required_dimension {
+          key = "TerraformDimension1"
+        }
+        required_dimension {
+          key = "TerraformDimensionEdit"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
We have a lot of `TypeSet` usages with potential bugs coming from the plugin SDK.
This is part 2 of several, where tests for all TypeSet fields are added and potential bugs are fixed.

#### **What** has changed?
TypeSet bugs fixed and tests added for all TypeSet usages except deprecated resources.
This covers the `api/builtin` folder from A to M

#### **How** does it do it?
By using our generic filterEmpty function to filter empty items and by adding tests that update TypeSet fields.

#### How is it **tested**?
Tests added that would produce the empty Set item.

#### How does it affect **users**?
More stable resources. Fixing several existing problems.

**Issue:** CA-19022
