### PR TITLE
test: make builtin configs more environment independent

### DIFF
--- a/dynatrace/api/builtin/appsec/notificationintegration/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/appsec/notificationintegration/testdata/terraform/example_a.tf
@@ -2,7 +2,7 @@ resource "dynatrace_appsec_notification" "Terraform_Security_Problem_Webhook_Tes
   type                                    = "WEBHOOK"
   enabled                                 = true
   display_name                            = "Terraform Security Problem Webhook Test"
-  security_problem_based_alerting_profile = "vu9U3hXa3q0AAAABACxidWlsdGluOmFwcHNlYy5ub3RpZmljYXRpb24tYWxlcnRpbmctcHJvZmlsZQAGdGVuYW50AAZ0ZW5hbnQAJDMyMDhkNWMyLTFlZmYtMzk5My1iNjMwLWI0MjQ5N2U4MDQ2Nr7vVN4V2t6t"
+  security_problem_based_alerting_profile = dynatrace_vulnerability_alerting.alert.id
   trigger                                 = "SECURITY_PROBLEM"
   security_problem_based_webhook_payload {
     payload = jsonencode({
@@ -16,4 +16,11 @@ resource "dynatrace_appsec_notification" "Terraform_Security_Problem_Webhook_Tes
     accept_any_certificate = false
     url                    = "https://www.dynatrace.com"
   }
+}
+
+resource "dynatrace_vulnerability_alerting" "alert" {
+  name                   = "#name#"
+  enabled                = true
+  enabled_risk_levels    = ["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+  enabled_trigger_events = ["SECURITY_PROBLEM_OPENED"]
 }

--- a/dynatrace/api/builtin/bizevents/processing/buckets/service_test.go
+++ b/dynatrace/api/builtin/bizevents/processing/buckets/service_test.go
@@ -26,5 +26,6 @@ import (
 )
 
 func TestAccBizEventsBuckets(t *testing.T) {
+	t.Skip("Deprecated")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/bizevents/processing/metrics/service_test.go
+++ b/dynatrace/api/builtin/bizevents/processing/metrics/service_test.go
@@ -26,5 +26,6 @@ import (
 )
 
 func TestAccBizEventsMetrics(t *testing.T) {
+	t.Skip("Deprecated")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/bizevents/processing/pipelines/service_test.go
+++ b/dynatrace/api/builtin/bizevents/processing/pipelines/service_test.go
@@ -26,5 +26,6 @@ import (
 )
 
 func TestAccBizEventsProcessing(t *testing.T) {
+	t.Skip("Deprecated")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/bizevents/security/contextrules/service_test.go
+++ b/dynatrace/api/builtin/bizevents/security/contextrules/service_test.go
@@ -26,5 +26,6 @@ import (
 )
 
 func TestAccBizEventsSecurityContext(t *testing.T) {
+	t.Skip("Deprecated")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/dashboards/general/service_test.go
+++ b/dynatrace/api/builtin/dashboards/general/service_test.go
@@ -23,8 +23,13 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDashboardsGeneral(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAcc(t, api.TestAccOptions{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {Source: "hashicorp/time"},
+		},
+	})
 }

--- a/dynatrace/api/builtin/dashboards/general/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/dashboards/general/testdata/terraform/example_a.tf
@@ -1,9 +1,43 @@
-resource "dynatrace_dashboards_general" "#name#" {
+resource "dynatrace_dashboards_general" "general" {
+  depends_on = [time_sleep.dashboard_create]
   enable_public_sharing = false
   default_dashboard_list {
     default_dashboard {
-      dashboard = "41eae96d-4930-4f44-bbd8-3699f21a8bbf"
-      user_group = "d0c2d3e3-c1b4-456a-b0ce-c560273f1488"
+      dashboard = dynatrace_dashboard.dashboard.id
+      user_group = dynatrace_iam_group.group.id
     }
+  }
+}
+
+# the datasource of dynatrace_dashboards_general may not be updated yet.
+resource "time_sleep" "dashboard_create" {
+  depends_on = [dynatrace_dashboard.dashboard]
+  create_duration = "5s"
+}
+
+resource "dynatrace_iam_group" "group" {
+  name = "#name#"
+}
+
+resource "dynatrace_dashboard" "dashboard" {
+  dashboard_metadata {
+    name   = "#name#"
+    owner  = "Dynatrace"
+    tags   = ["Kubernetes"]
+    dynamic_filters {
+      filters = ["KUBERNETES_CLUSTER"]
+    }
+  }
+  tile {
+    name       = "Markdown"
+    tile_type  = "MARKDOWN"
+    configured = true
+    bounds {
+      top    = 0
+      width  = 684
+      height = 38
+      left   = 0
+    }
+    markdown = "## Cluster resource overview"
   }
 }

--- a/dynatrace/api/builtin/dashboards/presets/service_test.go
+++ b/dynatrace/api/builtin/dashboards/presets/service_test.go
@@ -23,8 +23,13 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDashboardsPresets(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAcc(t, api.TestAccOptions{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {Source: "hashicorp/time"},
+		},
+	})
 }

--- a/dynatrace/api/builtin/dashboards/presets/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/dashboards/presets/testdata/terraform/example_a.tf
@@ -1,9 +1,45 @@
-resource "dynatrace_dashboards_presets" "#name#" {
+resource "dynatrace_dashboards_presets" "presets" {
+  depends_on = [time_sleep.dashboard_create]
   enable_dashboard_presets = true
   dashboard_presets_list {
     dashboard_presets {
-      dashboard_preset = "41eae96d-4930-4f44-bbd8-3699f21a8bbf"
-      user_group = "d0c2d3e3-c1b4-456a-b0ce-c560273f1488"
+      dashboard_preset = dynatrace_dashboard.dashboard.id
+      user_group = dynatrace_iam_group.group.id
     }
+  }
+}
+
+
+# the datasource of dynatrace_dashboards_presets may not be updated yet.
+resource "time_sleep" "dashboard_create" {
+  depends_on = [dynatrace_dashboard.dashboard]
+  create_duration = "5s"
+}
+
+resource "dynatrace_iam_group" "group" {
+  name = "#name#"
+}
+
+resource "dynatrace_dashboard" "dashboard" {
+  dashboard_metadata {
+    preset = true
+    name   = "#name#"
+    owner  = "Dynatrace"
+    tags   = ["Kubernetes"]
+    dynamic_filters {
+      filters = ["KUBERNETES_CLUSTER"]
+    }
+  }
+  tile {
+    name       = "Markdown"
+    tile_type  = "MARKDOWN"
+    configured = true
+    bounds {
+      top    = 0
+      width  = 684
+      height = 38
+      left   = 0
+    }
+    markdown = "## Cluster resource overview"
   }
 }

--- a/dynatrace/api/builtin/davis/anomalydetectors/testcases/update-analyzer-input-field-set/create.tf
+++ b/dynatrace/api/builtin/davis/anomalydetectors/testcases/update-analyzer-input-field-set/create.tf
@@ -37,5 +37,10 @@ resource "dynatrace_davis_anomaly_detectors" "detector" {
     }
   }
   execution_settings {
+    actor = dynatrace_iam_service_user.user.id
   }
+}
+
+resource "dynatrace_iam_service_user" "user" {
+  name = "#name#"
 }

--- a/dynatrace/api/builtin/davis/anomalydetectors/testcases/update-analyzer-input-field-set/update.tf
+++ b/dynatrace/api/builtin/davis/anomalydetectors/testcases/update-analyzer-input-field-set/update.tf
@@ -38,5 +38,10 @@ resource "dynatrace_davis_anomaly_detectors" "detector" {
     }
   }
   execution_settings {
+    actor = dynatrace_iam_service_user.user.id
   }
+}
+
+resource "dynatrace_iam_service_user" "user" {
+  name = "#name#"
 }

--- a/dynatrace/api/builtin/davis/anomalydetectors/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/davis/anomalydetectors/testdata/terraform/example_a.tf
@@ -57,5 +57,10 @@ resource "dynatrace_davis_anomaly_detectors" "#name#" {
     }
   }
   execution_settings {
+    actor = dynatrace_iam_service_user.user.id
   }
+}
+
+resource "dynatrace_iam_service_user" "user" {
+  name = "#name#"
 }

--- a/dynatrace/api/builtin/davis/anomalydetectors/testdata/terraform/example_b.tf
+++ b/dynatrace/api/builtin/davis/anomalydetectors/testdata/terraform/example_b.tf
@@ -8,7 +8,7 @@ resource "dynatrace_davis_anomaly_detectors" "anomaly" {
     input {
       analyzer_input_field {
         key   = "query.expression"
-        value =<<-EOT
+        value = <<-EOT
           fetch dt.system.query_executions
                                  | filter status == "SUCCEEDED"
                                  | fields timestamp, scanned_bytes, user.email
@@ -70,6 +70,11 @@ resource "dynatrace_davis_anomaly_detectors" "anomaly" {
   }
   execution_settings {
     query_offset = 3
-    delay = 60
+    delay        = 60
+    actor        = dynatrace_iam_service_user.user.id
   }
+}
+
+resource "dynatrace_iam_service_user" "user" {
+  name = "#name#"
 }

--- a/dynatrace/api/builtin/generic/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/generic/testdata/terraform/example_a.tf
@@ -1,12 +1,23 @@
 resource "dynatrace_generic_setting" "ABC" {
-  schema = "app:my.booking.analytics:connection"
+  schema = "app:dynatrace.site.reliability.guardian:guardians"
   scope  = "environment"
   value = jsonencode({
-    "client_id"     : "asdfhh",
-    "client_secret" : "mysecret",
-    "name"          : "ABC",
-    "tenant_id"     : "asdf",
-    "type"          : "client_secret",
-    "user_id"       : "asdf"
+    "name": "#name#",
+    "tags": [ "stage:staging" ],
+    "eventKind": "BIZ_EVENT",
+    "objectives": [
+      {
+        "name": "Error rate",
+        "comparisonOperator": "LESS_THAN_OR_EQUAL",
+        "dqlQuery": <<-EOT
+        fetch logs
+        | fieldsAdd errors = toLong(loglevel == "ERROR")
+        | summarize errorRate = sum(errors)/count() * 100
+      EOT
+        "objectiveType": "DQL",
+        "target": 8,
+        "warning": 6
+      }
+    ]
   })
 }

--- a/dynatrace/api/builtin/host/monitoring/mode/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/host/monitoring/mode/testdata/terraform/example_a.tf
@@ -1,4 +1,8 @@
-resource "dynatrace_host_monitoring_mode" "#name#" {
-  host_id         = "HOST-E532D48B0DBD5A6B"
+resource "dynatrace_host_monitoring_mode" "mode" {
+  host_id         = data.dynatrace_entities.hosts.entities[0].entity_id
   monitoring_mode = "FULL_STACK"
+}
+
+data "dynatrace_entities" "hosts" {
+  type = "HOST"
 }

--- a/dynatrace/api/builtin/rum/web/appdetection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/rum/web/appdetection/testdata/terraform/example_a.tf
@@ -1,5 +1,67 @@
-resource "dynatrace_application_detection_rule_v2" "#name#" {
-  application_id = "APPLICATION-90CE01F27D579187"
+resource "dynatrace_application_detection_rule_v2" "detection_rule" {
+  application_id = dynatrace_web_application.application.id
   matcher        = "DOMAIN_MATCHES"
   pattern        = "TerraformTest"
+}
+
+resource "dynatrace_web_application" "application" {
+  name                                 = "#name#"
+  type                                 = "AUTO_INJECTED"
+  cost_control_user_session_percentage = 100
+  load_action_key_performance_metric   = "VISUALLY_COMPLETE"
+  real_user_monitoring_enabled         = true
+  xhr_action_key_performance_metric    = "VISUALLY_COMPLETE"
+  custom_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  load_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  monitoring_settings {
+    add_cross_origin_anonymous_attribute = true
+    cache_control_header_optimizations   = true
+    injection_mode                       = "JAVASCRIPT_TAG"
+    script_tag_cache_duration_in_hours   = 1
+    advanced_javascript_tag_settings {
+      max_action_name_length = 100
+      max_errors_to_capture  = 10
+      additional_event_handlers {
+        max_dom_nodes = 5000
+      }
+    }
+    content_capture {
+      resource_timing_settings {
+        instrumentation_delay    = 53
+        non_w3c_resource_timings = true
+        w3c_resource_timings     = true
+      }
+      timeout_settings {
+        temporary_action_limit         = 3
+        temporary_action_total_timeout = 100
+        timed_action_support           = true
+      }
+    }
+  }
+  user_action_naming_settings {}
+  waterfall_settings {
+    resource_browser_caching_threshold            = 50
+    resources_threshold                           = 100000
+    slow_cnd_resources_threshold                  = 200000
+    slow_first_party_resources_threshold          = 200000
+    slow_third_party_resources_threshold          = 200000
+    speed_index_visually_complete_ratio_threshold = 50
+    uncompressed_resources_threshold              = 860
+  }
+  xhr_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
 }

--- a/dynatrace/api/builtin/rum/web/appdetection/testdata/terraform/example_insert_after.tf
+++ b/dynatrace/api/builtin/rum/web/appdetection/testdata/terraform/example_insert_after.tf
@@ -1,12 +1,74 @@
 resource "dynatrace_application_detection_rule_v2" "first-instance" {
-  application_id = "APPLICATION-90CE01F27D579187"
+  application_id = dynatrace_web_application.application.id
   matcher        = "DOMAIN_MATCHES"
   pattern        = "TerraformTest"
 }
 
 resource "dynatrace_application_detection_rule_v2" "second-instance" {
-  application_id = "APPLICATION-90CE01F27D579187"
+  application_id = dynatrace_web_application.application.id
   matcher        = "DOMAIN_MATCHES"
   pattern        = "TerraformTest-2"
-  insert_after = dynatrace_application_detection_rule_v2.first-instance.id
+  insert_after   = dynatrace_application_detection_rule_v2.first-instance.id
+}
+
+resource "dynatrace_web_application" "application" {
+  name                                 = "#name#"
+  type                                 = "AUTO_INJECTED"
+  cost_control_user_session_percentage = 100
+  load_action_key_performance_metric   = "VISUALLY_COMPLETE"
+  real_user_monitoring_enabled         = true
+  xhr_action_key_performance_metric    = "VISUALLY_COMPLETE"
+  custom_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  load_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
+  monitoring_settings {
+    add_cross_origin_anonymous_attribute = true
+    cache_control_header_optimizations   = true
+    injection_mode                       = "JAVASCRIPT_TAG"
+    script_tag_cache_duration_in_hours   = 1
+    advanced_javascript_tag_settings {
+      max_action_name_length = 100
+      max_errors_to_capture  = 10
+      additional_event_handlers {
+        max_dom_nodes = 5000
+      }
+    }
+    content_capture {
+      resource_timing_settings {
+        instrumentation_delay    = 53
+        non_w3c_resource_timings = true
+        w3c_resource_timings     = true
+      }
+      timeout_settings {
+        temporary_action_limit         = 3
+        temporary_action_total_timeout = 100
+        timed_action_support           = true
+      }
+    }
+  }
+  user_action_naming_settings {}
+  waterfall_settings {
+    resource_browser_caching_threshold            = 50
+    resources_threshold                           = 100000
+    slow_cnd_resources_threshold                  = 200000
+    slow_first_party_resources_threshold          = 200000
+    slow_third_party_resources_threshold          = 200000
+    speed_index_visually_complete_ratio_threshold = 50
+    uncompressed_resources_threshold              = 860
+  }
+  xhr_action_apdex_settings {
+    frustrating_fallback_threshold = 12000
+    frustrating_threshold          = 12000
+    tolerated_fallback_threshold   = 3000
+    tolerated_threshold            = 3000
+  }
 }

--- a/dynatrace/api/builtin/tags/autotagging/rules/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/tags/autotagging/rules/testdata/terraform/example_a.tf
@@ -1,5 +1,5 @@
-resource "dynatrace_autotag_rules" "Avengers" {
-  auto_tag_id = "vu9U3hXa3q0AAAABABlidWlsdGluOnRhZ3MuYXV0by10YWdnaW5nAAZ0ZW5hbnQABnRlbmFudAAkOTNjMDBkYzktY2FkMC0zMWY3LWEzZGQtMWQ4MDdjMWQwMjhivu9U3hXa3q0"
+resource "dynatrace_autotag_rules" "rules" {
+  auto_tag_id = dynatrace_autotag_v2.tag.id
   rules {
     rule {
       type                = "ME"
@@ -58,4 +58,10 @@ resource "dynatrace_autotag_rules" "Avengers" {
       }
     }
   }
+}
+
+
+resource "dynatrace_autotag_v2" "tag" {
+  name                        = "#name#"
+  rules_maintained_externally = true
 }


### PR DESCRIPTION
#### **Why** this PR?
It's not possible to execute some E2E in other environments because of hardcoded IDs.

#### **What** has changed?
Builtin configs (except OpenPipeline) can now be executed on a different environment

#### **How** does it do it?
- By replacing hardcoded location IDs with a datasource or a resource
- By skipping deprecated OpenPipeline schemas
- By changing a generic settings example to use a builtin setting
- By changing examples so that they can be applied (e.g., dynatrace_activegate_token)

#### How is it **tested**?
Tests updated and are working

#### How does it affect **users**?
N/A

**Issue:** CA-17770
