### PR TITLE
fix: flaky dynatrace_dashboards_presets creation/update

### DIFF
--- a/dynatrace/api/builtin/dashboards/general/service.go
+++ b/dynatrace/api/builtin/dashboards/general/service.go
@@ -19,10 +19,6 @@ package general
 
 import (
 	"context"
-	"errors"
-	"net/http"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -37,6 +33,9 @@ const SchemaVersion = "1.0.18"
 const SchemaID = "builtin:dashboards.general"
 const defaultTimeout = 20 * time.Second
 
+// During "create" the data source of the dashboard may not be up to date.
+const retryErr = "Invalid value in datasource"
+
 type service struct {
 	service settings.CRUDService[*general.Settings]
 }
@@ -49,7 +48,7 @@ func (me *service) Create(ctx context.Context, v *general.Settings) (*api.Stub, 
 	err := retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
 		var err error
 		apiStub, err = me.service.Create(ctx, v)
-		return classifyRetryError(err)
+		return settings.ClassifyConstraintRetryError(err, retryErr)
 	})
 
 	if err != nil {
@@ -58,28 +57,10 @@ func (me *service) Create(ctx context.Context, v *general.Settings) (*api.Stub, 
 	return apiStub, nil
 }
 
-// classifyRetryErrors retries on certain conflicts
-// During "create" the data source of the dashboard may not be up to date.
-func classifyRetryError(err error) *retry.RetryError {
-	if err == nil {
-		return nil
-	}
-	if restError, ok := errors.AsType[rest.Error](err); ok && restError.Code == http.StatusBadRequest {
-		containsConflict := slices.ContainsFunc(restError.ConstraintViolations, func(cv rest.ConstraintViolation) bool {
-			return strings.Contains(cv.Message, "Invalid value in datasource")
-		})
-		if containsConflict {
-			return retry.RetryableError(err)
-		}
-	}
-
-	return retry.NonRetryableError(err)
-}
-
 func (me *service) Update(ctx context.Context, id string, v *general.Settings) error {
 	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
 		err := me.service.Update(ctx, id, v)
-		return classifyRetryError(err)
+		return settings.ClassifyConstraintRetryError(err, retryErr)
 	})
 }
 

--- a/dynatrace/api/builtin/dashboards/presets/service.go
+++ b/dynatrace/api/builtin/dashboards/presets/service.go
@@ -20,16 +20,22 @@ package presets
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	presets "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/dashboards/presets/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
 const SchemaVersion = "0.9.14"
 const SchemaID = "builtin:dashboards.presets"
+const defaultTimeout = 20 * time.Second
+
+// During "create" the data source of the dashboard may not be up to date.
+const retryErr = "Invalid value in datasource"
 
 var mu sync.Mutex
 
@@ -63,17 +69,29 @@ func (me *service) SchemaID() string {
 func (me *service) Create(ctx context.Context, v *presets.Settings) (*api.Stub, error) {
 	mu.Lock()
 	defer mu.Unlock()
+	var apiStub *api.Stub
 	// This schema is flagged with `multiobject=false` - in other words only one
 	// object can exist per environment
 	// Instead of trying to CREATE the settings we simply update the existing one
 	if stubs, _ := me.service.List(ctx); len(stubs) > 0 {
 		return stubs[0], me.update(ctx, stubs[0].ID, v)
 	}
-	return me.service.Create(ctx, v)
+	err := retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
+		var err error
+		apiStub, err = me.service.Create(ctx, v)
+		return settings.ClassifyConstraintRetryError(err, retryErr)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return apiStub, nil
 }
 
 func (me *service) update(ctx context.Context, id string, v *presets.Settings) error {
-	return me.service.Update(ctx, id, v)
+	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
+		err := me.service.Update(ctx, id, v)
+		return settings.ClassifyConstraintRetryError(err, retryErr)
+	})
 }
 
 func (me *service) Update(ctx context.Context, id string, v *presets.Settings) error {
@@ -83,9 +101,9 @@ func (me *service) Update(ctx context.Context, id string, v *presets.Settings) e
 	// environment insists on having we're checking first, whether an object
 	// already exists. If so, we're updating using THAT ID.
 	if stubs, _ := me.service.List(ctx); len(stubs) > 0 {
-		return me.update(ctx, stubs[0].ID, v)
+		id = stubs[0].ID
 	}
-	return me.service.Update(ctx, id, v)
+	return me.update(ctx, id, v)
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {

--- a/dynatrace/api/builtin/dashboards/presets/service_test.go
+++ b/dynatrace/api/builtin/dashboards/presets/service_test.go
@@ -23,13 +23,8 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDashboardsPresets(t *testing.T) {
-	api.TestAcc(t, api.TestAccOptions{
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {Source: "hashicorp/time"},
-		},
-	})
+	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/dashboards/presets/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/dashboards/presets/testdata/terraform/example_a.tf
@@ -1,5 +1,4 @@
 resource "dynatrace_dashboards_presets" "presets" {
-  depends_on = [time_sleep.dashboard_create]
   enable_dashboard_presets = true
   dashboard_presets_list {
     dashboard_presets {
@@ -7,13 +6,6 @@ resource "dynatrace_dashboards_presets" "presets" {
       user_group = dynatrace_iam_group.group.id
     }
   }
-}
-
-
-# the datasource of dynatrace_dashboards_presets may not be updated yet.
-resource "time_sleep" "dashboard_create" {
-  depends_on = [dynatrace_dashboard.dashboard]
-  create_duration = "5s"
 }
 
 resource "dynatrace_iam_group" "group" {

--- a/dynatrace/api/builtin/failuredetection/environment/parameters/service.go
+++ b/dynatrace/api/builtin/failuredetection/environment/parameters/service.go
@@ -19,10 +19,6 @@ package parameters
 
 import (
 	"context"
-	"errors"
-	"net/http"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -37,6 +33,11 @@ const SchemaVersion = "1.0.6"
 const SchemaID = "builtin:failure-detection.environment.parameters"
 const defaultTimeout = 10 * time.Second
 
+// During "create" and potentially "update" there is a "delete"-error happening that is not related to the object that should be created.
+// Seems like the delete-constraint is done at the wrong place, and that there is some eventual consistency.
+// error: builtin:failure-detection.environment.parameters: Failure detection rule EnvironmentFailureDetectionRules {your-values-here} refers to this parameter ID: <uuid>.
+const retryErr = "refers to this parameter"
+
 type service struct {
 	service settings.CRUDService[*parameters.Settings]
 }
@@ -49,7 +50,7 @@ func (me *service) Create(ctx context.Context, v *parameters.Settings) (*api.Stu
 	err := retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
 		var err error
 		apiStub, err = me.service.Create(ctx, v)
-		return classifyRetryError(err)
+		return settings.ClassifyConstraintRetryError(err, retryErr)
 	})
 
 	if err != nil {
@@ -58,30 +59,10 @@ func (me *service) Create(ctx context.Context, v *parameters.Settings) (*api.Stu
 	return apiStub, nil
 }
 
-// classifyRetryErrors retries on certain conflicts
-// During "create" and potentially "update" there is a "delete"-error happening that is not related to the object that should be created.
-// Seems like the delete-constraint is done at the wrong place, and that there is some eventual consistency.
-// error: builtin:failure-detection.environment.parameters: Failure detection rule EnvironmentFailureDetectionRules {your-values-here} refers to this parameter ID: <uuid>.
-func classifyRetryError(err error) *retry.RetryError {
-	if err == nil {
-		return nil
-	}
-	if restError, ok := errors.AsType[rest.Error](err); ok && restError.Code == http.StatusBadRequest {
-		containsConflict := slices.ContainsFunc(restError.ConstraintViolations, func(cv rest.ConstraintViolation) bool {
-			return strings.Contains(cv.Message, "refers to this parameter")
-		})
-		if containsConflict {
-			return retry.RetryableError(err)
-		}
-	}
-
-	return retry.NonRetryableError(err)
-}
-
 func (me *service) Update(ctx context.Context, id string, v *parameters.Settings) error {
 	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
 		err := me.service.Update(ctx, id, v)
-		return classifyRetryError(err)
+		return settings.ClassifyConstraintRetryError(err, retryErr)
 	})
 }
 

--- a/dynatrace/settings/retry.go
+++ b/dynatrace/settings/retry.go
@@ -1,0 +1,45 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package settings
+
+import (
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+)
+
+// ClassifyConstraintRetryError returns a retryable or non-retryable error on certain conflicts (constraint violations), e.g., data-source is not up to date
+// If the provided violationMessage is inside a constraint violation, a retryable error is returned
+func ClassifyConstraintRetryError(err error, violationMessage string) *retry.RetryError {
+	if err == nil {
+		return nil
+	}
+	if restError, ok := errors.AsType[rest.Error](err); ok && restError.Code == http.StatusBadRequest {
+		containsConflict := slices.ContainsFunc(restError.ConstraintViolations, func(cv rest.ConstraintViolation) bool {
+			return strings.Contains(cv.Message, violationMessage)
+		})
+		if containsConflict {
+			return retry.RetryableError(err)
+		}
+	}
+
+	return retry.NonRetryableError(err)
+}


### PR DESCRIPTION
#### **Why** this PR?
dynatrace_dashboards_presets sometimes returned an error `Invalid value in datasource` during create/update.

#### **What** has changed?
It should not error anymore

#### **How** does it do it?
By adding retries, so that the data source behind is updated with the just-created resources (dashboard)

#### How is it **tested**?
Current tests should not fail anymore

#### How does it affect **users**?
More consistent resource

**Issue:** NOISSUE