### PR TITLE
fix: TypeSet maintenance part 5

### DIFF
--- a/dynatrace/api/v1/config/dashboards/sharing/service_test.go
+++ b/dynatrace/api/v1/config/dashboards/sharing/service_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sharing_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccDashboardSharing(t *testing.T) {
+	api.TestAcc(t)
+}
+
+func TestAccTestCasesDashboardSharing(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/v1/config/dashboards/sharing/testcases/update-share-permission-set/create.tf
+++ b/dynatrace/api/v1/config/dashboards/sharing/testcases/update-share-permission-set/create.tf
@@ -1,0 +1,44 @@
+resource "dynatrace_dashboard" "dashboard" {
+  dashboard_metadata {
+    name   = "#name#"
+    owner  = "Dynatrace"
+    tags   = ["Kubernetes"]
+    dynamic_filters {
+      filters = ["KUBERNETES_CLUSTER"]
+    }
+  }
+  tile {
+    name       = "Markdown"
+    tile_type  = "MARKDOWN"
+    configured = true
+    bounds {
+      top    = 0
+      width  = 684
+      height = 38
+      left   = 0
+    }
+    markdown = "## Cluster resource overview"
+  }
+}
+
+resource "dynatrace_iam_group" "group" {
+  count = 2
+  name = "#name#-${count.index}"
+}
+
+resource "dynatrace_dashboard_sharing" "sharing" {
+  dashboard_id = dynatrace_dashboard.dashboard.id
+  permissions {
+    permission {
+      level = "VIEW"
+      type  = "GROUP"
+      id = dynatrace_iam_group.group[0].id
+    }
+    # to update
+    permission {
+      level = "VIEW"
+      type  = "GROUP"
+      id = dynatrace_iam_group.group[1].id
+    }
+  }
+}

--- a/dynatrace/api/v1/config/dashboards/sharing/testcases/update-share-permission-set/update.tf
+++ b/dynatrace/api/v1/config/dashboards/sharing/testcases/update-share-permission-set/update.tf
@@ -1,0 +1,44 @@
+resource "dynatrace_dashboard" "dashboard" {
+  dashboard_metadata {
+    name   = "#name#"
+    owner  = "Dynatrace"
+    tags   = ["Kubernetes"]
+    dynamic_filters {
+      filters = ["KUBERNETES_CLUSTER"]
+    }
+  }
+  tile {
+    name       = "Markdown"
+    tile_type  = "MARKDOWN"
+    configured = true
+    bounds {
+      top    = 0
+      width  = 684
+      height = 38
+      left   = 0
+    }
+    markdown = "## Cluster resource overview"
+  }
+}
+
+resource "dynatrace_iam_group" "group" {
+  count = 2
+  name = "#name#-${count.index}"
+}
+
+resource "dynatrace_dashboard_sharing" "sharing" {
+  dashboard_id = dynatrace_dashboard.dashboard.id
+  permissions {
+    permission {
+      level = "VIEW"
+      type  = "GROUP"
+      id = dynatrace_iam_group.group[0].id
+    }
+    # updated
+    permission {
+      level = "EDIT"
+      type  = "GROUP"
+      id = dynatrace_iam_group.group[1].id
+    }
+  }
+}

--- a/dynatrace/api/v1/config/dashboards/sharing/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/dashboards/sharing/testdata/terraform/example_a.tf
@@ -1,0 +1,51 @@
+resource "dynatrace_dashboard_sharing" "sharing" {
+  dashboard_id = dynatrace_dashboard.dashboard.id
+  permissions {
+    permission {
+      level = "VIEW"
+      type  = "ALL"
+    }
+    permission {
+      level = "EDIT"
+      type  = "GROUP"
+      id = dynatrace_iam_group.group.id
+    }
+    permission {
+      level = "EDIT"
+      type  = "USER"
+      id = dynatrace_iam_service_user.user.id
+    }
+  }
+}
+
+
+resource "dynatrace_dashboard" "dashboard" {
+  dashboard_metadata {
+    name   = "#name#"
+    owner  = "Dynatrace"
+    tags   = ["Kubernetes"]
+    dynamic_filters {
+      filters = ["KUBERNETES_CLUSTER"]
+    }
+  }
+  tile {
+    name       = "Markdown"
+    tile_type  = "MARKDOWN"
+    configured = true
+    bounds {
+      top    = 0
+      width  = 684
+      height = 38
+      left   = 0
+    }
+    markdown = "## Cluster resource overview"
+  }
+}
+
+resource "dynatrace_iam_group" "group" {
+  name = "#name#"
+}
+
+resource "dynatrace_iam_service_user" "user" {
+  name = "#name#"
+}

--- a/dynatrace/api/v1/config/notifications/service_test.go
+++ b/dynatrace/api/v1/config/notifications/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccNotifications(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesNotifications(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/v1/config/notifications/testcases/update-web-hook-headers-set/create.tf
+++ b/dynatrace/api/v1/config/notifications/testcases/update-web-hook-headers-set/create.tf
@@ -1,0 +1,23 @@
+resource "dynatrace_notification" "notification" {
+  web_hook {
+    name                   = "#name#"
+    accept_any_certificate = true
+    active                 = false
+    alerting_profile       = dynatrace_alerting_profile.Default.id
+    payload = "test6"
+    url     = "https://dynatrace.com/#name#"
+    header {
+      name  = "http-header-name-01"
+      value = "http-header-value-01"
+    }
+    # to update
+    header {
+      name  = "http-header-name-02"
+      value = "http-header-value-02"
+    }
+  }
+}
+
+resource "dynatrace_alerting_profile" "Default" {
+  display_name = "#name#"
+}

--- a/dynatrace/api/v1/config/notifications/testcases/update-web-hook-headers-set/update.tf
+++ b/dynatrace/api/v1/config/notifications/testcases/update-web-hook-headers-set/update.tf
@@ -1,0 +1,23 @@
+resource "dynatrace_notification" "notification" {
+  web_hook {
+    name                   = "#name#"
+    accept_any_certificate = true
+    active                 = false
+    alerting_profile       = dynatrace_alerting_profile.Default.id
+    payload = "test6"
+    url     = "https://dynatrace.com/#name#"
+    header {
+      name  = "http-header-name-01"
+      value = "http-header-value-01"
+    }
+    # updated
+    header {
+      name  = "http-header-name-edit"
+      value = "http-header-value-edit"
+    }
+  }
+}
+
+resource "dynatrace_alerting_profile" "Default" {
+  display_name = "#name#"
+}

--- a/dynatrace/api/v1/config/notifications/testcases/update-xmatters-headers-set/create.tf
+++ b/dynatrace/api/v1/config/notifications/testcases/update-xmatters-headers-set/create.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_notification" "notification" {
+  xmatters {
+    name                   = "#name#"
+    accept_any_certificate = true
+    active                 = false
+    alerting_profile       = dynatrace_alerting_profile.Default.id
+    payload                = "x-matters-payload"
+    url                    = "https://dynatrace.com/#name#"
+    header {
+      name  = "http-header-name-01"
+      value = "http-header-value-01"
+    }
+    # to update
+    header {
+      name  = "http-header-name-02"
+      value = "http-header-value-02"
+    }
+  }
+}
+
+
+resource "dynatrace_alerting_profile" "Default" {
+  display_name = "#name#"
+}

--- a/dynatrace/api/v1/config/notifications/testcases/update-xmatters-headers-set/update.tf
+++ b/dynatrace/api/v1/config/notifications/testcases/update-xmatters-headers-set/update.tf
@@ -1,0 +1,24 @@
+resource "dynatrace_notification" "notification" {
+  xmatters {
+    name                   = "#name#"
+    accept_any_certificate = true
+    active                 = false
+    alerting_profile       = dynatrace_alerting_profile.Default.id
+    payload                = "x-matters-payload"
+    url                    = "https://dynatrace.com/#name#"
+    header {
+      name  = "http-header-name-01"
+      value = "http-header-value-01"
+    }
+    # to update
+    header {
+      name  = "http-header-name-edit"
+      value = "http-header-value-edit"
+    }
+  }
+}
+
+
+resource "dynatrace_alerting_profile" "Default" {
+  display_name = "#name#"
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/service_test.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/service_test.go
@@ -29,3 +29,9 @@ import (
 func TestAccBrowserMonitors(t *testing.T) {
 	api.TestAcc(t, api.TestAccOptions{ExternalProviders: map[string]resource.ExternalProvider{"time": {Source: "hashicorp/time"}}})
 }
+
+func TestAccTestCasesBrowserMonitors(t *testing.T) {
+	t.Skip("Skipping because the eventual consistency time is way too high")
+
+	api.TestAccTestCases(t, api.TestCaseAccOptions{ExternalProviders: map[string]resource.ExternalProvider{"time": {Source: "hashicorp/time"}}})
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/testcases/update-headers-tags-and-threshold-sets/create.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/testcases/update-headers-tags-and-threshold-sets/create.tf
@@ -1,0 +1,253 @@
+resource "dynatrace_synthetic_location" "location" {
+  name                                  = "#name#"
+  city                                  = "San Francisco de Asis"
+  country_code                          = "VE"
+  region_code                           = "04"
+  deployment_type                       = "STANDARD"
+  latitude                              = 10.0756
+  location_node_outage_delay_in_minutes = 3
+  longitude                             = -67.5442
+}
+
+resource "dynatrace_web_application" "application" {
+  name                                 = "#name#"
+  type                                 = "AUTO_INJECTED"
+  cost_control_user_session_percentage = 100
+  load_action_key_performance_metric   = "VISUALLY_COMPLETE"
+  real_user_monitoring_enabled         = true
+  xhr_action_key_performance_metric    = "VISUALLY_COMPLETE"
+  custom_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  load_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  monitoring_settings {
+    add_cross_origin_anonymous_attribute = true
+    cache_control_header_optimizations   = true
+    injection_mode = "JAVASCRIPT_TAG"
+    script_tag_cache_duration_in_hours = 1
+    advanced_javascript_tag_settings {
+      max_action_name_length = 100
+      max_errors_to_capture  = 10
+      additional_event_handlers {
+        max_dom_nodes = 5000
+      }
+    }
+    content_capture {
+      resource_timing_settings {
+        instrumentation_delay    = 53
+        non_w3c_resource_timings = true
+        w3c_resource_timings     = true
+      }
+      timeout_settings {
+        temporary_action_limit         = 3
+        temporary_action_total_timeout = 100
+        timed_action_support           = true
+      }
+    }
+  }
+  user_action_naming_settings {}
+  waterfall_settings {
+    resource_browser_caching_threshold            = 50
+    resources_threshold                           = 100000
+    slow_cnd_resources_threshold                  = 200000
+    slow_first_party_resources_threshold          = 200000
+    slow_third_party_resources_threshold          = 200000
+    speed_index_visually_complete_ratio_threshold = 50
+    uncompressed_resources_threshold              = 860
+  }
+  xhr_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+}
+
+resource "dynatrace_credentials" "credentials_vault" {
+  name        = "#name#"
+  description = "my credentials vault"
+  scopes      = ["SYNTHETIC"]
+  username = "username"
+  password = "password"
+}
+
+resource "time_sleep" "wait_5_seconds" {
+  depends_on = [dynatrace_synthetic_location.location, dynatrace_web_application.application, dynatrace_credentials.credentials_vault]
+  create_duration = "5s"
+}
+
+resource "dynatrace_browser_monitor" "monitor" {
+  depends_on = [time_sleep.wait_5_seconds]
+  name                   = "#name#"
+  frequency              = 15
+  locations              = [dynatrace_synthetic_location.location.id]
+  manually_assigned_apps = [dynatrace_web_application.application.id]
+  anomaly_detection {
+    loading_time_thresholds {
+      enabled = true
+      thresholds {
+        threshold {
+          type  = "TOTAL"
+          value_ms = 1000
+          event_index = 0
+        }
+        # to update
+        threshold {
+          type  = "ACTION"
+          value_ms = 2000
+          event_index = 2
+        }
+      }
+    }
+    outage_handling {
+      global_outage  = true
+      retry_on_error = true
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  key_performance_metrics {
+    load_action_kpm = "VISUALLY_COMPLETE"
+    xhr_action_kpm  = "VISUALLY_COMPLETE"
+  }
+  script {
+    type = "clickpath"
+    configuration {
+      bypass_csp = true
+      user_agent = "Mozilla"
+      bandwidth {
+        network_type = "GPRS"
+      }
+      device {
+        name        = "Apple iPhone 8"
+        orientation = "landscape"
+      }
+      headers {
+        header {
+          name  = "name1"
+          value = "value1"
+        }
+        # to update
+        header {
+          name  = "name2"
+          value = "value2"
+        }
+      }
+      ignored_error_codes {
+        status_codes = "400"
+      }
+      javascript_setttings {
+        timeout_settings {
+          action_limit  = 3
+          total_timeout = 100
+        }
+        visually_complete_options {
+          image_size_threshold = 0
+          inactivity_timeout   = 0
+          mutation_timeout     = 0
+        }
+      }
+    }
+    events {
+      event {
+        description = "Loading of \"https://example.com\""
+        navigate {
+          url = "https://example.com"
+          authentication {
+            type  = "http_authentication"
+            creds = dynatrace_credentials.credentials_vault.id
+          }
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+      event {
+        description = "jhjhjh"
+        navigate {
+          url = "https://example.com"
+          authentication {
+            type  = "http_authentication"
+            creds = dynatrace_credentials.credentials_vault.id
+          }
+          validate {
+            validation {
+              type  = "text_match"
+              match = "kkl"
+              regex = true
+              target {
+                window = "k"
+              }
+            }
+          }
+          wait {
+            timeout  = 60000
+            wait_for = "validation"
+            validation {
+              type  = "element_match"
+              match = "kjkj"
+              target {
+                locators {
+                  locator {
+                    type  = "css"
+                    value = "jjj"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      event {
+        description = "fvf"
+        click {
+          button = 0
+          validate {
+            validation {
+              type = "text_match"
+            }
+          }
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+      event {
+        description = "jsfoo"
+        javascript {
+          code = <<-EOT
+            let x = 3;
+            for (var i = 0; i < x; x++) {
+                console.log("asdf");
+            }
+          EOT
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+    }
+  }
+  tags {
+    tag {
+      context = "CONTEXTLESS"
+      key = "key1"
+      source = "USER"
+    }
+    # to update
+    tag {
+      context = "CONTEXTLESS"
+      key = "key2"
+      source = "USER"
+    }
+  }
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/testcases/update-headers-tags-and-threshold-sets/update.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/testcases/update-headers-tags-and-threshold-sets/update.tf
@@ -1,0 +1,258 @@
+resource "dynatrace_synthetic_location" "location" {
+  name                                  = "#name#"
+  city                                  = "San Francisco de Asis"
+  country_code                          = "VE"
+  region_code                           = "04"
+  deployment_type                       = "STANDARD"
+  latitude                              = 10.0756
+  location_node_outage_delay_in_minutes = 3
+  longitude                             = -67.5442
+}
+
+resource "dynatrace_web_application" "application" {
+  name                                 = "#name#"
+  type                                 = "AUTO_INJECTED"
+  cost_control_user_session_percentage = 100
+  load_action_key_performance_metric   = "VISUALLY_COMPLETE"
+  real_user_monitoring_enabled         = true
+  xhr_action_key_performance_metric    = "VISUALLY_COMPLETE"
+  custom_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  load_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  monitoring_settings {
+    add_cross_origin_anonymous_attribute = true
+    cache_control_header_optimizations   = true
+    injection_mode = "JAVASCRIPT_TAG"
+    script_tag_cache_duration_in_hours = 1
+    advanced_javascript_tag_settings {
+      max_action_name_length = 100
+      max_errors_to_capture  = 10
+      additional_event_handlers {
+        max_dom_nodes = 5000
+      }
+    }
+    content_capture {
+      resource_timing_settings {
+        instrumentation_delay    = 53
+        non_w3c_resource_timings = true
+        w3c_resource_timings     = true
+      }
+      timeout_settings {
+        temporary_action_limit         = 3
+        temporary_action_total_timeout = 100
+        timed_action_support           = true
+      }
+    }
+  }
+  user_action_naming_settings {}
+  waterfall_settings {
+    resource_browser_caching_threshold            = 50
+    resources_threshold                           = 100000
+    slow_cnd_resources_threshold                  = 200000
+    slow_first_party_resources_threshold          = 200000
+    slow_third_party_resources_threshold          = 200000
+    speed_index_visually_complete_ratio_threshold = 50
+    uncompressed_resources_threshold              = 860
+  }
+  xhr_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+}
+
+resource "dynatrace_credentials" "credentials_vault" {
+  name        = "#name#"
+  description = "my credentials vault"
+  scopes      = ["SYNTHETIC"]
+  username = "username"
+  password = "password"
+}
+
+resource "time_sleep" "wait_5_seconds" {
+  depends_on = [dynatrace_synthetic_location.location, dynatrace_web_application.application, dynatrace_credentials.credentials_vault]
+  create_duration = "5s"
+}
+
+resource "dynatrace_browser_monitor" "monitor" {
+  depends_on = [time_sleep.wait_5_seconds]
+  name                   = "#name#"
+  frequency              = 15
+  locations              = [dynatrace_synthetic_location.location.id]
+  manually_assigned_apps = [dynatrace_web_application.application.id]
+  anomaly_detection {
+    loading_time_thresholds {
+      enabled = true
+      thresholds {
+        threshold {
+          type  = "TOTAL"
+          value_ms = 1000
+          event_index = 0
+        }
+        # updated
+        threshold {
+          type  = "ACTION"
+          value_ms = 3000
+          event_index = 2
+        }
+      }
+    }
+    outage_handling {
+      global_outage  = true
+      retry_on_error = true
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  key_performance_metrics {
+    load_action_kpm = "VISUALLY_COMPLETE"
+    xhr_action_kpm  = "VISUALLY_COMPLETE"
+  }
+  script {
+    type = "clickpath"
+    configuration {
+      bypass_csp = true
+      user_agent = "Mozilla"
+      bandwidth {
+        network_type = "GPRS"
+      }
+      device {
+        name        = "Apple iPhone 8"
+        orientation = "landscape"
+      }
+      headers {
+        header {
+          name  = "name1"
+          value = "value1"
+        }
+        # to update
+        header {
+          name  = "nameEdit"
+          value = "valueEdit"
+        }
+      }
+      ignored_error_codes {
+        status_codes = "400"
+      }
+      javascript_setttings {
+        timeout_settings {
+          action_limit  = 3
+          total_timeout = 100
+        }
+        visually_complete_options {
+          image_size_threshold = 0
+          inactivity_timeout   = 0
+          mutation_timeout     = 0
+        }
+      }
+    }
+    events {
+      event {
+        description = "Loading of \"https://example.com\""
+        navigate {
+          url = "https://example.com"
+          authentication {
+            type  = "http_authentication"
+            creds = dynatrace_credentials.credentials_vault.id
+          }
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+      event {
+        description = "jhjhjh"
+        navigate {
+          url = "https://example.com"
+          authentication {
+            type  = "http_authentication"
+            creds = dynatrace_credentials.credentials_vault.id
+          }
+          validate {
+            validation {
+              type  = "text_match"
+              match = "kkl"
+              regex = true
+              target {
+                window = "k"
+              }
+            }
+          }
+          wait {
+            timeout  = 60000
+            wait_for = "validation"
+            validation {
+              type  = "element_match"
+              match = "kjkj"
+              target {
+                locators {
+                  locator {
+                    type  = "css"
+                    value = "jjj"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      event {
+        description = "fvf"
+        click {
+          button = 0
+          validate {
+            validation {
+              type = "text_match"
+            }
+          }
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+      event {
+        description = "jsfoo"
+        javascript {
+          code = <<-EOT
+            let x = 3;
+            for (var i = 0; i < x; x++) {
+                console.log("asdf");
+            }
+          EOT
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+    }
+  }
+  tags {
+    tag {
+      context = "CONTEXTLESS"
+      key = "key1"
+      source = "USER"
+    }
+    # updated
+    tag {
+      context = "CONTEXTLESS"
+      key = "keyEdit"
+      source = "USER"
+    }
+  }
+}
+
+resource "time_sleep" "wait_for_monitor" {
+  depends_on = [dynatrace_browser_monitor.monitor]
+  create_duration = "10s"
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/http/service_test.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service_test.go
@@ -31,3 +31,9 @@ func TestAccHTTPMonitors(t *testing.T) {
 		"time": {Source: "hashicorp/time"},
 	}})
 }
+
+func TestAccTestCasesHTTPMonitors(t *testing.T) {
+	api.TestAccTestCases(t, api.TestCaseAccOptions{ExternalProviders: map[string]resource.ExternalProvider{
+		"time": {Source: "hashicorp/time"},
+	}})
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/http/settings/customProperty.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/settings/customProperty.go
@@ -43,15 +43,8 @@ func (me *CustomProperties) UnmarshalHCL(decoder hcl.Decoder) error {
 	if err := decoder.DecodeSlice("custom_property", me); err != nil {
 		return err
 	}
-	// https://github.com/hashicorp/terraform-plugin-sdk/issues/895
-	// Only known workaround is to ignore these blocks
-	customProperties := CustomProperties{}
-	for _, property := range *me {
-		if property.Name != "" || property.Value != "" {
-			customProperties = append(customProperties, property)
-		}
-	}
-	*me = customProperties
+
+	*me = hcl.FilterEmpty(*me, CustomProperty{})
 	return nil
 }
 

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testcases/update-custom-properties-and-request-headers-set/create.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testcases/update-custom-properties-and-request-headers-set/create.tf
@@ -1,0 +1,52 @@
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
+resource "dynatrace_http_monitor" "advanced" {
+  name      = "#name#"
+  frequency = 1
+  locations = [data.dynatrace_synthetic_location.location.id]
+  anomaly_detection {
+    loading_time_thresholds {
+    }
+    outage_handling {
+      global_outage = true
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  script {
+    request {
+      description     = "getOffice365ActiveUserCounts"
+      method          = "GET"
+      url             = "https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserCounts(period='D7')"
+      configuration {
+        accept_any_certificate = true
+        follow_redirects       = true
+        headers {
+          header {
+            name  = "name1"
+            value = "value1"
+          }
+          # to update
+          header {
+            name  = "name2"
+            value = "value2"
+          }
+        }
+      }
+    }
+    custom_properties {
+      custom_property {
+        name = "hmRequestTimeoutInMs"
+        value = "5000"
+      }
+      # to update
+      custom_property {
+        name = "hmConnectTimeoutInMs"
+        value = "6000"
+      }
+    }
+  }
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testcases/update-custom-properties-and-request-headers-set/update.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testcases/update-custom-properties-and-request-headers-set/update.tf
@@ -1,0 +1,57 @@
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
+resource "dynatrace_http_monitor" "advanced" {
+  name      = "#name#"
+  frequency = 1
+  locations = [data.dynatrace_synthetic_location.location.id]
+  anomaly_detection {
+    loading_time_thresholds {
+    }
+    outage_handling {
+      global_outage = true
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  script {
+    request {
+      description     = "getOffice365ActiveUserCounts"
+      method          = "GET"
+      url             = "https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserCounts(period='D7')"
+      configuration {
+        accept_any_certificate = true
+        follow_redirects       = true
+        headers {
+          header {
+            name  = "name1"
+            value = "value1"
+          }
+          # updated (eventual consistency)
+          header {
+            name  = "nameEdit"
+            value = "valueEdit"
+          }
+        }
+      }
+    }
+    custom_properties {
+      custom_property {
+        name = "hmRequestTimeoutInMs"
+        value = "5000"
+      }
+      # updated
+      custom_property {
+        name = "hmDnsQueryTimeoutInMs"
+        value = "7000"
+      }
+    }
+  }
+}
+
+resource "time_sleep" "wait_for_monitor" {
+  depends_on = [dynatrace_http_monitor.advanced]
+  create_duration = "10s"
+}

--- a/templates/resources/dashboard_sharing.md.tmpl
+++ b/templates/resources/dashboard_sharing.md.tmpl
@@ -18,5 +18,8 @@ description: |-
 
 - Dashboards API - https://www.dynatrace.com/support/help/dynatrace-api/configuration-api/dashboards-api
 
+## Resource Example Usage
+
+{{ tffile "dynatrace/api/v1/config/dashboards/sharing/testdata/terraform/example_a.tf" }}
+
 {{ .SchemaMarkdown | trimspace }}
- 


### PR DESCRIPTION
#### **Why** this PR?
We have a lot of `TypeSet` usages with potential bugs coming from the plugin SDK.
This is part 5 of several, where tests for all TypeSet fields are added and potential bugs are fixed.

#### **What** has changed?
TypeSet bugs fixed and tests added for all TypeSet usages except deprecated resources.
This covers the `V1` folders in `api`

#### **How** does it do it?
By using our generic filterEmpty function to filter empty items and by adding tests that update TypeSet fields.

#### How is it **tested**?
Tests added that would produce the empty Set item.

#### How does it affect **users**?
More stable resources. Fixing several existing problems.

**Issue:** CA-19022
