### PR TITLE
chore: ignore SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACK-15702236 vulnerability

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -23,3 +23,9 @@ ignore:
   'snyk:lic:golang:github.com:hashicorp:terraform-registry-address:MPL-2.0': *ignore-mpl-2-0-license
   'snyk:lic:golang:github.com:hashicorp:terraform-svchost:MPL-2.0': *ignore-mpl-2-0-license
   'snyk:lic:golang:github.com:hashicorp:yamux:MPL-2.0': *ignore-mpl-2-0-license
+
+  SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACK-15702236: &msg-pack-ignore
+    - '*':
+        reason: 'Transitive dependency via terraform-plugin-sdk/v2; no fixed version available upstream.'
+        expires: 2026-06-06T00:00:00.000Z
+  SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACKV5-15702238: *msg-pack-ignore


### PR DESCRIPTION
#### **Why** this PR?
This vulnerability is a transitive dependency via terraform-plugin-sdk/v2, which is a core dependency of the Terraform provider. There is no fixed version available upstream at this time.

ref: https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACK-15702236

#### **What** has changed?

Ignore is set to expire in one month (2026-06-06) to allow time for the upstream dependency to be updated.



**Issue:** CA-19398
