### PR TITLE
fix: boundary export

### DIFF
--- a/dynatrace/api/iam/boundaries/service.go
+++ b/dynatrace/api/iam/boundaries/service.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -31,17 +33,27 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 )
 
+const maxPageSize = 10000
+
 func Service(credentials *rest.Credentials) settings.CRUDService[*boundaries.PolicyBoundary] {
 	return &BoundaryServiceClient{
-		clientID:     credentials.IAM.ClientID,
-		accountID:    credentials.IAM.AccountID,
-		clientSecret: credentials.IAM.ClientSecret,
-		tokenURL:     credentials.IAM.TokenURL,
-		endpointURL:  credentials.IAM.EndpointURL,
+		iamClientGetter: &iamClientGetterImp{
+			clientID:     credentials.IAM.ClientID,
+			accountID:    credentials.IAM.AccountID,
+			clientSecret: credentials.IAM.ClientSecret,
+			tokenURL:     credentials.IAM.TokenURL,
+			endpointURL:  credentials.IAM.EndpointURL,
+		},
+		accountID:   credentials.IAM.AccountID,
+		endpointURL: credentials.IAM.EndpointURL,
 	}
 }
 
-type BoundaryServiceClient struct {
+type iamClientGetter interface {
+	New(ctx context.Context) iam.IAMClient
+}
+
+type iamClientGetterImp struct {
 	clientID     string
 	accountID    string
 	clientSecret string
@@ -49,64 +61,74 @@ type BoundaryServiceClient struct {
 	endpointURL  string
 }
 
-func (me *BoundaryServiceClient) ClientID() string {
+func (me *iamClientGetterImp) ClientID() string {
 	return me.clientID
 }
 
-func (me *BoundaryServiceClient) AccountID() string {
+func (me *iamClientGetterImp) AccountID() string {
 	return me.accountID
 }
 
-func (me *BoundaryServiceClient) ClientSecret() string {
+func (me *iamClientGetterImp) ClientSecret() string {
 	return me.clientSecret
 }
 
-func (me *BoundaryServiceClient) TokenURL() string {
+func (me *iamClientGetterImp) TokenURL() string {
 	return me.tokenURL
 }
 
-func (me *BoundaryServiceClient) EndpointURL() string {
+func (me *iamClientGetterImp) EndpointURL() string {
 	return me.endpointURL
 }
 
+func (me *iamClientGetterImp) New(ctx context.Context) iam.IAMClient {
+	return iam.NewIAMClient(ctx, me)
+}
+
+type BoundaryServiceClient struct {
+	iamClientGetter iamClientGetter
+	accountID       string
+	endpointURL     string
+}
+
 func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	var err error
-	var responseBytes []byte
-
-	client := iam.NewIAMClient(ctx, me)
-
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries", me.endpointURL, me.AccountID()), 200, false); err != nil {
-		return nil, err
-	}
-
-	var response ListPolicyBoundariesResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
-		return nil, err
-	}
-	if len(response.PolicyBoundaries) == 0 {
-		return api.Stubs{}, nil
-	}
+	client := me.iamClientGetter.New(ctx)
 	stubs := api.Stubs{}
-	for _, boundary := range response.PolicyBoundaries {
-		stubs = append(stubs, &api.Stub{ID: boundary.UUID, Name: boundary.Name})
+	params := url.Values{}
+	params.Set("size", strconv.Itoa(maxPageSize))
+
+	for page := 1; ; page++ {
+		params.Set("page", strconv.Itoa(page))
+		reqURL := fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries?%s", me.endpointURL, me.accountID, params.Encode())
+		responseBytes, err := client.GET(ctx, reqURL, 200, false)
+		if err != nil {
+			return nil, err
+		}
+
+		var response ListPolicyBoundariesResponse
+		if err = json.Unmarshal(responseBytes, &response); err != nil {
+			return nil, err
+		}
+
+		for _, boundary := range response.PolicyBoundaries {
+			stubs = append(stubs, &api.Stub{ID: boundary.UUID, Name: boundary.Name})
+		}
+
+		if len(response.PolicyBoundaries) < maxPageSize {
+			break
+		}
 	}
+
 	return stubs, nil
 }
 
 func (me *BoundaryServiceClient) Get(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
-	var err error
-	var responseBytes []byte
-
-	client := iam.NewIAMClient(ctx, me)
-
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id), 200, false); err != nil {
+	responseBytes, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.accountID, id), 200, false)
+	if err != nil {
 		return err
 	}
 
-	if err = json.Unmarshal(responseBytes, v); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(responseBytes, v)
 }
 
 func (me *BoundaryServiceClient) SchemaID() string {
@@ -114,18 +136,14 @@ func (me *BoundaryServiceClient) SchemaID() string {
 }
 
 func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.PolicyBoundary) (*api.Stub, error) {
-	var err error
-	var responseBytes []byte
-
-	client := iam.NewIAMClient(ctx, me)
-
-	if responseBytes, err = client.POST(
+	responseBytes, err := me.iamClientGetter.New(ctx).POST(
 		ctx,
-		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries", me.endpointURL, me.AccountID()),
+		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries", me.endpointURL, me.accountID),
 		v,
 		201,
 		false,
-	); err != nil {
+	)
+	if err != nil {
 		return nil, err
 	}
 
@@ -142,40 +160,30 @@ func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.Polic
 }
 
 func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
-	var err error
-
-	client := iam.NewIAMClient(ctx, me)
-
-	if _, err = client.PUT_MULTI_RESPONSE(
+	_, err := me.iamClientGetter.New(ctx).PUT_MULTI_RESPONSE(
 		ctx,
-		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id),
+		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.accountID, id),
 		v,
 		[]int{201, 204},
 		false,
-	); err != nil {
-		return err
-
-	}
-
-	return nil
+	)
+	return err
 }
 
 func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
-	var err error
-
-	client := iam.NewIAMClient(ctx, me)
-
-	if _, err = client.DELETE(
+	client := me.iamClientGetter.New(ctx)
+	_, err := client.DELETE(
 		ctx,
-		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id),
+		fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.accountID, id),
 		204,
 		false,
-	); err != nil {
+	)
+	if err != nil {
 		if strings.Contains(err.Error(), "Policy boundary is in use") {
 			clean.CleanUp.Register(func() {
 				client.DELETE(
 					ctx,
-					fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.AccountID(), id),
+					fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries/%s", me.endpointURL, me.accountID, id),
 					204,
 					false,
 				)

--- a/dynatrace/api/iam/boundaries/service_unit_test.go
+++ b/dynatrace/api/iam/boundaries/service_unit_test.go
@@ -1,0 +1,167 @@
+//go:build unit
+
+/**
+* @license
+* Copyright 2025 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package boundaries
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAccountID   = "test-account-id"
+	testEndpointURL = "https://api.dynatrace.com"
+)
+
+func newTestClient(mock iam.IAMClient) *BoundaryServiceClient {
+	return &BoundaryServiceClient{
+		iamClientGetter: &testing2.MockIAMClientGetter{Client: mock},
+		accountID:       testAccountID,
+		endpointURL:     testEndpointURL,
+	}
+}
+
+func boundaryPageResponse(items []PolicyBoundary) []byte {
+	data, _ := json.Marshal(ListPolicyBoundariesResponse{PolicyBoundaries: items})
+	return data
+}
+
+func pageURL(page int) string {
+	params := url.Values{}
+	params.Set("size", strconv.Itoa(maxPageSize))
+	params.Set("page", strconv.Itoa(page))
+	return fmt.Sprintf("%s/iam/v1/repo/account/%s/boundaries?%s", testEndpointURL, testAccountID, params.Encode())
+}
+
+func TestBoundaryServiceClient_List(t *testing.T) {
+	t.Run("Returns error on GET failure", func(t *testing.T) {
+		mock := &testing2.MockIAMClient{
+			GETFunc: func(_ context.Context, _ string, _ int, _ bool) ([]byte, error) {
+				return nil, assert.AnError
+			},
+		}
+		_, err := newTestClient(mock).List(t.Context())
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("Returns error on invalid JSON response", func(t *testing.T) {
+		mock := &testing2.MockIAMClient{
+			GETFunc: func(_ context.Context, _ string, _ int, _ bool) ([]byte, error) {
+				return []byte("not-json"), nil
+			},
+		}
+		_, err := newTestClient(mock).List(t.Context())
+		expectedErr := &json.SyntaxError{}
+		assert.ErrorAs(t, err, &expectedErr)
+	})
+
+	t.Run("Returns empty stubs for empty response", func(t *testing.T) {
+		mock := &testing2.MockIAMClient{
+			GETFunc: func(_ context.Context, _ string, _ int, _ bool) ([]byte, error) {
+				return boundaryPageResponse(nil), nil
+			},
+		}
+		stubs, err := newTestClient(mock).List(t.Context())
+		require.NoError(t, err)
+		assert.Empty(t, stubs)
+	})
+
+	t.Run("Returns stubs for single page", func(t *testing.T) {
+		items := []PolicyBoundary{
+			{UUID: "uuid-1", Name: "boundary-1"},
+			{UUID: "uuid-2", Name: "boundary-2"},
+		}
+		callCount := 0
+		mock := &testing2.MockIAMClient{
+			GETFunc: func(_ context.Context, reqURL string, _ int, _ bool) ([]byte, error) {
+				callCount++
+				assert.Equal(t, pageURL(1), reqURL)
+				return boundaryPageResponse(items), nil
+			},
+		}
+
+		stubs, err := newTestClient(mock).List(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, 1, callCount)
+		require.Len(t, stubs, 2)
+		assert.Equal(t, "uuid-1", stubs[0].ID)
+		assert.Equal(t, "boundary-1", stubs[0].Name)
+		assert.Equal(t, "uuid-2", stubs[1].ID)
+		assert.Equal(t, "boundary-2", stubs[1].Name)
+	})
+
+	t.Run("Paginates until partial page", func(t *testing.T) {
+		fullPage := make([]PolicyBoundary, maxPageSize)
+		for i := range fullPage {
+			fullPage[i] = PolicyBoundary{UUID: fmt.Sprintf("uuid-p1-%d", i), Name: fmt.Sprintf("b-p1-%d", i)}
+		}
+		page2 := []PolicyBoundary{
+			{UUID: "uuid-p2-0", Name: "b-p2-0"},
+			{UUID: "uuid-p2-1", Name: "b-p2-1"},
+		}
+
+		callCount := 0
+		mock := &testing2.MockIAMClient{
+			GETFunc: func(_ context.Context, reqURL string, _ int, _ bool) ([]byte, error) {
+				callCount++
+				switch callCount {
+				case 1:
+					assert.Equal(t, pageURL(1), reqURL)
+					return boundaryPageResponse(fullPage), nil
+				case 2:
+					assert.Equal(t, pageURL(2), reqURL)
+					return boundaryPageResponse(page2), nil
+				default:
+					return nil, fmt.Errorf("unexpected page request %d", callCount)
+				}
+			},
+		}
+
+		stubs, err := newTestClient(mock).List(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, 2, callCount)
+		assert.Len(t, stubs, maxPageSize+2)
+	})
+
+	t.Run("Returns error on second page GET failure", func(t *testing.T) {
+		fullPage := make([]PolicyBoundary, maxPageSize)
+		callCount := 0
+		mock := &testing2.MockIAMClient{
+			GETFunc: func(_ context.Context, _ string, _ int, _ bool) ([]byte, error) {
+				callCount++
+				if callCount == 1 {
+					return boundaryPageResponse(fullPage), nil
+				}
+				return nil, assert.AnError
+			},
+		}
+
+		_, err := newTestClient(mock).List(t.Context())
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+}

--- a/dynatrace/api/iam/serviceusers/service_test.go
+++ b/dynatrace/api/iam/serviceusers/service_test.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	serviceusers "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,58 +34,19 @@ import (
 const testAccountID = "test-account-id"
 const testEndpointURL = "https://api-test.dynatrace.com"
 
-type mockIAMClient struct {
-	POSTFunc   func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
-	PUTFunc    func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
-	GETFunc    func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
-	DELETEFunc func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
-}
-
-func (me *mockIAMClient) POST(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
-	return me.POSTFunc(ctx, url, payload, expectedResponseCode, forceNewBearer)
-}
-
-func (me *mockIAMClient) PUT(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
-	return me.PUTFunc(ctx, url, payload, expectedResponseCode, forceNewBearer)
-}
-
-func (me *mockIAMClient) PUT_MULTI_RESPONSE(ctx context.Context, url string, payload any, expectedResponseCodes []int, forceNewBearer bool) ([]byte, error) {
-	panic("mock doesnt support PUT_MULTI_RESPONSE")
-}
-
-func (me *mockIAMClient) GET(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
-	return me.GETFunc(ctx, url, expectedResponseCode, forceNewBearer)
-}
-
-func (me *mockIAMClient) DELETE(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
-	return me.DELETEFunc(ctx, url, expectedResponseCode, forceNewBearer)
-}
-
-func (me *mockIAMClient) DELETE_MULTI_RESPONSE(ctx context.Context, url string, expectedResponseCodes []int, forceNewBearer bool) ([]byte, error) {
-	panic("mock doesnt support DELETE_MULTI_RESPONSE")
-}
-
-func createTestServiceUserServiceClient(client *mockIAMClient) *serviceUserServiceClient {
+func createTestServiceUserServiceClient(client *testing2.MockIAMClient) *serviceUserServiceClient {
 	return &serviceUserServiceClient{
-		iamClientGetter: &mockIAMClientGetter{
-			client: client,
+		iamClientGetter: &testing2.MockIAMClientGetter{
+			Client: client,
 		},
 		accountID:   testAccountID,
 		endpointURL: testEndpointURL,
 	}
 }
 
-type mockIAMClientGetter struct {
-	client *mockIAMClient
-}
-
-func (me *mockIAMClientGetter) New(_ context.Context) iam.IAMClient {
-	return me.client
-}
-
 func TestService_Create(t *testing.T) {
 	t.Run("successful creation", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", testEndpointURL, testAccountID), url)
 				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
@@ -110,7 +71,7 @@ func TestService_Create(t *testing.T) {
 	})
 
 	t.Run("successful creation with empty groups", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", testEndpointURL, testAccountID), url)
 				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
@@ -135,7 +96,7 @@ func TestService_Create(t *testing.T) {
 	})
 
 	t.Run("creation fails on POST", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return nil, errors.New("POST failed")
 			},
@@ -151,7 +112,7 @@ func TestService_Create(t *testing.T) {
 	})
 
 	t.Run("creation fails on group assignment and cleanup succeeds", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
 			},
@@ -174,7 +135,7 @@ func TestService_Create(t *testing.T) {
 	})
 
 	t.Run("creation fails on group assignment and cleanup fails", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
 			},
@@ -197,7 +158,7 @@ func TestService_Create(t *testing.T) {
 	})
 
 	t.Run("creation fails on invalid JSON response", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			POSTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{invalid json`), nil
 			},
@@ -217,7 +178,7 @@ func TestService_Create(t *testing.T) {
 func TestService_Get(t *testing.T) {
 	t.Run("successful get with groups", func(t *testing.T) {
 		getCallCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				getCallCount++
 				if getCallCount == 1 {
@@ -247,7 +208,7 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("successful get without groups", func(t *testing.T) {
 		getCallCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				getCallCount++
 				if getCallCount == 1 {
@@ -274,7 +235,7 @@ func TestService_Get(t *testing.T) {
 	})
 
 	t.Run("get fails on service user fetch", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return nil, errors.New("GET failed")
 			},
@@ -289,7 +250,7 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("get fails on user groups fetch", func(t *testing.T) {
 		getCallCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				getCallCount++
 				if getCallCount == 1 {
@@ -311,7 +272,7 @@ func TestService_Get(t *testing.T) {
 	})
 
 	t.Run("get returns error when service user not found", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return nil, errors.New("Service user test-uid does not exist")
 			},
@@ -325,7 +286,7 @@ func TestService_Get(t *testing.T) {
 	})
 
 	t.Run("get fails on invalid JSON for service user", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{invalid json`), nil
 			},
@@ -340,7 +301,7 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("get fails on invalid JSON for user groups", func(t *testing.T) {
 		getCallCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				getCallCount++
 				if getCallCount == 1 {
@@ -364,7 +325,7 @@ func TestService_Get(t *testing.T) {
 
 func TestService_GetAll(t *testing.T) {
 	t.Run("successful get all without pagination", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users", testEndpointURL, testAccountID), url)
 				return []byte(`{
@@ -393,7 +354,7 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("successful get all with pagination", func(t *testing.T) {
 		callCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				callCount++
 				if callCount == 1 {
@@ -431,7 +392,7 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("successful get all with multiple pagination pages", func(t *testing.T) {
 		callCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				callCount++
 				if callCount == 1 {
@@ -467,7 +428,7 @@ func TestService_GetAll(t *testing.T) {
 	})
 
 	t.Run("get all fails", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return nil, errors.New("GET failed")
 			},
@@ -480,7 +441,7 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("get all fails on second page", func(t *testing.T) {
 		callCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				callCount++
 				if callCount == 1 {
@@ -500,7 +461,7 @@ func TestService_GetAll(t *testing.T) {
 	})
 
 	t.Run("get all empty", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{
 					"count": 0,
@@ -516,7 +477,7 @@ func TestService_GetAll(t *testing.T) {
 	})
 
 	t.Run("get all fails on invalid JSON response", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{invalid json`), nil
 			},
@@ -529,7 +490,7 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("get all fails on invalid JSON response on second page", func(t *testing.T) {
 		callCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				callCount++
 				if callCount == 1 {
@@ -551,7 +512,7 @@ func TestService_GetAll(t *testing.T) {
 
 func TestService_List(t *testing.T) {
 	t.Run("successful list without pagination", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{
 					"count": 2,
@@ -575,7 +536,7 @@ func TestService_List(t *testing.T) {
 
 	t.Run("successful list with pagination", func(t *testing.T) {
 		callCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				callCount++
 				if callCount == 1 {
@@ -610,7 +571,7 @@ func TestService_List(t *testing.T) {
 	})
 
 	t.Run("list fails", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return nil, errors.New("GET failed")
 			},
@@ -622,7 +583,7 @@ func TestService_List(t *testing.T) {
 	})
 
 	t.Run("list empty", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{
 					"count": 0,
@@ -638,7 +599,7 @@ func TestService_List(t *testing.T) {
 	})
 
 	t.Run("list fails on invalid JSON response", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			GETFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return []byte(`{invalid json`), nil
 			},
@@ -653,7 +614,7 @@ func TestService_List(t *testing.T) {
 func TestService_Update(t *testing.T) {
 	t.Run("successful update", func(t *testing.T) {
 		putCallCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				putCallCount++
 				if putCallCount == 1 {
@@ -685,7 +646,7 @@ func TestService_Update(t *testing.T) {
 	})
 
 	t.Run("update fails on user details", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return nil, errors.New("PUT failed")
 			},
@@ -703,7 +664,7 @@ func TestService_Update(t *testing.T) {
 
 	t.Run("update fails on group assignment", func(t *testing.T) {
 		putCallCount := 0
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			PUTFunc: func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				putCallCount++
 				if putCallCount == 1 {
@@ -733,7 +694,7 @@ func TestService_Update(t *testing.T) {
 
 func TestService_Delete(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			DELETEFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				assert.Equal(t, fmt.Sprintf("%s/iam/v1/accounts/%s/service-users/%s", testEndpointURL, testAccountID, "test-uid"), url)
 				return nil, nil
@@ -746,7 +707,7 @@ func TestService_Delete(t *testing.T) {
 	})
 
 	t.Run("delete fails", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			DELETEFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return nil, errors.New("DELETE failed")
 			},
@@ -758,7 +719,7 @@ func TestService_Delete(t *testing.T) {
 	})
 
 	t.Run("delete errors if service user does not exist", func(t *testing.T) {
-		mockClient := &mockIAMClient{
+		mockClient := &testing2.MockIAMClient{
 			DELETEFunc: func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
 				return nil, errors.New("User test-uid does not exist")
 			},
@@ -771,7 +732,7 @@ func TestService_Delete(t *testing.T) {
 }
 
 func TestService_SchemaID(t *testing.T) {
-	client := createTestServiceUserServiceClient(&mockIAMClient{})
+	client := createTestServiceUserServiceClient(&testing2.MockIAMClient{})
 	schemaID := client.SchemaID()
 	assert.Equal(t, "accounts:iam:serviceusers", schemaID)
 }

--- a/dynatrace/testing/mockiamclient.go
+++ b/dynatrace/testing/mockiamclient.go
@@ -1,0 +1,62 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testing
+
+import (
+	"context"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
+)
+
+type MockIAMClient struct {
+	POSTFunc   func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
+	PUTFunc    func(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
+	GETFunc    func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
+	DELETEFunc func(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error)
+}
+
+func (me *MockIAMClient) POST(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+	return me.POSTFunc(ctx, url, payload, expectedResponseCode, forceNewBearer)
+}
+
+func (me *MockIAMClient) PUT(ctx context.Context, url string, payload any, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+	return me.PUTFunc(ctx, url, payload, expectedResponseCode, forceNewBearer)
+}
+
+func (me *MockIAMClient) PUT_MULTI_RESPONSE(ctx context.Context, url string, payload any, expectedResponseCodes []int, forceNewBearer bool) ([]byte, error) {
+	panic("mock doesnt support PUT_MULTI_RESPONSE")
+}
+
+func (me *MockIAMClient) GET(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+	return me.GETFunc(ctx, url, expectedResponseCode, forceNewBearer)
+}
+
+func (me *MockIAMClient) DELETE(ctx context.Context, url string, expectedResponseCode int, forceNewBearer bool) ([]byte, error) {
+	return me.DELETEFunc(ctx, url, expectedResponseCode, forceNewBearer)
+}
+
+func (me *MockIAMClient) DELETE_MULTI_RESPONSE(ctx context.Context, url string, expectedResponseCodes []int, forceNewBearer bool) ([]byte, error) {
+	panic("mock doesnt support DELETE_MULTI_RESPONSE")
+}
+
+type MockIAMClientGetter struct {
+	Client iam.IAMClient
+}
+
+func (me *MockIAMClientGetter) New(_ context.Context) iam.IAMClient {
+	return me.Client
+}


### PR DESCRIPTION
#### **Why** this PR?
Exporting boundaries (dynatrace_iam_policy_boundary) only exported a max of 100 boundaries.

#### **What** has changed?
All boundaries are now exported

#### **How** does it do it?
By iterating over all pages and returning the full result.

#### How is it **tested**?
New tests added
Testing utilities of service-user moved to a central testing folder.

#### How does it affect **users**?
They can now use our export functionality to download all boundaries instead of the first 100 ones.

**Issue:** CA-19254