### PR TITLE
fix(workflow): correctly export tasks

### DIFF
--- a/dynatrace/api/automation/workflows/settings/task.go
+++ b/dynatrace/api/automation/workflows/settings/task.go
@@ -88,7 +88,7 @@ func (me *Tasks) UnmarshalHCL(decoder hcl.Decoder) error {
 	if err := decoder.DecodeSlice("task", me); err != nil {
 		return err
 	}
-	*me = hcl.FilterEmpty(*me, Task{Active: true, Input: map[string]any{}})
+	*me = hcl.FilterEmpty(*me, Task{Active: new(true), Input: map[string]any{}})
 	return nil
 }
 
@@ -97,7 +97,7 @@ type Task struct {
 	Action       string               `json:"action" pattern:"^.+:.+$"`
 	Description  *string              `json:"description,omitempty"` // A description for this task
 	Input        map[string]any       `json:"input"`
-	Active       bool                 `json:"active"` // Specifies whether a task should be skipped as a no operation or not
+	Active       *bool                `json:"active,omitempty"` // Specifies whether a task should be skipped as a no operation or not
 	Position     *TaskPosition        `json:"position"`
 	Predecessors []string             `json:"predecessors,omitempty"`
 	Conditions   *TaskConditionOption `json:"conditions,omitempty"`
@@ -256,6 +256,16 @@ func (me *Task) UnmarshalHCL(decoder hcl.Decoder) error {
 				me.Predecessors = append(me.Predecessors, k)
 			}
 		}
+	}
+	return nil
+}
+
+func (me *Task) HandlePreconditions() error {
+	// not set => default of "true"
+	// set to `false` => d.GetOk is !ok => me.Active == nil => we need to correctly set it to "false"
+	// We can't remove the pointer because export would then return false instead of null/notGiven
+	if me.Active == nil {
+		me.Active = new(false)
 	}
 	return nil
 }

--- a/terraform/hcl/filter.go
+++ b/terraform/hcl/filter.go
@@ -22,8 +22,8 @@ import "reflect"
 // This is a generic workaround for https://github.com/hashicorp/terraform-plugin-sdk/issues/895
 // which creates phantom empty entries in TypeSet blocks during updates.
 // There may occur two different types of empty set items.
-// 1. A zero value (e.g. FieldExtractionEntry)
-// 2. A default value with all default fields set (e.g. FieldExtractionEntry{ExtractionType: "field"}) including values set by `HandlePreconditions`
+// 1. A zero value (e.g. FieldExtractionEntry) including values set by `HandlePreconditions`.
+// 2. A default value with all default fields set (e.g. FieldExtractionEntry{ExtractionType: "field"}) including values set by `HandlePreconditions`.
 //
 // Usage example:
 //
@@ -31,16 +31,7 @@ import "reflect"
 func FilterEmpty[T any](entries []*T, defaultValue T) []*T {
 	result := make([]*T, 0, len(entries))
 	var zeroValue T
-	defaultValues := []T{zeroValue}
-	pointVal := &defaultValue
-
-	if v, ok := any(pointVal).(Preconditioner); ok {
-		// if the value with the defaults is in the state file, it also went through `HandlePreconditions`
-		_ = v.HandlePreconditions()
-		defaultValues = append(defaultValues, *pointVal)
-	} else {
-		defaultValues = append(defaultValues, defaultValue)
-	}
+	defaultValues := []T{preconditionOrDefault(zeroValue), preconditionOrDefault(defaultValue)}
 
 	for _, entry := range entries {
 		isEmpty := false
@@ -55,4 +46,14 @@ func FilterEmpty[T any](entries []*T, defaultValue T) []*T {
 		}
 	}
 	return result
+}
+
+func preconditionOrDefault[T any](val T) T {
+	pointVal := &val
+	if v, ok := any(pointVal).(Preconditioner); ok {
+		// if the value with the defaults is in the state file, it also went through `HandlePreconditions`
+		_ = v.HandlePreconditions()
+		return *pointVal
+	}
+	return val
 }

--- a/terraform/hcl/filter_test.go
+++ b/terraform/hcl/filter_test.go
@@ -126,7 +126,7 @@ func TestFilterEmpty_WithPreconditioner_RemovesZeroValue(t *testing.T) {
 	defaultVal := preconditionEntry{Name: "", Value: 0}
 
 	entries := []*preconditionEntry{
-		{},                        // zero value → removed
+		{Name: "default-name"},    // zero value + precondition → removed
 		{Name: "real", Value: 99}, // kept
 	}
 
@@ -153,7 +153,7 @@ func TestFilterEmpty_IgnoresErrors(t *testing.T) {
 	defaultVal := preconditionErrorEntry{Name: "", Value: 0}
 
 	entries := []*preconditionErrorEntry{
-		{},                        // zero value → removed
+		{Name: "default-name"},    // zero value + precondition → removed
 		{Name: "real", Value: 99}, // kept
 	}
 


### PR DESCRIPTION
#### **Why** this PR?
During export, workflows tasks without having the `active` property set, were incorrectly exported with `false` instead of "not set". Because the default value for active is `true` if undefined, this is the wrong data.

#### **What** has changed?
Task active state is now correctly exported

#### **How** does it do it?
By setting the active field of a task to `*bool`, which will not result in `null => false` but correctly `null => undefined` (not set in HCL).
Because `*bool` has the zero value `nil` and not `false`, we also need to update our HandlePrecondition, becaues "zero value or not set at all in HCL" leads to "nil in struct". Because we have a default value of `true`, we know that it's always set and if it's not set, it must be `false` instead of "not set".

Background: With the Terraform Plugin SDK, we simply can't determine if a boolean field is false or simply not set at all; we assume it's set to false (the same thing if a string is an empty string or not set at all)

#### How is it **tested**?
Manual tests for export for the task active states: true, false, and undefined.
Existing tests cover the current case.

#### How does it affect **users**?
"Export" exports the correct active value

**Issue:** CA-19293