### PR TITLE
fix: add workaround for deleting dynatrace_calculated_web_metric

### DIFF
--- a/dynatrace/api/v1/config/metrics/calculated/web/service.go
+++ b/dynatrace/api/v1/config/metrics/calculated/web/service.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	retrycommon "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/retry"
 	mysettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/metrics/calculated/web/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
@@ -36,15 +35,16 @@ import (
 )
 
 const SchemaID = "v1:config:calculated-metrics-web"
-const defaultTimeout = 20 * time.Second
+const defaultTimeout = 30 * time.Second
 
 // error messages (parts) that may be returned because of eventual consistency
 const (
 	overallErr = "Found more than one metric" // create => delete => create => leads to having the same "unique" identifier (metric key) twice
-	createErr  = "Unable to create"
-	deleteErr  = "Unable to delete"
-	getErr     = "does not exist" // should exist but is not synced across server nodes.
+	deleteErr  = "Unable to delete"           // status 500
+	getErr     = "does not exist"             // should exist but is not synced across server nodes.
 )
+
+var createErrs = []string{"Unable to create", "already exists"}
 
 func Service(credentials *rest.Credentials) settings.CRUDService[*mysettings.CalculatedWebMetric] {
 	return &service{client: rest.APITokenClient(credentials)}
@@ -55,10 +55,14 @@ type service struct {
 }
 
 func (me *service) Get(ctx context.Context, id string, v *mysettings.CalculatedWebMetric) error {
-	return retry.RetryContext(ctx, retrycommon.DurationUntilDeadlineOrDefault(ctx, defaultTimeout), func() *retry.RetryError {
-		err := me.client.Get(ctx, fmt.Sprintf("/api/config/v1/calculatedMetrics/rum/%s", url.PathEscape(id)), 200).Finish(v)
+	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
+		err := me.get(ctx, id, v)
 		return classifyRetryError(err, getErr)
 	})
+}
+
+func (me *service) get(ctx context.Context, id string, v *mysettings.CalculatedWebMetric) error {
+	return me.client.Get(ctx, fmt.Sprintf("/api/config/v1/calculatedMetrics/rum/%s", url.PathEscape(id)), 200).Finish(v)
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
@@ -87,15 +91,15 @@ func (me *service) Validate(ctx context.Context, v *mysettings.CalculatedWebMetr
 func (me *service) Create(ctx context.Context, v *mysettings.CalculatedWebMetric) (*api.Stub, error) {
 	var stub api.Stub
 
-	err := retry.RetryContext(ctx, retrycommon.DurationUntilDeadlineOrDefault(ctx, defaultTimeout), func() *retry.RetryError {
+	err := retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
 		err := me.client.Post(ctx, "/api/config/v1/calculatedMetrics/rum", v, 201).Finish(&stub)
-		return classifyRetryError(err, createErr)
+		return classifyRetryError(err, createErrs...)
 	})
 
 	return &stub, err
 }
 
-// classifyRetryError retries when there is a conflict during create/update/delete.
+// classifyRetryError retries when there is a conflict during get/create/update/delete.
 // Create after delete (e.g., ForceNew) => "Unable to create RumMetric my-metric in DemMetricsConfigPersistence or Metadata: Unable to create RumMetric my-metric in DemMetricsConfigPersistence"
 // Delete after cleanup => "Found more than one metric with key <my-key>"
 // GET after apply of an update => "Metric with key <my-key> does not exist"
@@ -105,7 +109,7 @@ func classifyRetryError(err error, expectedErrs ...string) *retry.RetryError {
 	}
 	restError, ok := errors.AsType[rest.Error](err)
 
-	if !ok || restError.Code != http.StatusBadRequest {
+	if !ok || (restError.Code != http.StatusBadRequest && restError.Code != http.StatusInternalServerError) {
 		return retry.NonRetryableError(err)
 	}
 
@@ -122,17 +126,66 @@ func classifyRetryError(err error, expectedErrs ...string) *retry.RetryError {
 }
 
 func (me *service) Update(ctx context.Context, id string, v *mysettings.CalculatedWebMetric) error {
-	return retry.RetryContext(ctx, retrycommon.DurationUntilDeadlineOrDefault(ctx, defaultTimeout), func() *retry.RetryError {
+	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
 		err := me.client.Put(ctx, fmt.Sprintf("/api/config/v1/calculatedMetrics/rum/%s", url.PathEscape(id)), v, 204).Finish()
 		return classifyRetryError(err, getErr)
 	})
 }
 
-func (me *service) Delete(ctx context.Context, id string) error {
-	return retry.RetryContext(ctx, retrycommon.DurationUntilDeadlineOrDefault(ctx, defaultTimeout), func() *retry.RetryError {
+func (me *service) delete(ctx context.Context, id string) error {
+	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
 		err := me.client.Delete(ctx, fmt.Sprintf("/api/config/v1/calculatedMetrics/rum/%s", url.PathEscape(id)), 204, 200).Finish()
 		return classifyRetryError(err, deleteErr)
 	})
+}
+
+func (me *service) Delete(ctx context.Context, id string) error {
+	// There are several problems with this resource that are caused by server-node syncs:
+	// 1. Consistency errors (server nodes issues) during delete => "500: Unable to delete" or "Found more than one metric with key <my-key>"
+	//    Retrying on delete resolves that
+	// 2. Creation errors after deletion (e.g., ForceNew) => "Found more than one metric with key <my-key>"
+	//    Retrying inside create may not resolve it, even after minutes.
+	//    Current solution: retry inside delete until GET returns 404 {desiredSuccesses} times
+	//    Problem: GET after delete may return 404 but create fails again with "Found more than one metric with key <my-key>", even with 30s retry
+	//    Assumption: Delete may be ignored
+	err := me.delete(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	desiredSuccesses := 5
+	successes := 0
+	consistencyRetryErr := errors.New("eventual consistency check")
+	err = retry.RetryContext(ctx, 1*time.Minute /*just to be on the safe side*/, func() *retry.RetryError {
+		err = me.get(ctx, id, new(mysettings.CalculatedWebMetric))
+		if err == nil {
+			// Metric still exists - delete and try again
+			err = me.delete(ctx, id)
+			// ignore 404 during delete
+			if err != nil && !rest.IsNotFoundError(err) {
+				return retry.NonRetryableError(err)
+			}
+			return retry.RetryableError(consistencyRetryErr)
+		}
+		if rest.IsNotFoundError(err) {
+			successes++
+			if successes >= desiredSuccesses {
+				// Consider it a success if the metric is not found for several consecutive retries,
+				// which indicates that the deletion has fully propagated across server nodes.
+				return nil
+			}
+			// Not found, but might be eventual consistency - retry until desiredSuccesses is reached
+			return retry.RetryableError(consistencyRetryErr)
+		}
+		// Unexpected error - stop retrying
+		return retry.NonRetryableError(err)
+	})
+
+	if err != nil && errors.Is(err, consistencyRetryErr) {
+		// ignore our retry check errors (returned by timeout)
+		return nil
+	}
+	return err
 }
 
 func (me *service) SchemaID() string {


### PR DESCRIPTION
#### **Why** this PR?
There are still issues when creating a calculated web metric after delete (re-create due to forceNew).
`Found more than one metric with key` or it already exists, even after deletion.

#### **What** has changed?
Updating/Deleting a metric is less likely to run into errors.

#### **How** does it do it?
There is a huge problem with eventual consistency here. Delete alone doesn't seem to be proof that deletion actually worked. Create after delete with the same metric key may lead to conflicts, even minutes after the deletion.

Therefore, we need to add retry logic with multiple deletes until GET returns 404 several times.

#### How is it **tested**?
Current tests are still working and less flaky

#### How does it affect **users**?
Updating a calculated web metric is less likely to run into issues.

**Issue:**  CA-19218