### PR TITLE
feat(extensions): data source for active version

### DIFF
--- a/datasources/extensions/active_version/data_source.go
+++ b/datasources/extensions/active_version/data_source.go
@@ -1,0 +1,103 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package active_version
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	coreextensions "github.com/dynatrace/dynatrace-configuration-as-code-core/clients/extensions"
+)
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: logging.EnableDSCtx(dataSourceRead),
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of the extension",
+				Required:    true,
+			},
+			"active_version": {
+				Type:        schema.TypeString,
+				Description: "The active version of the extension",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// ExtensionClient defines the interface for interacting with the Extensions API.
+type ExtensionClient interface {
+	// GetEnvironmentConfiguration returns the active version of an extension in an environment
+	GetEnvironmentConfiguration(ctx context.Context, extensionName string) (coreapi.Response, error)
+}
+
+func createCoreClient(ctx context.Context, credentials *rest.Credentials) (ExtensionClient, error) {
+	platformClient, err := rest.CreatePlatformClient(ctx, credentials.OAuth.EnvironmentURL, credentials)
+	if err != nil {
+		return nil, err
+	}
+	return coreextensions.NewClient(platformClient), nil
+}
+
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	creds, err := config.Credentials(m, config.CredValDefault)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	client, err := createCoreClient(ctx, creds)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return DataSourceReadWithClient(ctx, d, client)
+}
+
+type environmentConfiguration struct {
+	Version string `json:"version"`
+}
+
+func DataSourceReadWithClient(ctx context.Context, d *schema.ResourceData, client ExtensionClient) diag.Diagnostics {
+	extName := d.Get("name").(string)
+
+	response, err := client.GetEnvironmentConfiguration(ctx, extName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var conf environmentConfiguration
+	err = json.Unmarshal(response.Data, &conf)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(extName)
+	err = d.Set("active_version", conf.Version)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return diag.Diagnostics{}
+}

--- a/datasources/extensions/active_version/data_source_test.go
+++ b/datasources/extensions/active_version/data_source_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package active_version_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccExtensionsActiveVersion(t *testing.T) {
+	datasourceConfig, _ := api.ReadTfConfig(t, "testdata/example.tf")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"dynatrace": func() (*schema.Provider, error) {
+				return provider.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: datasourceConfig,
+				Check:  resource.TestCheckOutput("active_version", "2.1.1"),
+			},
+		},
+	})
+}

--- a/datasources/extensions/active_version/data_source_unit_test.go
+++ b/datasources/extensions/active_version/data_source_unit_test.go
@@ -1,0 +1,104 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package active_version_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/extensions/active_version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+)
+
+type mockClient struct {
+	getEnvironmentConfiguration func(ctx context.Context, extensionName string) (coreapi.Response, error)
+}
+
+func (m *mockClient) GetEnvironmentConfiguration(ctx context.Context, extensionName string) (coreapi.Response, error) {
+	return m.getEnvironmentConfiguration(ctx, extensionName)
+}
+
+// makeResponse returns a response with a version
+func makeResponse() coreapi.Response {
+	return coreapi.Response{
+		Data: []byte(`{"version": "2.1.1"}`),
+	}
+}
+
+func newResourceData(t *testing.T) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, active_version.DataSource().Schema, map[string]any{
+		"name": "com.dynatrace.extension.test",
+	})
+}
+
+// TestDataSourceReadWithClient_ReturnsActiveVersion verifies that among multiple
+// installed versions the highest semver is selected.
+func TestDataSourceReadWithClient_ReturnsActiveVersion(t *testing.T) {
+	d := newResourceData(t)
+	client := &mockClient{
+		getEnvironmentConfiguration: func(_ context.Context, _ string) (coreapi.Response, error) {
+			return makeResponse(), nil
+		},
+	}
+
+	diags := active_version.DataSourceReadWithClient(t.Context(), d, client)
+
+	require.False(t, diags.HasError(), "expected no error, got: %v", diags)
+	assert.Equal(t, "2.1.1", d.Get("active_version").(string))
+	assert.Equal(t, "com.dynatrace.extension.test", d.Id())
+}
+
+// TestDataSourceReadWithClient_ClientError verifies that errors from the client
+// are surfaced as diagnostics.
+func TestDataSourceReadWithClient_ClientError(t *testing.T) {
+	d := newResourceData(t)
+	client := &mockClient{
+		getEnvironmentConfiguration: func(_ context.Context, _ string) (coreapi.Response, error) {
+			return coreapi.Response{}, assert.AnError
+		},
+	}
+
+	diags := active_version.DataSourceReadWithClient(t.Context(), d, client)
+
+	require.True(t, diags.HasError(), "expected an error diagnostic, got none")
+	assert.ElementsMatch(t, diags, diag.FromErr(assert.AnError), "expected diagnostic summary to contain client error message")
+}
+
+// TestDataSourceReadWithClient_InvalidJSON verifies that malformed JSON in the
+// response is surfaced as an error diagnostic.
+func TestDataSourceReadWithClient_InvalidJSON(t *testing.T) {
+	d := newResourceData(t)
+	client := &mockClient{
+		getEnvironmentConfiguration: func(_ context.Context, _ string) (coreapi.Response, error) {
+			return coreapi.Response{
+				Data: []byte("not-valid-json"),
+			}, nil
+		},
+	}
+
+	diags := active_version.DataSourceReadWithClient(t.Context(), d, client)
+
+	assert.True(t, diags.HasError(), "expected an error diagnostic from invalid JSON, got none")
+}

--- a/datasources/extensions/active_version/testdata/example.tf
+++ b/datasources/extensions/active_version/testdata/example.tf
@@ -1,0 +1,7 @@
+data "dynatrace_hub_extension_v2_active_version" "active_version" {
+  name = "com.dynatrace.extension.jmx-weblogic-cp"
+}
+
+output "active_version" {
+  value = data.dynatrace_hub_extension_v2_active_version.active_version.active_version
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -38,6 +38,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/documents/document"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/entities"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/entity"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/extensions/active_version"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/extensions/latest_version"
 	failure_detection_parameters "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/failuredetection/parameters"
 	genericsettingsds "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/generic/settings"
@@ -280,6 +281,7 @@ func Provider() *schema.Provider {
 			"dynatrace_application_detection_rules":     appdetection.DataSource(),
 			"dynatrace_platform_slo_templates":          objectivetemplates.DataSourceMulti(),
 			"dynatrace_platform_slo_template":           objectivetemplates.DataSource(),
+			"dynatrace_hub_extension_v2_active_version": active_version.DataSource(),
 			"dynatrace_hub_extension_v2_latest_version": latest_version.DataSource(),
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/templates/data-sources/hub_extension_v2_active_version.md.tmpl
+++ b/templates/data-sources/hub_extension_v2_active_version.md.tmpl
@@ -1,0 +1,24 @@
+---
+layout: ""
+page_title: "dynatrace_hub_extension_v2_active_version Resource - terraform-provider-dynatrace"
+subcategory: "Extensions"
+description: |-
+  The `dynatrace_hub_extension_v2_active_version` data source retrieves the active installed version of an extension.
+---
+
+
+# dynatrace_hub_extension_v2_active_version (Data Source)
+
+-> This data source requires the OAuth scope `extensions:definitions:read`.
+
+The `dynatrace_hub_extension_v2_active_version` data source retrieves the active installed version of an extension.
+
+## Dynatrace Documentation
+
+- Extensions 2.0 - https://docs.dynatrace.com/docs/ingest-from/extensions
+
+## Example Usage
+
+{{ tffile "datasources/extensions/active_version/testdata/example.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
#### **Why** this PR?
At the moment, it's not possible to get the active version of an extension (for the platform-based resource).
And we also don't support setting it.

#### **What** has changed?
There is a new data source `dynatrace_hub_extension_v2_active_version` for getting the latest version of an extension.

#### **How** does it do it?
By adding a data source that calls `/extensions/{extension-name}/environment-configuration` and returns the active version.

#### How is it **tested**?
New tests added

#### How does it affect **users**?
They can get the active version of an extension.

**Issue:** CA-19281