### PR TITLE
test: sequential integration test setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,42 @@ jobs:
           TF_VAR_PROCESS_GROUP_ID: ${{ secrets.PROCESS_GROUP_ID }}
         run: go test -tags=integration -v -p 1 ${{ matrix.config.path }}
 
+  sequential-integration-tests:
+    name: Sequential Integration Tests
+    runs-on: ubuntu-latest
+    needs: [ run-setup ]
+    concurrency:
+      group: sequential-integration-tests # only one run at a time, globally
+      cancel-in-progress: false # queue, don't cancel
+    steps:
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
+      - name: 🛠️ Set up Go 1.x
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # 6.4.0
+        with:
+          go-version-file: ./go.mod
+
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4.0.0
+        with:
+          terraform_wrapper: false
+
+      - name: Run Integration Tests - Sequential
+        if: success() || failure()
+        env:
+          GOPROXY: "https://proxy.golang.org"
+          TF_ACC: "true"
+          DYNATRACE_DEBUG: "true"
+          DYNATRACE_HTTP_OAUTH_PREFERENCE: "true"
+          DT_NO_REPAIR_INPUT: "false"
+          DYNATRACE_ENV_URL: ${{ secrets.DYNATRACE_ENV_URL }}
+          DYNATRACE_API_TOKEN: ${{ secrets.DYNATRACE_API_TOKEN }}
+          DT_CLIENT_ID: ${{ secrets.DT_CLIENT_ID }}
+          DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
+          DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
+          TF_VAR_PROCESS_GROUP_ID: ${{ secrets.PROCESS_GROUP_ID }}
+        run: go test -tags=sequential_integration -v -p 1 ./...
+
   sonar_scan:
     name: SonarQube lint and test coverage
     if: ${{ always() }} # always runs after lint and test have completed, regardless of whether they were successful

--- a/dynatrace/api/app/dynatrace/infraops/settings/service_test.go
+++ b/dynatrace/api/app/dynatrace/infraops/settings/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/app/dynatrace/launchpad/service_test.go
+++ b/dynatrace/api/app/dynatrace/launchpad/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/activegatetoken/service_test.go
+++ b/dynatrace/api/builtin/activegatetoken/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/alerting/connectivityalerts/service_test.go
+++ b/dynatrace/api/builtin/alerting/connectivityalerts/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/databases/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/databases/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/frequentissues/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/frequentissues/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/aws/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/aws/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/disks/perdiskoverride/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/disks/perdiskoverride/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/disks/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/disks/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/hosts/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/infrastructure/vmware/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/infrastructure/vmware/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/cluster/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/namespace/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/namespace/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/node/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/node/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/pvc/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/pvc/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/kubernetes/workload/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/kubernetes/workload/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/rum/custom/crashrate/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/rum/custom/crashrate/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/rum/custom/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/rum/custom/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/rum/mobile/crashrate/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/rum/mobile/crashrate/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/rum/mobile/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/rum/mobile/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/rum/web/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/rum/web/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/anomalydetection/services/service_test.go
+++ b/dynatrace/api/builtin/anomalydetection/services/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/appengineregistry/clouddevelopmentenvironments/service_test.go
+++ b/dynatrace/api/builtin/appengineregistry/clouddevelopmentenvironments/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/appsec/attackprotectionsettings/service_test.go
+++ b/dynatrace/api/builtin/appsec/attackprotectionsettings/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/service_test.go
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/apptransition/kubernetes/service_test.go
+++ b/dynatrace/api/builtin/apptransition/kubernetes/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/attribute/preferences/service_test.go
+++ b/dynatrace/api/builtin/attribute/preferences/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/auditlog/service_test.go
+++ b/dynatrace/api/builtin/auditlog/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/automation/approval/service_test.go
+++ b/dynatrace/api/builtin/automation/approval/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/cloud/kubernetes/monitoring/service_test.go
+++ b/dynatrace/api/builtin/cloud/kubernetes/monitoring/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/cloud/kubernetes/service_test.go
+++ b/dynatrace/api/builtin/cloud/kubernetes/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/container/builtinmonitoringrule/service_test.go
+++ b/dynatrace/api/builtin/container/builtinmonitoringrule/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/container/registry/service_test.go
+++ b/dynatrace/api/builtin/container/registry/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/container/technology/service_test.go
+++ b/dynatrace/api/builtin/container/technology/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/crashdump/analytics/service_test.go
+++ b/dynatrace/api/builtin/crashdump/analytics/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/dashboards/general/service_test.go
+++ b/dynatrace/api/builtin/dashboards/general/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/dashboards/image/allowlist/service_test.go
+++ b/dynatrace/api/builtin/dashboards/image/allowlist/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/dashboards/presets/service_test.go
+++ b/dynatrace/api/builtin/dashboards/presets/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/deployment/activegate/updates/service_test.go
+++ b/dynatrace/api/builtin/deployment/activegate/updates/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/deployment/oneagent/defaultmode/service_test.go
+++ b/dynatrace/api/builtin/deployment/oneagent/defaultmode/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/deployment/oneagent/defaultversion/service_test.go
+++ b/dynatrace/api/builtin/deployment/oneagent/defaultversion/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/deployment/oneagent/updates/service_test.go
+++ b/dynatrace/api/builtin/deployment/oneagent/updates/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/devobs/agentoptin/service_test.go
+++ b/dynatrace/api/builtin/devobs/agentoptin/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/disk/analytics/extension/service_test.go
+++ b/dynatrace/api/builtin/disk/analytics/extension/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/disk/options/service_test.go
+++ b/dynatrace/api/builtin/disk/options/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/service_test.go
+++ b/dynatrace/api/builtin/dtjavascriptruntime/allowedoutboundconnections/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/service_test.go
+++ b/dynatrace/api/builtin/dtjavascriptruntime/appmonitoring/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/ebpf/service/discovery/service_test.go
+++ b/dynatrace/api/builtin/ebpf/service/discovery/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/eec/local/service_test.go
+++ b/dynatrace/api/builtin/eec/local/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/eec/remote/service_test.go
+++ b/dynatrace/api/builtin/eec/remote/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/endpointdetectionrules/optin/service_test.go
+++ b/dynatrace/api/builtin/endpointdetectionrules/optin/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/eulasettings/service_test.go
+++ b/dynatrace/api/builtin/eulasettings/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/exclude/network/traffic/service_test.go
+++ b/dynatrace/api/builtin/exclude/network/traffic/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/failuredetection/service/generalparameters/service_test.go
+++ b/dynatrace/api/builtin/failuredetection/service/generalparameters/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/failuredetection/service/httpparameters/service_test.go
+++ b/dynatrace/api/builtin/failuredetection/service/httpparameters/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/geosettings/service_test.go
+++ b/dynatrace/api/builtin/geosettings/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/grail/metrics/allowall/service_test.go
+++ b/dynatrace/api/builtin/grail/metrics/allowall/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/grail/metrics/allowlist/service_test.go
+++ b/dynatrace/api/builtin/grail/metrics/allowlist/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/histogrammetrics/service_test.go
+++ b/dynatrace/api/builtin/histogrammetrics/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/host/monitoring/advanced/service_test.go
+++ b/dynatrace/api/builtin/host/monitoring/advanced/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/host/monitoring/aixkernelextension/service_test.go
+++ b/dynatrace/api/builtin/host/monitoring/aixkernelextension/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/host/monitoring/mode/service_test.go
+++ b/dynatrace/api/builtin/host/monitoring/mode/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/host/monitoring/service_test.go
+++ b/dynatrace/api/builtin/host/monitoring/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/hub/subscriptions/service_test.go
+++ b/dynatrace/api/builtin/hub/subscriptions/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/kubernetes/enrichment/service_test.go
+++ b/dynatrace/api/builtin/kubernetes/enrichment/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/kubernetes/securityposturemanagement/service_test.go
+++ b/dynatrace/api/builtin/kubernetes/securityposturemanagement/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/logmonitoring/logagentconfiguration/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/logagentconfiguration/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/logmonitoring/logagentfeatureflags/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/logagentfeatureflags/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/logmonitoring/logdebugsettings/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/logdebugsettings/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/logmonitoring/logsongrailactivate/service_test.go
+++ b/dynatrace/api/builtin/logmonitoring/logsongrailactivate/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/mainframe/mqfilters/service_test.go
+++ b/dynatrace/api/builtin/mainframe/mqfilters/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/mainframe/txmonitoring/service_test.go
+++ b/dynatrace/api/builtin/mainframe/txmonitoring/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/mainframe/txstartfilters/service_test.go
+++ b/dynatrace/api/builtin/mainframe/txstartfilters/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/metric/metadata/service_test.go
+++ b/dynatrace/api/builtin/metric/metadata/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/metric/query/service_test.go
+++ b/dynatrace/api/builtin/metric/query/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/mobile/notifications/service_test.go
+++ b/dynatrace/api/builtin/mobile/notifications/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/apache/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/apache/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/dotnet/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/dotnet/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/go/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/go/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/iis/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/iis/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/java/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/java/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/nginx/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/nginx/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/nodejs/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/nodejs/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/opentracingnative/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/opentracingnative/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/php/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/php/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/python/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/python/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/varnish/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/varnish/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoredtechnologies/wsmb/service_test.go
+++ b/dynatrace/api/builtin/monitoredtechnologies/wsmb/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/monitoring/slo/normalization/service_test.go
+++ b/dynatrace/api/builtin/monitoring/slo/normalization/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/nettracer/traffic/service_test.go
+++ b/dynatrace/api/builtin/nettracer/traffic/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/oneagent/masking/service_test.go
+++ b/dynatrace/api/builtin/oneagent/masking/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/bizevents/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/davis/events/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/davis/problems/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/events/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/events/security/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/security/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/logs/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/metrics/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/security/events/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/spans/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/system/events/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/user/events/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/usersessions/routing/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/routing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/opentelemetrymetrics/service_test.go
+++ b/dynatrace/api/builtin/opentelemetrymetrics/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/ownership/config/service_test.go
+++ b/dynatrace/api/builtin/ownership/config/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/preferences/ipaddressmasking/service_test.go
+++ b/dynatrace/api/builtin/preferences/ipaddressmasking/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/preferences/privacy/service_test.go
+++ b/dynatrace/api/builtin/preferences/privacy/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/process/builtinprocessmonitoringrule/service_test.go
+++ b/dynatrace/api/builtin/process/builtinprocessmonitoringrule/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/process/monitoring/service_test.go
+++ b/dynatrace/api/builtin/process/monitoring/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/processgroup/cloudapplication/workloaddetection/service_test.go
+++ b/dynatrace/api/builtin/processgroup/cloudapplication/workloaddetection/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/processgroup/detectionflags/service_test.go
+++ b/dynatrace/api/builtin/processgroup/detectionflags/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/processgroup/monitoring/state/service_test.go
+++ b/dynatrace/api/builtin/processgroup/monitoring/state/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/processvisibility/service_test.go
+++ b/dynatrace/api/builtin/processvisibility/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/resourceattribute/service_test.go
+++ b/dynatrace/api/builtin/resourceattribute/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/custom/enablement/service_test.go
+++ b/dynatrace/api/builtin/rum/custom/enablement/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/mobile/enablement/service_test.go
+++ b/dynatrace/api/builtin/rum/mobile/enablement/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/mobile/keyperformancemetrics/service_test.go
+++ b/dynatrace/api/builtin/rum/mobile/keyperformancemetrics/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/mobile/requesterrors/service_test.go
+++ b/dynatrace/api/builtin/rum/mobile/requesterrors/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/overloadprevention/service_test.go
+++ b/dynatrace/api/builtin/rum/overloadprevention/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/processgroup/service_test.go
+++ b/dynatrace/api/builtin/rum/processgroup/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/userexperiencescore/service_test.go
+++ b/dynatrace/api/builtin/rum/userexperiencescore/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/automaticinjection/service_test.go
+++ b/dynatrace/api/builtin/rum/web/automaticinjection/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/beaconendpoint/service_test.go
+++ b/dynatrace/api/builtin/rum/web/beaconendpoint/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/capturecustomproperties/service_test.go
+++ b/dynatrace/api/builtin/rum/web/capturecustomproperties/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/customerrors/service_test.go
+++ b/dynatrace/api/builtin/rum/web/customerrors/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/customrumjavascriptversion/service_test.go
+++ b/dynatrace/api/builtin/rum/web/customrumjavascriptversion/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/enablement/service_test.go
+++ b/dynatrace/api/builtin/rum/web/enablement/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/injection/cookie/service_test.go
+++ b/dynatrace/api/builtin/rum/web/injection/cookie/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/ipaddressexclusion/service_test.go
+++ b/dynatrace/api/builtin/rum/web/ipaddressexclusion/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/keyperformancemetric/customactions/service_test.go
+++ b/dynatrace/api/builtin/rum/web/keyperformancemetric/customactions/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/keyperformancemetric/loadactions/service_test.go
+++ b/dynatrace/api/builtin/rum/web/keyperformancemetric/loadactions/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/keyperformancemetric/xhractions/service_test.go
+++ b/dynatrace/api/builtin/rum/web/keyperformancemetric/xhractions/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/manualinsertion/service_test.go
+++ b/dynatrace/api/builtin/rum/web/manualinsertion/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/requesterrors/service_test.go
+++ b/dynatrace/api/builtin/rum/web/requesterrors/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/rumjavascriptfilename/service_test.go
+++ b/dynatrace/api/builtin/rum/web/rumjavascriptfilename/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/web/rumjavascriptupdates/service_test.go
+++ b/dynatrace/api/builtin/rum/web/rumjavascriptupdates/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/securitycontext/service_test.go
+++ b/dynatrace/api/builtin/securitycontext/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/sessionreplay/web/privacypreferences/service_test.go
+++ b/dynatrace/api/builtin/sessionreplay/web/privacypreferences/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/sessionreplay/web/resourcecapturing/service_test.go
+++ b/dynatrace/api/builtin/sessionreplay/web/resourcecapturing/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/settings/keyrequests/service_test.go
+++ b/dynatrace/api/builtin/settings/keyrequests/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/settings/mutedrequests/service_test.go
+++ b/dynatrace/api/builtin/settings/mutedrequests/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/synthetic/availability/service_test.go
+++ b/dynatrace/api/builtin/synthetic/availability/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/synthetic/browser/outagehandling/service_test.go
+++ b/dynatrace/api/builtin/synthetic/browser/outagehandling/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/synthetic/browser/performancethresholds/service_test.go
+++ b/dynatrace/api/builtin/synthetic/browser/performancethresholds/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/synthetic/http/cookies/service_test.go
+++ b/dynatrace/api/builtin/synthetic/http/cookies/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/synthetic/http/outagehandling/service_test.go
+++ b/dynatrace/api/builtin/synthetic/http/outagehandling/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/synthetic/http/performancethresholds/service_test.go
+++ b/dynatrace/api/builtin/synthetic/http/performancethresholds/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/synthetic/multiprotocol/outagehandling/service_test.go
+++ b/dynatrace/api/builtin/synthetic/multiprotocol/outagehandling/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/tokens/tokensettings/service_test.go
+++ b/dynatrace/api/builtin/tokens/tokensettings/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/unifiedservices/enablement/service_test.go
+++ b/dynatrace/api/builtin/unifiedservices/enablement/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/unifiedservices/endpointmetrics/service_test.go
+++ b/dynatrace/api/builtin/unifiedservices/endpointmetrics/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/usability/analytics/service_test.go
+++ b/dynatrace/api/builtin/usability/analytics/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/builtin/usersettings/service_test.go
+++ b/dynatrace/api/builtin/usersettings/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/service/daviscopilot/dataminingblocklist/service_test.go
+++ b/dynatrace/api/service/daviscopilot/dataminingblocklist/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/v1/config/anomalies/processgroups/service_test.go
+++ b/dynatrace/api/v1/config/anomalies/processgroups/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/api/v1/config/customtags/service_test.go
+++ b/dynatrace/api/v1/config/customtags/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || sequential_integration
 
 /**
 * @license


### PR DESCRIPTION
#### **Why** this PR?
From time to time, some of our integration tests encountered race conditions.
This affects singleton settings schemas.
Problem: Pipeline A created and deleted the object, while pipeline B created (create acts the same way as update) and then did a `terraform plan` after apply. Pipeline B got "needs to be created" because pipeline A deleted it.

#### **What** has changed?
There aren't any conflicts anymore related to singleton settings.

#### **How** does it do it?
By adding a new `sequential_integration` tag to related schemas and adding another job that can't run in parallel.

#### How is it **tested**?
Manual tests. Pipeline will show

#### How does it affect **users**?
N/A

**Issue:** CA-19126