### PR TITLE
fix(dynatrace_automation_workflow): don't set `result` for SIMPLE workflows

### DIFF
--- a/dynatrace/api/automation/workflows/settings/workflow.go
+++ b/dynatrace/api/automation/workflows/settings/workflow.go
@@ -43,7 +43,7 @@ type Workflow struct {
 	HourlyExecutionLimit *int           `json:"hourlyExecutionLimit"` // Maximum number of executions per hour, default is 1000
 	Input                map[string]any `json:"input"`                // Workflow-level input parameters
 	Guide                string         `json:"guide"`                // Informational guide text for the workflow
-	Result               string         `json:"result"`               // The result of the workflow
+	Result               *string        `json:"result,omitempty"`     // The result of the workflow
 }
 
 func (me *Workflow) Name() string {
@@ -143,7 +143,7 @@ func (me *Workflow) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "The result of the workflow",
 			Optional:    true,
-			Default:     "", // Sets a default because Workflows behaves like PATCH if not provided; ignoring an empty value
+			// Default must not be set because SIMPLE workflows don't support it
 		},
 	}
 }
@@ -209,6 +209,15 @@ func (me *Workflow) UnmarshalHCL(decoder hcl.Decoder) error {
 		}
 	}
 
+	return nil
+}
+
+func (me *Workflow) HandlePreconditions() error {
+	// set conditional default value for STANDARD workflows
+	if me.Type == "STANDARD" && me.Result == nil {
+		// Sets a default because Workflows behaves like PATCH if not provided; ignoring an empty value
+		me.Result = new(string)
+	}
 	return nil
 }
 

--- a/dynatrace/api/automation/workflows/testdata/terraform/example-simple.tf
+++ b/dynatrace/api/automation/workflows/testdata/terraform/example-simple.tf
@@ -1,0 +1,17 @@
+resource "dynatrace_automation_workflow" "simple_workflow" {
+  type                   = "SIMPLE"
+  hourly_execution_limit = 1000
+  owner_type             = "USER"
+  private                = false
+  title                  = "#name#"
+  tasks {
+    task {
+      name        = "http_request_1"
+      description = "Issue an HTTP request to any API change"
+      action      = "dynatrace.automations:http-function"
+      active      = true
+    }
+  }
+  trigger {
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
It wasn't possible to create or update SIMPLE workflows because the `result` property, which is not supported for SIMPLE, was sent in every request.
This is a regression introduced with https://github.com/dynatrace-oss/terraform-provider-dynatrace/pull/1043

#### **What** has changed?
Creating and updating of SIMPLE workflows is now working again

#### **How** does it do it?
By conditionally setting `result` to an empty string if it's a STANDARD workflow and not setting it at all if it's SIMPLE.

#### How is it **tested**?
A new test has been added for creating a simple workflow.
A testcase for STANDARD => SIMPLE is not needed, as this is not possible from the API side.

#### How does it affect **users**?
They can now update and create SIMPLE workflows again

**Issue:** CA-19164