### PR TITLE
feat: Update `dynatrace_disk_edge_anomaly_detectors` resource

### DIFF
--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/schema.json
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/schema.json
@@ -4,11 +4,47 @@
 		"HOST_GROUP",
 		"environment"
 	],
-	"description": "The *Disk Edge* feature within Dynatrace provides automatic detection of performance anomalies related to disk infrastructure.\nUse these settings to tailor detection sensitivity to a specific disk's name and/or custom metadata. Defining custom properties can help with post processing of the event. \n\n**Policy Hierarchy and Scope**\n\nThe order of policies establishes a hierarchical structure. Disk is assigned to the first policy it matches to (based on disk name and/or metadata) according  to the policies hierarchy.\n\nPolicies  can be defined within Host, Host Group and Tenant scope. Lower scope has priority over the higher one.\n\nTo learn more about Disk Edge visit its [official documentation](https://dt-url.net/diskEdgeDoc).",
+	"description": "The *Disk Edge* feature within Dynatrace provides automatic detection of performance anomalies related to disk infrastructure.\nUse these settings to tailor detection sensitivity based on disk characteristics such as disk name, total space, filesystem type, disk type, and/or custom metadata. Defining custom properties can help with post processing of the event. \n\n**Policy Hierarchy and Scope**\n\nThe order of policies establishes a hierarchical structure. Disk is assigned to the first policy it matches to (based on disk name, total space, filesystem type, disk type, and/or metadata) according  to the policies hierarchy.\n\nPolicies  can be defined within Host, Host Group and Tenant scope. Lower scope has priority over the higher one.\n\nTo learn more about Disk Edge visit its [official documentation](https://dt-url.net/diskEdgeDoc).",
 	"displayName": "Anomaly detection for infrastructure: Disk Edge",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
+		"DiskProp": {
+			"description": "",
+			"displayName": "DiskItem",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Total Space",
+					"value": "DiskTotalSpace"
+				},
+				{
+					"displayName": "Filesystem",
+					"value": "DiskFilesystem"
+				},
+				{
+					"displayName": "Type",
+					"value": "DiskType"
+				}
+			],
+			"type": "enum"
+		},
+		"DiskType": {
+			"description": "",
+			"displayName": "Disk Type",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Local",
+					"value": "LOCAL"
+				},
+				{
+					"displayName": "Remote",
+					"value": "REMOTE"
+				}
+			],
+			"type": "enum"
+		},
 		"EOperatingSystem": {
 			"description": "",
 			"displayName": "Operating System",
@@ -25,6 +61,22 @@
 				{
 					"displayName": "AIX",
 					"value": "AIX"
+				}
+			],
+			"type": "enum"
+		},
+		"RuleType": {
+			"description": "",
+			"displayName": "Rule scope",
+			"documentation": "",
+			"items": [
+				{
+					"displayName": "Disk",
+					"value": "RuleTypeDisk"
+				},
+				{
+					"displayName": "Host",
+					"value": "RuleTypeHost"
 				}
 			],
 			"type": "enum"
@@ -66,6 +118,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "GENERAL_AVAILABILITY",
 	"maxObjects": 1000,
 	"metadata": {
 		"addItemButton": "Add policy",
@@ -105,6 +158,36 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "set"
+		},
+		"detectionConditions": {
+			"constraints": [
+				{
+					"customMessage": "Duplicate disk property.",
+					"customValidatorId": "uniqueDiskPropertyValidator",
+					"skipAsyncValidation": false,
+					"type": "CUSTOM_VALIDATOR_REF"
+				}
+			],
+			"description": "Set of rules to scope which disks the policy applies to. Rules can match based on disk properties (total space, filesystem, disk type) or host resource attributes. Each disk property type can be defined at most once per policy.",
+			"displayName": "Detection rules",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/detectionCondition"
+				}
+			},
+			"maxObjects": 33,
+			"metadata": {
+				"addItemButton": "Add rule",
+				"itemDisplayName": "New rule"
+			},
+			"minObjects": 0,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "list"
 		},
 		"diskNameFilters": {
 			"description": "Disk will be included in this policy if **any** of the filters match",
@@ -165,28 +248,6 @@
 			"metadata": {
 				"addItemButton": "Add Property",
 				"itemDisplayName": "New property"
-			},
-			"minObjects": 0,
-			"modificationPolicy": "DEFAULT",
-			"nullable": false,
-			"type": "set"
-		},
-		"hostMetadataConditions": {
-			"description": "",
-			"displayName": "Host resource attributes conditions",
-			"documentation": "Host resource attributes are dimensions enriching the host including custom metadata which are user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\nBy defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\nSee [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).\n\nNote: Starting from version 1.325 host resource attributes are supported in addition to host custom metadata.",
-			"items": {
-				"description": "",
-				"displayName": "Resource attribute",
-				"documentation": "",
-				"type": {
-					"$ref": "#/types/HostMetadataConditionType"
-				}
-			},
-			"maxObjects": 30,
-			"metadata": {
-				"addItemButton": "Add condition",
-				"itemDisplayName": "New condition"
 			},
 			"minObjects": 0,
 			"modificationPolicy": "DEFAULT",
@@ -454,6 +515,62 @@
 				}
 			},
 			"summaryPattern": "{trigger} {thresholdPercent}{thresholdMilliseconds}{thresholdMebibytes}{thresholdNumber}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"DiskTotalSpaceThresholds": {
+			"constraints": [
+				{
+					"customValidatorId": "diskTotalSpaceThresholdsValidator",
+					"skipAsyncValidation": false,
+					"type": "CUSTOM_VALIDATOR_REF"
+				}
+			],
+			"description": "",
+			"displayName": "DiskTotalSpaceThresholds",
+			"documentation": "",
+			"properties": {
+				"thresholdAbove": {
+					"constraints": [
+						{
+							"minimum": 0,
+							"type": "RANGE"
+						}
+					],
+					"description": "If this field is empty then there is no lower limit",
+					"displayName": "Threshold above (optional)",
+					"documentation": "Minimum total disk space in GiB",
+					"maxObjects": 1,
+					"metadata": {
+						"placeholder": "ex. 10",
+						"suffix": "GiB"
+					},
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "integer"
+				},
+				"thresholdBelow": {
+					"constraints": [
+						{
+							"minimum": 0,
+							"type": "RANGE"
+						}
+					],
+					"description": "If this field is empty then there is no upper limit",
+					"displayName": "Threshold below (optional)",
+					"documentation": "Maximum total disk space in GiB",
+					"maxObjects": 1,
+					"metadata": {
+						"placeholder": "ex. 10000",
+						"suffix": "GiB"
+					},
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"type": "integer"
+				}
+			},
+			"summaryPattern": "",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
@@ -797,7 +914,171 @@
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
+		},
+		"detectionCondition": {
+			"description": "",
+			"displayName": "",
+			"documentation": "",
+			"properties": {
+				"diskFilesystemCondition": {
+					"constraints": [
+						{
+							"maxLength": 100,
+							"minLength": 1,
+							"type": "LENGTH"
+						},
+						{
+							"customMessage": "This value does not match the required format.",
+							"customValidatorId": "ConditionGeneralRule",
+							"skipAsyncValidation": false,
+							"type": "CUSTOM_VALIDATOR_REF"
+						}
+					],
+					"default": "",
+					"description": "Disk filesystem will be included in this policy if **any** of the filters match",
+					"displayName": "Filesystem condition",
+					"documentation": "Disk filesystem has to match a required format.\n\n- `$match(ext*)` – Matches string with wildcards: `*` any number (including zero) of characters and `?` exactly one character.\n- `$contains(fs)` – Matches if `fs` appears anywhere in the filesystem type.\n- `$eq(ext4)` – Matches if `ext4` matches the filesystem type exactly.\n- `$prefix(ext)` – Matches if `ext` matches the prefix of the filesystem type.\n- `$suffix(fs)` – Matches if `fs` matches the suffix of the filesystem type.\n\nAvailable logic operations:\n- `$not($eq(tmpfs))` – Matches if the filesystem type is different from `tmpfs`.\n- `$and($prefix(ext),$suffix(4))` – Matches if filesystem type starts with `ext` and ends with `4`.\n- `$or($eq(xfs),$eq(btrfs))` – Matches if filesystem type equals `xfs` or `btrfs`.\n\nBrackets **(** and **)** that are part of the matched filesystem type **must be escaped with a tilde (~)**",
+					"maxObjects": 1,
+					"metadata": {
+						"minAgentVersion": "1.335"
+					},
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"preconditions": [
+							{
+								"expectedValue": "RuleTypeDisk",
+								"property": "ruleType",
+								"type": "EQUALS"
+							},
+							{
+								"expectedValue": "DiskFilesystem",
+								"property": "property",
+								"type": "EQUALS"
+							}
+						],
+						"type": "AND"
+					},
+					"type": "text"
+				},
+				"diskTotalCondition": {
+					"description": "",
+					"displayName": "Disk total space thresholds",
+					"documentation": "Specify disk total space range in GiB",
+					"maxObjects": 1,
+					"metadata": {
+						"minAgentVersion": "1.335"
+					},
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"preconditions": [
+							{
+								"expectedValue": "RuleTypeDisk",
+								"property": "ruleType",
+								"type": "EQUALS"
+							},
+							{
+								"expectedValue": "DiskTotalSpace",
+								"property": "property",
+								"type": "EQUALS"
+							}
+						],
+						"type": "AND"
+					},
+					"type": {
+						"$ref": "#/types/DiskTotalSpaceThresholds"
+					}
+				},
+				"hostMetadataCondition": {
+					"description": "",
+					"displayName": "Resource attribute",
+					"documentation": "Host resource attributes are dimensions enriching the host including custom metadata which are user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\nBy defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\nSee [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).\n\nNote: Starting from version 1.325 host resource attributes are supported in addition to host custom metadata.",
+					"maxObjects": 1,
+					"metadata": {
+						"minAgentVersion": "1.277"
+					},
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValues": [
+							"RuleTypeHost"
+						],
+						"property": "ruleType",
+						"type": "IN"
+					},
+					"type": {
+						"$ref": "#/types/HostMetadataConditionType"
+					}
+				},
+				"localDiskCondition": {
+					"default": "LOCAL",
+					"description": "",
+					"displayName": "",
+					"documentation": "",
+					"maxObjects": 1,
+					"metadata": {
+						"minAgentVersion": "1.335"
+					},
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"preconditions": [
+							{
+								"expectedValue": "RuleTypeDisk",
+								"property": "ruleType",
+								"type": "EQUALS"
+							},
+							{
+								"expectedValue": "DiskType",
+								"property": "property",
+								"type": "EQUALS"
+							}
+						],
+						"type": "AND"
+					},
+					"type": {
+						"$ref": "#/enums/DiskType"
+					}
+				},
+				"property": {
+					"default": "DiskTotalSpace",
+					"description": "",
+					"displayName": "Disk property",
+					"documentation": "",
+					"maxObjects": 1,
+					"metadata": {
+						"minAgentVersion": "1.335"
+					},
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"precondition": {
+						"expectedValue": "RuleTypeDisk",
+						"property": "ruleType",
+						"type": "EQUALS"
+					},
+					"type": {
+						"$ref": "#/enums/DiskProp"
+					}
+				},
+				"ruleType": {
+					"default": "RuleTypeDisk",
+					"description": "",
+					"displayName": "Rule scope",
+					"documentation": "Starting from agent 1.335 **disk** detection rules are supported.",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/enums/RuleType"
+					}
+				}
+			},
+			"summaryPattern": "{ruleType}: {property} {diskTotalCondition}{diskFilesystemCondition}{localDiskCondition}{hostMetadataCondition}",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
 		}
 	},
-	"version": "0.0.20"
+	"version": "0.1"
 }

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/service.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/service.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@
 package anomalydetectors
 
 import (
-	anomalydetectors "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.0.20"
+const SchemaVersion = "0.1"
 const SchemaID = "builtin:infrastructure.disk.edge.anomaly-detectors"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*anomalydetectors.Settings] {
-	return settings20.Service[*anomalydetectors.Settings](credentials, SchemaID, SchemaVersion)
+func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
+	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/alert.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/alert.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ func (me *Alert) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"sample_count_thresholds": {
 			Type:        schema.TypeList,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SampleCountThresholds).Schema()},
 			MinItems:    1,
@@ -70,7 +70,7 @@ func (me *Alert) Schema() map[string]*schema.Schema {
 		},
 		"sample_count_thresholds_immediately": {
 			Type:        schema.TypeList,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Optional:    true, // precondition
 			Elem:        &schema.Resource{Schema: new(SampleCountThresholdsImmediately).Schema()},
 			MinItems:    1,
@@ -78,22 +78,22 @@ func (me *Alert) Schema() map[string]*schema.Schema {
 		},
 		"threshold_mebibytes": {
 			Type:        schema.TypeFloat,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Optional:    true, // precondition
 		},
 		"threshold_milliseconds": {
 			Type:        schema.TypeFloat,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Optional:    true, // precondition
 		},
 		"threshold_number": {
 			Type:        schema.TypeFloat,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Optional:    true, // precondition
 		},
 		"threshold_percent": {
 			Type:        schema.TypeFloat,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Optional:    true, // precondition
 		},
 		"trigger": {

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/detection_condition.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/detection_condition.go
@@ -1,0 +1,154 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package anomalydetectors
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type DetectionConditions []*DetectionCondition
+
+func (me *DetectionConditions) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"detection_condition": {
+			Type:        schema.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(DetectionCondition).Schema()},
+		},
+	}
+}
+
+func (me DetectionConditions) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("detection_condition", me)
+}
+
+func (me *DetectionConditions) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("detection_condition", me)
+}
+
+type DetectionCondition struct {
+	DiskFilesystemCondition *string                    `json:"diskFilesystemCondition,omitempty"` // Disk filesystem will be included in this policy if **any** of the filters match. Disk filesystem has to match a required format.\n\n  - `$match(ext*)` – Matches string with wildcards: `*` any number (including zero) of characters and `?` exactly one character.\n - `$contains(fs)` – Matches if `fs` appears anywhere in the filesystem type.\n - `$eq(ext4)` – Matches if `ext4` matches the filesystem type exactly.\n - `$prefix(ext)` – Matches if `ext` matches the prefix of the filesystem type.\n - `$suffix(fs)` – Matches if `fs` matches the suffix of the filesystem type.\n\n  Available logic operations:\n - `$not($eq(tmpfs))` – Matches if the filesystem type is different from `tmpfs`.\n - `$and($prefix(ext),$suffix(4))` – Matches if filesystem type starts with `ext` and ends with `4`.\n - `$or($eq(xfs),$eq(btrfs))` – Matches if filesystem type equals `xfs` or `btrfs`.\n\n  Brackets **(** and **)** that are part of the matched filesystem type **must be escaped with a tilde (~)**
+	DiskTotalCondition      *DiskTotalSpaceThresholds  `json:"diskTotalCondition,omitempty"`      // Specify disk total space range in GiB
+	HostMetadataCondition   *HostMetadataConditionType `json:"hostMetadataCondition,omitempty"`   // Host resource attributes are dimensions enriching the host including custom metadata which are user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\n  By defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\n  See [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).\n\n  Note: Starting from version 1.325 host resource attributes are supported in addition to host custom metadata.
+	LocalDiskCondition      *DiskType                  `json:"localDiskCondition,omitempty"`      // Possible values: `LOCAL`, `REMOTE`
+	Property                *DiskProp                  `json:"property,omitempty"`                // Disk property. Possible values: `DiskFilesystem`, `DiskTotalSpace`, `DiskType`
+	RuleType                RuleType                   `json:"ruleType"`                          // Starting from agent 1.335 **disk** detection rules are supported. Possible values: `RuleTypeDisk`, `RuleTypeHost`
+}
+
+func (me *DetectionCondition) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"disk_filesystem_condition": {
+			Type:        schema.TypeString,
+			Description: "Disk filesystem will be included in this policy if **any** of the filters match. Disk filesystem has to match a required format.\n\n  - `$match(ext*)` – Matches string with wildcards: `*` any number (including zero) of characters and `?` exactly one character.\n - `$contains(fs)` – Matches if `fs` appears anywhere in the filesystem type.\n - `$eq(ext4)` – Matches if `ext4` matches the filesystem type exactly.\n - `$prefix(ext)` – Matches if `ext` matches the prefix of the filesystem type.\n - `$suffix(fs)` – Matches if `fs` matches the suffix of the filesystem type.\n\n  Available logic operations:\n - `$not($eq(tmpfs))` – Matches if the filesystem type is different from `tmpfs`.\n - `$and($prefix(ext),$suffix(4))` – Matches if filesystem type starts with `ext` and ends with `4`.\n - `$or($eq(xfs),$eq(btrfs))` – Matches if filesystem type equals `xfs` or `btrfs`.\n\n  Brackets **(** and **)** that are part of the matched filesystem type **must be escaped with a tilde (~)**",
+			Optional:    true, // precondition
+		},
+		"disk_total_condition": {
+			Type:        schema.TypeList,
+			Description: "Specify disk total space range in GiB",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(DiskTotalSpaceThresholds).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"host_metadata_condition": {
+			Type:        schema.TypeList,
+			Description: "Host resource attributes are dimensions enriching the host including custom metadata which are user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\n  By defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\n  See [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).\n\n  Note: Starting from version 1.325 host resource attributes are supported in addition to host custom metadata.",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(HostMetadataConditionType).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+		"local_disk_condition": {
+			Type:        schema.TypeString,
+			Description: "Possible values: `LOCAL`, `REMOTE`",
+			Optional:    true, // precondition
+		},
+		"property": {
+			Type:        schema.TypeString,
+			Description: "Disk property. Possible values: `DiskFilesystem`, `DiskTotalSpace`, `DiskType`",
+			Optional:    true, // precondition
+		},
+		"rule_type": {
+			Type:        schema.TypeString,
+			Description: "Starting from agent 1.335 **disk** detection rules are supported. Possible values: `RuleTypeDisk`, `RuleTypeHost`",
+			Required:    true,
+		},
+	}
+}
+
+func (me *DetectionCondition) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"disk_filesystem_condition": me.DiskFilesystemCondition,
+		"disk_total_condition":      me.DiskTotalCondition,
+		"host_metadata_condition":   me.HostMetadataCondition,
+		"local_disk_condition":      me.LocalDiskCondition,
+		"property":                  me.Property,
+		"rule_type":                 me.RuleType,
+	})
+}
+
+func (me *DetectionCondition) HandlePreconditions() error {
+	if (me.DiskFilesystemCondition == nil) && ((string(me.RuleType) == "RuleTypeDisk") && (me.Property != nil && (string(*me.Property) == "DiskFilesystem"))) {
+		return fmt.Errorf("'disk_filesystem_condition' must be specified if 'rule_type' is set to '%v' and 'property' is set to '%v'", me.RuleType, me.Property)
+	}
+	if (me.DiskFilesystemCondition != nil) && ((string(me.RuleType) != "RuleTypeDisk") || (me.Property == nil || (me.Property != nil && string(*me.Property) != "DiskFilesystem"))) {
+		return fmt.Errorf("'disk_filesystem_condition' must not be specified if 'rule_type' is set to '%v'", me.RuleType)
+	}
+	if (me.DiskTotalCondition == nil) && ((string(me.RuleType) == "RuleTypeDisk") && (me.Property != nil && (string(*me.Property) == "DiskTotalSpace"))) {
+		return fmt.Errorf("'disk_total_condition' must be specified if 'rule_type' is set to '%v' and 'property' is set to '%v'", me.RuleType, me.Property)
+	}
+	if (me.DiskTotalCondition != nil) && ((string(me.RuleType) != "RuleTypeDisk") || (me.Property == nil || (me.Property != nil && string(*me.Property) != "DiskTotalSpace"))) {
+		return fmt.Errorf("'disk_total_condition' must not be specified if 'rule_type' is set to '%v'", me.RuleType)
+	}
+	if (me.HostMetadataCondition == nil) && (slices.Contains([]string{"RuleTypeHost"}, string(me.RuleType))) {
+		return fmt.Errorf("'host_metadata_condition' must be specified if 'rule_type' is set to '%v'", me.RuleType)
+	}
+	if (me.HostMetadataCondition != nil) && (!slices.Contains([]string{"RuleTypeHost"}, string(me.RuleType))) {
+		return fmt.Errorf("'host_metadata_condition' must not be specified if 'rule_type' is set to '%v'", me.RuleType)
+	}
+	if (me.LocalDiskCondition == nil) && ((string(me.RuleType) == "RuleTypeDisk") && (me.Property != nil && (string(*me.Property) == "DiskType"))) {
+		return fmt.Errorf("'local_disk_condition' must be specified if 'rule_type' is set to '%v' and 'property' is set to '%v'", me.RuleType, me.Property)
+	}
+	if (me.LocalDiskCondition != nil) && ((string(me.RuleType) != "RuleTypeDisk") || (me.Property == nil || (me.Property != nil && string(*me.Property) != "DiskType"))) {
+		return fmt.Errorf("'local_disk_condition' must not be specified if 'rule_type' is set to '%v'", me.RuleType)
+	}
+	if (me.Property == nil) && (string(me.RuleType) == "RuleTypeDisk") {
+		return fmt.Errorf("'property' must be specified if 'rule_type' is set to '%v'", me.RuleType)
+	}
+	if (me.Property != nil) && (string(me.RuleType) != "RuleTypeDisk") {
+		return fmt.Errorf("'property' must not be specified if 'rule_type' is set to '%v'", me.RuleType)
+	}
+	return nil
+}
+
+func (me *DetectionCondition) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"disk_filesystem_condition": &me.DiskFilesystemCondition,
+		"disk_total_condition":      &me.DiskTotalCondition,
+		"host_metadata_condition":   &me.HostMetadataCondition,
+		"local_disk_condition":      &me.LocalDiskCondition,
+		"property":                  &me.Property,
+		"rule_type":                 &me.RuleType,
+	})
+}

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/disk_total_space_thresholds.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/disk_total_space_thresholds.go
@@ -1,0 +1,57 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package anomalydetectors
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type DiskTotalSpaceThresholds struct {
+	ThresholdAbove *int `json:"thresholdAbove,omitempty"` // If this field is empty then there is no lower limit. Minimum total disk space in GiB
+	ThresholdBelow *int `json:"thresholdBelow,omitempty"` // If this field is empty then there is no upper limit. Maximum total disk space in GiB
+}
+
+func (me *DiskTotalSpaceThresholds) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"threshold_above": {
+			Type:        schema.TypeInt,
+			Description: "If this field is empty then there is no lower limit. Minimum total disk space in GiB",
+			Optional:    true, // nullable
+		},
+		"threshold_below": {
+			Type:        schema.TypeInt,
+			Description: "If this field is empty then there is no upper limit. Maximum total disk space in GiB",
+			Optional:    true, // nullable
+		},
+	}
+}
+
+func (me *DiskTotalSpaceThresholds) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"threshold_above": me.ThresholdAbove,
+		"threshold_below": me.ThresholdBelow,
+	})
+}
+
+func (me *DiskTotalSpaceThresholds) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"threshold_above": &me.ThresholdAbove,
+		"threshold_below": &me.ThresholdBelow,
+	})
+}

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/enums.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/enums.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,6 +17,28 @@
 
 package anomalydetectors
 
+type DiskProp string
+
+var DiskProps = struct {
+	Diskfilesystem DiskProp
+	Disktotalspace DiskProp
+	Disktype       DiskProp
+}{
+	"DiskFilesystem",
+	"DiskTotalSpace",
+	"DiskType",
+}
+
+type DiskType string
+
+var DiskTypes = struct {
+	Local  DiskType
+	Remote DiskType
+}{
+	"LOCAL",
+	"REMOTE",
+}
+
 type EoperatingSystem string
 
 var EoperatingSystems = struct {
@@ -27,6 +49,16 @@ var EoperatingSystems = struct {
 	"AIX",
 	"LINUX",
 	"WINDOWS",
+}
+
+type RuleType string
+
+var RuleTypes = struct {
+	Ruletypedisk RuleType
+	Ruletypehost RuleType
+}{
+	"RuleTypeDisk",
+	"RuleTypeHost",
 }
 
 type Trigger string

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/host_metadata_condition.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/host_metadata_condition.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/host_metadata_condition_type.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/host_metadata_condition_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,28 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-type HostMetadataConditionTypes []*HostMetadataConditionType
-
-func (me *HostMetadataConditionTypes) Schema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"host_metadata_condition": {
-			Type:        schema.TypeSet,
-			Required:    true,
-			MinItems:    1,
-			Description: "",
-			Elem:        &schema.Resource{Schema: new(HostMetadataConditionType).Schema()},
-		},
-	}
-}
-
-func (me HostMetadataConditionTypes) MarshalHCL(properties hcl.Properties) error {
-	return properties.EncodeSlice("host_metadata_condition", me)
-}
-
-func (me *HostMetadataConditionTypes) UnmarshalHCL(decoder hcl.Decoder) error {
-	return decoder.DecodeSlice("host_metadata_condition", me)
-}
-
 type HostMetadataConditionType struct {
 	HostMetadataCondition *HostMetadataCondition `json:"hostMetadataCondition"`
 }
@@ -52,7 +30,7 @@ func (me *HostMetadataConditionType) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"host_metadata_condition": {
 			Type:        schema.TypeList,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Required:    true,
 			Elem:        &schema.Resource{Schema: new(HostMetadataCondition).Schema()},
 			MinItems:    1,

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/metadata_item.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/metadata_item.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ func (me *MetadataItem) Schema() map[string]*schema.Schema {
 		},
 		"metadata_value": {
 			Type:        schema.TypeString,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Required:    true,
 		},
 	}

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/sample_count_thresholds.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/sample_count_thresholds.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/sample_count_thresholds_immediately.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/sample_count_thresholds_immediately.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/settings.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/settings.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,15 +23,15 @@ import (
 )
 
 type Settings struct {
-	Alerts                 Alerts                     `json:"alerts,omitempty"`                 // Alerts
-	DiskNameFilters        []string                   `json:"diskNameFilters,omitempty"`        // Disk will be included in this policy if **any** of the filters match
-	Enabled                bool                       `json:"enabled"`                          // This setting is enabled (`true`) or disabled (`false`)
-	EventProperties        MetadataItems              `json:"eventProperties,omitempty"`        // Set of additional key-value properties to be attached to the triggered event. You can retrieve the available property keys using the [Events API v2](https://dt-url.net/9622g1w). Additionally any Host resource attribute can be dynamically substituted (agent 1.325+)
-	HostMetadataConditions HostMetadataConditionTypes `json:"hostMetadataConditions,omitempty"` // Host resource attributes are dimensions enriching the host including custom metadata which are user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\n  By defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\n  See [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).\n\n  Note: Starting from version 1.325 host resource attributes are supported in addition to host custom metadata.
-	OperatingSystem        []EoperatingSystem         `json:"operatingSystem,omitempty"`        // Select the operating systems on which policy should be applied. Possible values: `AIX`, `LINUX`, `WINDOWS`
-	PolicyName             string                     `json:"policyName"`                       // Policy name
-	Scope                  *string                    `json:"-" scope:"scope"`                  // The scope of this setting (HOST, HOST_GROUP). Omit this property if you want to cover the whole environment.
-	InsertAfter            string                     `json:"-"`
+	Alerts              Alerts              `json:"alerts,omitempty"`              // Alerts
+	DetectionConditions DetectionConditions `json:"detectionConditions,omitempty"` // Set of rules to scope which disks the policy applies to. Rules can match based on disk properties (total space, filesystem, disk type) or host resource attributes. Each disk property type can be defined at most once per policy.
+	DiskNameFilters     []string            `json:"diskNameFilters,omitempty"`     // Disk will be included in this policy if **any** of the filters match
+	Enabled             bool                `json:"enabled"`                       // This setting is enabled (`true`) or disabled (`false`)
+	EventProperties     MetadataItems       `json:"eventProperties,omitempty"`     // Set of additional key-value properties to be attached to the triggered event. You can retrieve the available property keys using the [Events API v2](https://dt-url.net/9622g1w). Additionally any Host resource attribute can be dynamically substituted (agent 1.325+)
+	OperatingSystem     []EoperatingSystem  `json:"operatingSystem,omitempty"`     // Select the operating systems on which policy should be applied. Possible values: `AIX`, `LINUX`, `WINDOWS`
+	PolicyName          string              `json:"policyName"`                    // Policy name
+	Scope               *string             `json:"-" scope:"scope"`               // The scope of this setting (HOST, HOST_GROUP). Omit this property if you want to cover the whole environment.
+	InsertAfter         string              `json:"-"`
 }
 
 func (me *Settings) Name() string {
@@ -51,6 +51,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
+		"detection_conditions": {
+			Type:        schema.TypeList,
+			Description: "Set of rules to scope which disks the policy applies to. Rules can match based on disk properties (total space, filesystem, disk type) or host resource attributes. Each disk property type can be defined at most once per policy.",
+			Optional:    true, // minobjects == 0
+			Elem:        &schema.Resource{Schema: new(DetectionConditions).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"disk_name_filters": {
 			Type:        schema.TypeSet,
 			Description: "Disk will be included in this policy if **any** of the filters match",
@@ -67,14 +75,6 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Set of additional key-value properties to be attached to the triggered event. You can retrieve the available property keys using the [Events API v2](https://dt-url.net/9622g1w). Additionally any Host resource attribute can be dynamically substituted (agent 1.325+)",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Resource{Schema: new(MetadataItems).Schema()},
-			MinItems:    1,
-			MaxItems:    1,
-		},
-		"host_metadata_conditions": {
-			Type:        schema.TypeList,
-			Description: "Host resource attributes are dimensions enriching the host including custom metadata which are user-defined key-value pairs that you can assign to hosts monitored by Dynatrace.\n\n  By defining custom metadata, you can enrich the monitoring data with context specific to your organization's needs, such as environment names, team ownership, application versions, or any other relevant details.\n\n  See [Define tags and metadata for hosts](https://dt-url.net/w3hv0kbw).\n\n  Note: Starting from version 1.325 host resource attributes are supported in addition to host custom metadata.",
-			Optional:    true, // minobjects == 0
-			Elem:        &schema.Resource{Schema: new(HostMetadataConditionTypes).Schema()},
 			MinItems:    1,
 			MaxItems:    1,
 		},
@@ -106,28 +106,28 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"alerts":                   me.Alerts,
-		"disk_name_filters":        me.DiskNameFilters,
-		"enabled":                  me.Enabled,
-		"event_properties":         me.EventProperties,
-		"host_metadata_conditions": me.HostMetadataConditions,
-		"operating_system":         me.OperatingSystem,
-		"policy_name":              me.PolicyName,
-		"scope":                    me.Scope,
-		"insert_after":             me.InsertAfter,
+		"alerts":               me.Alerts,
+		"detection_conditions": me.DetectionConditions,
+		"disk_name_filters":    me.DiskNameFilters,
+		"enabled":              me.Enabled,
+		"event_properties":     me.EventProperties,
+		"operating_system":     me.OperatingSystem,
+		"policy_name":          me.PolicyName,
+		"scope":                me.Scope,
+		"insert_after":         me.InsertAfter,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"alerts":                   &me.Alerts,
-		"disk_name_filters":        &me.DiskNameFilters,
-		"enabled":                  &me.Enabled,
-		"event_properties":         &me.EventProperties,
-		"host_metadata_conditions": &me.HostMetadataConditions,
-		"operating_system":         &me.OperatingSystem,
-		"policy_name":              &me.PolicyName,
-		"scope":                    &me.Scope,
-		"insert_after":             &me.InsertAfter,
+		"alerts":               &me.Alerts,
+		"detection_conditions": &me.DetectionConditions,
+		"disk_name_filters":    &me.DiskNameFilters,
+		"enabled":              &me.Enabled,
+		"event_properties":     &me.EventProperties,
+		"operating_system":     &me.OperatingSystem,
+		"policy_name":          &me.PolicyName,
+		"scope":                &me.Scope,
+		"insert_after":         &me.InsertAfter,
 	})
 }

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/settings.go
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/settings/settings.go
@@ -94,6 +94,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "The scope of this setting (HOST, HOST_GROUP). Omit this property if you want to cover the whole environment.",
 			Optional:    true,
 			Default:     "environment",
+			ForceNew:    true,
 		},
 		"insert_after": {
 			Type:        schema.TypeString,

--- a/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/infrastructure/diskedge/anomalydetectors/testdata/terraform/example_a.tf
@@ -22,12 +22,35 @@ resource "dynatrace_disk_edge_anomaly_detectors" "#name#" {
       metadata_value = "ExampleValue"
     }
   }
-  # host_metadata_conditions { # Disabling until v297
-  #   host_metadata_condition {
-  #     host_metadata_condition {
-  #       metadata_condition = "$contains(terraform)"
-  #       metadata_key       = "ExampleKey"
-  #     }
-  #   }
-  # }
+
+  detection_conditions {
+    detection_condition {
+      rule_type = "RuleTypeHost"
+      host_metadata_condition {
+        host_metadata_condition {
+          # key_must_exist   = true
+          metadata_condition = "$contains(terraform)"
+          metadata_key       = "ExampleKey"
+        }
+      }
+    }
+    detection_condition {
+      local_disk_condition = "REMOTE"
+      property             = "DiskType"
+      rule_type            = "RuleTypeDisk"
+    }
+    detection_condition {
+      disk_filesystem_condition = "$match(ext*)"
+      property                  = "DiskFilesystem"
+      rule_type                 = "RuleTypeDisk"
+    }
+    detection_condition {
+      property  = "DiskTotalSpace"
+      rule_type = "RuleTypeDisk"
+      disk_total_condition {
+        threshold_above = 10
+        threshold_below = 1000
+      }
+    }
+  }
 }


### PR DESCRIPTION
#### **Why** this PR?
Update generated resource `dynatrace_disk_edge_anomaly_detectors` for `builtin:infrastructure.disk.edge.anomaly-detectors` version `0.1`.

#### **What** has changed?
This is a breaking change: `host_metadata_conditions` is removed and replaced with the more generic `detection_conditions`, which may include `disk_filesystem_condition`, `disk_total_condition`, `host_metadata_condition`, or `local_disk_condition`, depending on the values of `rule_type` and `property`.

The `scope` field is also modified to force recreation when it changes as required by the Settings API.

#### **How** does it do it?
The resource is regenerated.

#### How is it **tested**?
The test is extended to cover the types of `detection_conditions`.

#### How does it affect **users**?
The resource is usable again.

**Issue:** CA-19072