### PR TITLE
fix: Use correct payload type for `default_sampling_ratio` in `dynatrace_dql`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,6 +140,7 @@ jobs:
           - { name: "builtin (n-o)", path: "$(go list ./dynatrace/api/builtin/... | grep -E '^.+/dynatrace/api/builtin/[n-o][^/]*/?')" }
           - { name: "builtin (p-s)", path: "$(go list ./dynatrace/api/builtin/... | grep -E '^.+/dynatrace/api/builtin/[p-s][^/]*/?')" }
           - { name: "builtin (t-z)", path: "$(go list ./dynatrace/api/builtin/... | grep -E '^.+/dynatrace/api/builtin/[t-z][^/]*/?')" }
+          - { name: "data sources", path: "./datasources/..." }
     steps:
       - name: ⬇️ Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2

--- a/datasources/dql/data_source.go
+++ b/datasources/dql/data_source.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -167,7 +167,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		dqlRequest.FetchTimeoutSeconds = new(v.(int))
 	}
 	if v, ok := d.GetOk("default_sampling_ratio"); ok {
-		dqlRequest.DefaultSamplingRatio = new(v.(int))
+		dqlRequest.DefaultSamplingRatio = new(v.(float64))
 	}
 	if v, ok := d.GetOk("default_scan_limit_gbytes"); ok {
 		dqlRequest.DefaultScanLimitGbytes = new(v.(int))
@@ -234,18 +234,18 @@ type DQLResponse struct {
 }
 
 type DQLRequest struct {
-	Query                      string  `json:"query"`
-	DefaultTimeframeStart      *string `json:"defaultTimeframeStart,omitempty"`
-	DefaultTimeframeEnd        *string `json:"defaultTimeframeEnd,omitempty"`
-	Timezone                   *string `json:"timezone,omitempty"`
-	Locale                     *string `json:"locale,omitempty"`
-	MaxResultRecords           *int    `json:"maxResultRecords,omitempty"`
-	MaxResultBytes             *int    `json:"maxResultBytes,omitempty"`
-	FetchTimeoutSeconds        *int    `json:"fetchTimeoutSeconds,omitempty"`
-	RequestTimeoutMilliseconds int     `json:"requestTimeoutMilliseconds,omitempty"`
-	EnablePreview              bool    `json:"enablePreview"`
-	DefaultSamplingRatio       *int    `json:"defaultSamplingRatio,omitempty"`
-	DefaultScanLimitGbytes     *int    `json:"defaultScanLimitGbytes,omitempty"`
-	QueryOptions               any     `json:"queryOptions"`
-	FilterSegments             any     `json:"filterSegments"`
+	Query                      string   `json:"query"`
+	DefaultTimeframeStart      *string  `json:"defaultTimeframeStart,omitempty"`
+	DefaultTimeframeEnd        *string  `json:"defaultTimeframeEnd,omitempty"`
+	Timezone                   *string  `json:"timezone,omitempty"`
+	Locale                     *string  `json:"locale,omitempty"`
+	MaxResultRecords           *int     `json:"maxResultRecords,omitempty"`
+	MaxResultBytes             *int     `json:"maxResultBytes,omitempty"`
+	FetchTimeoutSeconds        *int     `json:"fetchTimeoutSeconds,omitempty"`
+	RequestTimeoutMilliseconds int      `json:"requestTimeoutMilliseconds,omitempty"`
+	EnablePreview              bool     `json:"enablePreview"`
+	DefaultSamplingRatio       *float64 `json:"defaultSamplingRatio,omitempty"`
+	DefaultScanLimitGbytes     *int     `json:"defaultScanLimitGbytes,omitempty"`
+	QueryOptions               any      `json:"queryOptions"`
+	FilterSegments             any      `json:"filterSegments"`
 }

--- a/datasources/dql/data_source_test.go
+++ b/datasources/dql/data_source_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package dql_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccDatasourceDQL(t *testing.T) {
+	datasourceConfig, _ := api.ReadTfConfig(t, "testdata/datasource.tf")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"dynatrace": func() (*schema.Provider, error) {
+				return provider.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: datasourceConfig,
+				Check:  resource.TestCheckOutput("records", "[{\"id\":\"1\"}]"),
+			},
+		},
+	})
+
+}

--- a/datasources/dql/testdata/datasource.tf
+++ b/datasources/dql/testdata/datasource.tf
@@ -1,0 +1,16 @@
+data "dynatrace_dql" "records" {
+  default_sampling_ratio = 1.0
+  default_scan_limit_gbytes = -1
+  timezone = "UTC"
+  fetch_timeout_seconds = 60
+  locale = "en"
+  max_result_records = 10
+  max_result_bytes = 10485760
+  query = <<-EOT
+    data record(id = 1) | fields id
+  EOT
+}
+
+output "records" {
+  value = data.dynatrace_dql.records.records
+}


### PR DESCRIPTION
#### **Why** this PR?
The type for `default_sampling_ratio` in `dynatrace_dql` is set to `float`. In the payload and the associated type assert, it was `int`, causing a panic.

#### **What** has changed and **how** does it do it?
The type-assert and type of `default_sampling_ratio` in the payload has been changed to `float64`.

#### How is it **tested**?
A rudimentary test, `TestAccDatasourceDQL`,  has been added and now passes with the fix.

#### How does it affect **users**?
Users can set `default_sampling_ratio` when using the `dynatrace_dql` data source.

**Issue:** CA-19165
