### PR TITLE
test: fix example uniqueness

### DIFF
--- a/dynatrace/api/app/dynatrace/kubernetes/connector/connection/testdata/terraform/example_a.tf
+++ b/dynatrace/api/app/dynatrace/kubernetes/connector/connection/testdata/terraform/example_a.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_automation_workflow_k8s_connections" "connection" {
-  name      = "terraform1"
+  name      = "#name#"
   uid       = "00000000-0000-0000-0000-000000000000"
   namespace = "terraform1"
   token     = "dt0e01.000000000000000000000000.0000000000000000000000000000000000000000000000000000000000000000"

--- a/dynatrace/api/builtin/rum/ipdetermination/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/rum/ipdetermination/testdata/terraform/example_a.tf
@@ -1,3 +1,3 @@
-resource "dynatrace_rum_ip_determination" "#name#" {
-  header_name = "X-Header-Example3"
+resource "dynatrace_rum_ip_determination" "determination" {
+  header_name = "X-Header-#name#"
 }

--- a/dynatrace/api/builtin/rum/ipdetermination/testdata/terraform/example_insert_after.tf
+++ b/dynatrace/api/builtin/rum/ipdetermination/testdata/terraform/example_insert_after.tf
@@ -1,8 +1,8 @@
 resource "dynatrace_rum_ip_determination" "first-instance" {
-  header_name = "X-Header-Example3"
+  header_name = "X-Header-#name#-3"
 }
 
 resource "dynatrace_rum_ip_determination" "second-instance" {
-  header_name  = "X-Header-Example4"
+  header_name  = "X-Header-#name#-4"
   insert_after = dynatrace_rum_ip_determination.first-instance.id
 }


### PR DESCRIPTION
#### **Why** this PR?
There were potential conflicts when running dynatrace_rum_ip_determination and dynatrace_automation_workflow_k8s_connections in parallel

#### **What** has changed?
No conflicts anymore

#### **How** does it do it?
Using our placeholder `#name#` to make the unique properties unique

#### How is it **tested**?
This is about tests

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
