### PR TITLE
chore: remove dlclark/regexp2 lib

### DIFF
--- a/dynatrace/api/v1/config/entityruleengine/comparison/string.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/string.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"maps"
 
-	"github.com/dlclark/regexp2"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/entityruleengine/comparison/stringc"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
@@ -212,45 +211,5 @@ func (sc *String) UnmarshalJSON(data []byte) error {
 }
 
 func (sc *String) Validate() []string {
-	if sc.Operator == stringc.Operators.RegexMatches && sc.Value != nil {
-		r, _ := regexCheck(*sc.Value)
-		return r
-	}
 	return []string{}
-}
-
-// Please use possessive or lazy quantifiers within your capture group
-const QUANTIFIERS_WITHIN_CAPTURING_GROUP = `(?<!\\)(?:\\\\)*([^\*\+]*[\+\*](?![\+\?]).*(?<!\\)(?:\\\\)*)`
-
-// Please do not use a greedy all match
-const ALL_MATCH_NO_CAPTURING_GROUP = `(?<!\()\.[\*\+](?![\)\+\?])`
-
-// Greedy or lazy character classes are not allowed, please use a possessive quantifier instead
-const CHARACTER_CLASS_WITH_GREEDY_OR_LAZY_QUANTIFIER = `(?<!\\)(?:\\\\)*](?>\*|\+)(?!\+)`
-
-func regexCheck(s string) ([]string, error) {
-	return []string{}, nil
-}
-
-func RegexCheck(s string) ([]string, error) {
-	result := []string{}
-	match := false
-	var err error
-
-	if match, err = regexp2.MustCompile(QUANTIFIERS_WITHIN_CAPTURING_GROUP, 0).MatchString(s); err != nil {
-		return nil, err
-	} else if match {
-		result = append(result, "FLAWED SETTINGS Please use possessive or lazy quantifiers within your capture group")
-	}
-	if match, err = regexp2.MustCompile(ALL_MATCH_NO_CAPTURING_GROUP, 0).MatchString(s); err != nil {
-		return nil, err
-	} else if match {
-		result = append(result, "FLAWED SETTINGS Please do not use a greedy all match")
-	}
-	if match, err = regexp2.MustCompile(CHARACTER_CLASS_WITH_GREEDY_OR_LAZY_QUANTIFIER, 0).MatchString(s); err != nil {
-		return nil, err
-	} else if match {
-		result = append(result, "FLAWED SETTINGS Greedy or lazy character classes are not allowed, please use a possessive quantifier instead")
-	}
-	return result, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/dynatrace-oss/terraform-provider-dynatrace
 go 1.26.2
 
 require (
-	github.com/dlclark/regexp2 v1.11.5
 	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260319155614-6bc81b419401
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
-github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260319155614-6bc81b419401 h1:xXknG58UA8JPujKSWwrB5bBxE25+06bjCuw/pzhkYpI=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260319155614-6bc81b419401/go.mod h1:VXl9eph7jcJb+Ao5uPaYJ+Jxi+o3439kpabmBRU8huw=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=


### PR DESCRIPTION
#### **Why** this PR?
Coming from https://github.com/dynatrace-oss/terraform-provider-dynatrace/pull/1070, I wondered if we even need this lib.
Turn out we don't, therefore we can remove it.

#### **What** has changed?
Removed dead code and the `dlclark/regexp2` lib.

#### **How** does it do it?
Removed dead code and the `dlclark/regexp2` lib.

#### How is it **tested**?
N/A

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
