### PR TITLE
feat: Update `dynatrace_k8s_cluster_anomalies` resource

### DIFF
--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/schema.json
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/schema.json
@@ -3,11 +3,12 @@
 		"KUBERNETES_CLUSTER",
 		"environment"
 	],
-	"description": "Dynatrace automatically detects a wide range of common Kubernetes-related issues. Use these settings to configure alerts relevant to your Kubernetes cluster. Changing thresholds resets the observation period.",
+	"description": "Dynatrace automatically detects a wide range of common Kubernetes-related issues. Use these settings to configure alerts relevant to your Kubernetes cluster. Changing thresholds resets the observation period. Additional information can be found on our [documentation page](https://dt-url.net/wq02okj#cluster).",
 	"displayName": "Kubernetes cluster anomaly detection",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1,
 	"metadata": {
 		"minActiveGateVersion": "1.253"

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/service.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 package cluster
 
 import (
-	cluster "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
@@ -27,6 +27,6 @@ import (
 const SchemaVersion = "1.4"
 const SchemaID = "builtin:anomaly-detection.kubernetes.cluster"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*cluster.Settings] {
-	return settings20.Service[*cluster.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/cpu_requests_saturation.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/cpu_requests_saturation.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -32,11 +34,10 @@ func (me *CpuRequestsSaturation) Schema() map[string]*schema.Schema {
 		"configuration": {
 			Type:        schema.TypeList,
 			Description: "Alert if",
-			Optional:    true,
-
-			Elem:     &schema.Resource{Schema: new(CpuRequestsSaturationConfig).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(CpuRequestsSaturationConfig).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
@@ -51,6 +52,16 @@ func (me *CpuRequestsSaturation) MarshalHCL(properties hcl.Properties) error {
 		"configuration": me.Configuration,
 		"enabled":       me.Enabled,
 	})
+}
+
+func (me *CpuRequestsSaturation) HandlePreconditions() error {
+	if (me.Configuration == nil) && (me.Enabled) {
+		return fmt.Errorf("'configuration' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.Configuration != nil) && (!me.Enabled) {
+		return fmt.Errorf("'configuration' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *CpuRequestsSaturation) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/cpu_requests_saturation_config.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/cpu_requests_saturation_config.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/memory_requests_saturation.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/memory_requests_saturation.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -32,11 +34,10 @@ func (me *MemoryRequestsSaturation) Schema() map[string]*schema.Schema {
 		"configuration": {
 			Type:        schema.TypeList,
 			Description: "Alert if",
-			Optional:    true,
-
-			Elem:     &schema.Resource{Schema: new(MemoryRequestsSaturationConfig).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(MemoryRequestsSaturationConfig).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
@@ -51,6 +52,16 @@ func (me *MemoryRequestsSaturation) MarshalHCL(properties hcl.Properties) error 
 		"configuration": me.Configuration,
 		"enabled":       me.Enabled,
 	})
+}
+
+func (me *MemoryRequestsSaturation) HandlePreconditions() error {
+	if (me.Configuration == nil) && (me.Enabled) {
+		return fmt.Errorf("'configuration' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.Configuration != nil) && (!me.Enabled) {
+		return fmt.Errorf("'configuration' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *MemoryRequestsSaturation) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/memory_requests_saturation_config.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/memory_requests_saturation_config.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/monitoring_issues.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/monitoring_issues.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -32,11 +34,10 @@ func (me *MonitoringIssues) Schema() map[string]*schema.Schema {
 		"configuration": {
 			Type:        schema.TypeList,
 			Description: "Alert if",
-			Optional:    true,
-
-			Elem:     &schema.Resource{Schema: new(MonitoringIssuesConfig).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(MonitoringIssuesConfig).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
@@ -51,6 +52,16 @@ func (me *MonitoringIssues) MarshalHCL(properties hcl.Properties) error {
 		"configuration": me.Configuration,
 		"enabled":       me.Enabled,
 	})
+}
+
+func (me *MonitoringIssues) HandlePreconditions() error {
+	if (me.Configuration == nil) && (me.Enabled) {
+		return fmt.Errorf("'configuration' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.Configuration != nil) && (!me.Enabled) {
+		return fmt.Errorf("'configuration' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *MonitoringIssues) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/monitoring_issues_config.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/monitoring_issues_config.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/pods_saturation.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/pods_saturation.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -32,11 +34,10 @@ func (me *PodsSaturation) Schema() map[string]*schema.Schema {
 		"configuration": {
 			Type:        schema.TypeList,
 			Description: "Alert if",
-			Optional:    true,
-
-			Elem:     &schema.Resource{Schema: new(PodsSaturationConfig).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(PodsSaturationConfig).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
@@ -51,6 +52,16 @@ func (me *PodsSaturation) MarshalHCL(properties hcl.Properties) error {
 		"configuration": me.Configuration,
 		"enabled":       me.Enabled,
 	})
+}
+
+func (me *PodsSaturation) HandlePreconditions() error {
+	if (me.Configuration == nil) && (me.Enabled) {
+		return fmt.Errorf("'configuration' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.Configuration != nil) && (!me.Enabled) {
+		return fmt.Errorf("'configuration' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *PodsSaturation) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/pods_saturation_config.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/pods_saturation_config.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/readiness_issues.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/readiness_issues.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -32,11 +34,10 @@ func (me *ReadinessIssues) Schema() map[string]*schema.Schema {
 		"configuration": {
 			Type:        schema.TypeList,
 			Description: "Alert if",
-			Optional:    true,
-
-			Elem:     &schema.Resource{Schema: new(ReadinessIssuesConfig).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(ReadinessIssuesConfig).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"enabled": {
 			Type:        schema.TypeBool,
@@ -51,6 +52,16 @@ func (me *ReadinessIssues) MarshalHCL(properties hcl.Properties) error {
 		"configuration": me.Configuration,
 		"enabled":       me.Enabled,
 	})
+}
+
+func (me *ReadinessIssues) HandlePreconditions() error {
+	if (me.Configuration == nil) && (me.Enabled) {
+		return fmt.Errorf("'configuration' must be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	if (me.Configuration != nil) && (!me.Enabled) {
+		return fmt.Errorf("'configuration' must not be specified if 'enabled' is set to '%v'", me.Enabled)
+	}
+	return nil
 }
 
 func (me *ReadinessIssues) UnmarshalHCL(decoder hcl.Decoder) error {

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/readiness_issues_config.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/readiness_issues_config.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/settings.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,48 +39,43 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"cpu_requests_saturation": {
 			Type:        schema.TypeList,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(CpuRequestsSaturation).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(CpuRequestsSaturation).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"memory_requests_saturation": {
 			Type:        schema.TypeList,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(MemoryRequestsSaturation).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(MemoryRequestsSaturation).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"monitoring_issues": {
 			Type:        schema.TypeList,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(MonitoringIssues).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(MonitoringIssues).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"pods_saturation": {
 			Type:        schema.TypeList,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(PodsSaturation).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(PodsSaturation).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"readiness_issues": {
 			Type:        schema.TypeList,
 			Description: "Alerts if cluster has not been ready for a given amount of time",
 			Required:    true,
-
-			Elem:     &schema.Resource{Schema: new(ReadinessIssues).Schema()},
-			MinItems: 1,
-			MaxItems: 1,
+			Elem:        &schema.Resource{Schema: new(ReadinessIssues).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
 		},
 		"scope": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
#### **Why** this PR?
While the resource was already generated for `builtin:anomaly-detection.kubernetes.cluster` version `1.4`, re-generating it adds `HandlePreconditions()` implementations for `cpu_requests_saturation`, `memory_requests_saturation`, `monitoring_issues`, `pods_saturation`, and `readiness_issues` blocks.

#### **What** has changed and **how** does it do it?
The additional `HandlePreconditions()` implementations for `cpu_requests_saturation`, `memory_requests_saturation`, `monitoring_issues`, `pods_saturation`, and `readiness_issues` require a `configuration` to be supplied if  `enabled` is set to `true` or not supplied if `enabled` is `false`.

#### How is it **tested**?
Existing tests.

#### How does it affect **users**?
Users will receive feedback if a `configuration` is supplied when a block is not enabled, or are missing if enabled, for example:

```
Error: monitoring_issues.0: 'configuration' must not be specified if 'enabled' is set to 'false'
```

or

```
│ Error: monitoring_issues.0: 'configuration' must be specified if 'enabled' is set to 'true'
```

**Issue:** CA-19128
