### PR TITLE
test: fix dynatrace_web_app_custom_config_properties race condition

### DIFF
--- a/dynatrace/api/builtin/rum/web/customconfigurationproperties/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/rum/web/customconfigurationproperties/testdata/terraform/example_a.tf
@@ -1,4 +1,4 @@
 resource "dynatrace_web_app_custom_config_properties" "#name#" {
   application_id  = "APPLICATION-1234567890000000"
-  custom_property = "examplekey=examplevalue"
+  custom_property = "examplekey=#name#"
 }


### PR DESCRIPTION
#### **Why** this PR?
The test for `dynatrace_web_app_custom_config_properties` sometimes failed due to race conditions.

#### **What** has changed?
It doesn't fail anymore.

#### **How** does it do it?
This adds `#name#` for the custom_property that needs to be unique, so that this one won't conflict with other parallel test executions

#### How is it **tested**?
This is actually about a test.

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
