### PR TITLE
test: make V2 configs more environment independent

### DIFF
--- a/dynatrace/api/v2/hub/extension/active_version/testdata/terraform/example-a.tf
+++ b/dynatrace/api/v2/hub/extension/active_version/testdata/terraform/example-a.tf
@@ -1,4 +1,4 @@
-resource "dynatrace_hub_extension_active_version" "custom_com_dynatrace_extension_prometheus-cadvisor" {
-  name    = "com.dynatrace.extension.active-directory-python"
-  version = "3.1.6"
+resource "dynatrace_hub_extension_active_version" "jmx-weblogic-cp" {
+  name    = "com.dynatrace.extension.jmx-weblogic-cp"
+  version = "2.1.1"
 }

--- a/dynatrace/api/v2/synthetic/monitors/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v2/synthetic/monitors/testdata/terraform/example_a.tf
@@ -1,10 +1,14 @@
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
 resource "dynatrace_network_monitor" "DNS_Test" {
   name          = "DNS Test"
   description   = "This is an example DNS test"
   type          = "MULTI_PROTOCOL"
   enabled       = false
   frequency_min = 15
-  locations     = [ "SYNTHETIC_LOCATION-39F97465BE7BF644" ]
+  locations     = [ data.dynatrace_synthetic_location.location.id ]
   outage_handling {
     global_consecutive_outage_count_threshold = 1
     global_outages                            = true

--- a/dynatrace/api/v2/synthetic/monitors/testdata/terraform/example_b.tf
+++ b/dynatrace/api/v2/synthetic/monitors/testdata/terraform/example_b.tf
@@ -1,9 +1,13 @@
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
 resource "dynatrace_network_monitor" "ICMP_Test" {
   name          = "ICMP Test"
   type          = "MULTI_PROTOCOL"
   enabled       = false
   frequency_min = 30
-  locations     = [ "SYNTHETIC_LOCATION-39F97465BE7BF644" ]
+  locations     = [ data.dynatrace_synthetic_location.location.id ]
   outage_handling {
     global_consecutive_outage_count_threshold = 1
     global_outages                            = true

--- a/dynatrace/api/v2/synthetic/monitors/testdata/terraform/example_c.tf
+++ b/dynatrace/api/v2/synthetic/monitors/testdata/terraform/example_c.tf
@@ -1,10 +1,14 @@
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
 resource "dynatrace_network_monitor" "TCP_Test" {
   name          = "TCP Test"
   description   = "This is an example TCP Test"
   type          = "MULTI_PROTOCOL"
   enabled       = false
   frequency_min = 15
-  locations     = [ "SYNTHETIC_LOCATION-39F97465BE7BF644" ]
+  locations     = [ data.dynatrace_synthetic_location.location.id ]
   outage_handling {
     global_consecutive_outage_count_threshold = 1
     global_outages                            = true


### PR DESCRIPTION
#### **Why** this PR?
It's not possible to execute some E2E in other environments because of hardcoded IDs.

#### **What** has changed?
V2 configs can now be executed on a different environment

#### **How** does it do it?
- By replacing hardcoded location IDs with a datasource
- By using the same extension for all examples (`com.dynatrace.extension.jmx-weblogic-cp`)

#### How is it **tested**?
Tests updated and are working

#### How does it affect **users**?
N/A

**Issue:** CA-17770
