### PR TITLE
fix: flaky dashboard general creation

### DIFF
--- a/dynatrace/api/builtin/dashboards/general/service.go
+++ b/dynatrace/api/builtin/dashboards/general/service.go
@@ -18,15 +18,83 @@
 package general
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	general "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/dashboards/general/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
 const SchemaVersion = "1.0.18"
 const SchemaID = "builtin:dashboards.general"
+const defaultTimeout = 20 * time.Second
+
+type service struct {
+	service settings.CRUDService[*general.Settings]
+}
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*general.Settings] {
-	return settings20.Service[*general.Settings](credentials, SchemaID, SchemaVersion)
+	return &service{settings20.Service[*general.Settings](credentials, SchemaID, SchemaVersion)}
+}
+func (me *service) Create(ctx context.Context, v *general.Settings) (*api.Stub, error) {
+	var apiStub *api.Stub
+	err := retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
+		var err error
+		apiStub, err = me.service.Create(ctx, v)
+		return classifyRetryError(err)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return apiStub, nil
+}
+
+// classifyRetryErrors retries on certain conflicts
+// During "create" the data source of the dashboard may not be up to date.
+func classifyRetryError(err error) *retry.RetryError {
+	if err == nil {
+		return nil
+	}
+	if restError, ok := errors.AsType[rest.Error](err); ok && restError.Code == http.StatusBadRequest {
+		containsConflict := slices.ContainsFunc(restError.ConstraintViolations, func(cv rest.ConstraintViolation) bool {
+			return strings.Contains(cv.Message, "Invalid value in datasource")
+		})
+		if containsConflict {
+			return retry.RetryableError(err)
+		}
+	}
+
+	return retry.NonRetryableError(err)
+}
+
+func (me *service) Update(ctx context.Context, id string, v *general.Settings) error {
+	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
+		err := me.service.Update(ctx, id, v)
+		return classifyRetryError(err)
+	})
+}
+
+func (me *service) Delete(ctx context.Context, id string) error {
+	return me.service.Delete(ctx, id)
+}
+
+func (me *service) Get(ctx context.Context, id string, v *general.Settings) error {
+	return me.service.Get(ctx, id, v)
+}
+
+func (me *service) List(ctx context.Context) (api.Stubs, error) {
+	return me.service.List(ctx)
+}
+
+func (me *service) SchemaID() string {
+	return SchemaID
 }

--- a/dynatrace/api/builtin/dashboards/general/service_test.go
+++ b/dynatrace/api/builtin/dashboards/general/service_test.go
@@ -23,13 +23,12 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDashboardsGeneral(t *testing.T) {
-	api.TestAcc(t, api.TestAccOptions{
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {Source: "hashicorp/time"},
-		},
-	})
+	api.TestAcc(t)
+}
+
+func TestAccTestCasesDashboardsGeneral(t *testing.T) {
+	api.TestAccTestCases(t)
 }

--- a/dynatrace/api/builtin/dashboards/general/testcases/update/create.tf
+++ b/dynatrace/api/builtin/dashboards/general/testcases/update/create.tf
@@ -2,6 +2,7 @@ resource "dynatrace_dashboards_general" "general" {
   enable_public_sharing = false
   default_dashboard_list {
     default_dashboard {
+      # to update (a new just created dashboard)
       dashboard = dynatrace_dashboard.dashboard.id
       user_group = dynatrace_iam_group.group.id
     }

--- a/dynatrace/api/builtin/dashboards/general/testcases/update/update.tf
+++ b/dynatrace/api/builtin/dashboards/general/testcases/update/update.tf
@@ -2,7 +2,8 @@ resource "dynatrace_dashboards_general" "general" {
   enable_public_sharing = false
   default_dashboard_list {
     default_dashboard {
-      dashboard = dynatrace_dashboard.dashboard.id
+      # updated to use a new just created dashboard
+      dashboard = dynatrace_dashboard.dashboard_new.id
       user_group = dynatrace_iam_group.group.id
     }
   }
@@ -12,9 +13,9 @@ resource "dynatrace_iam_group" "group" {
   name = "#name#"
 }
 
-resource "dynatrace_dashboard" "dashboard" {
+resource "dynatrace_dashboard" "dashboard_new" {
   dashboard_metadata {
-    name   = "#name#"
+    name   = "#name#-new"
     owner  = "Dynatrace"
     tags   = ["Kubernetes"]
     dynamic_filters {


### PR DESCRIPTION
#### **Why** this PR?
When creating dashboards and user groups, the data source of `dynatrace_dashboard_general` may not be up to date yet. This may lead to an error during create

#### **What** has changed?
It should not fail anymore if the referenced resource was just created

#### **How** does it do it?
By adding custom retry logic in the resource (max 10s)

#### How is it **tested**?
Test now succeeds without time_sleep

#### How does it affect **users**?
More consistent creation of `dynatrace_dashboard_general`

**Issue:** NOISSUE
