### PR TITLE
test: use data source for process groups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,7 +168,6 @@ jobs:
           DT_CLIENT_ID: ${{ secrets.DT_CLIENT_ID }}
           DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
-          TF_VAR_PROCESS_GROUP_ID: ${{ secrets.PROCESS_GROUP_ID }}
         run: go test -tags=integration -v -p 1 ${{ matrix.config.path }}
 
   sequential-integration-tests:
@@ -204,7 +203,6 @@ jobs:
           DT_CLIENT_ID: ${{ secrets.DT_CLIENT_ID }}
           DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
-          TF_VAR_PROCESS_GROUP_ID: ${{ secrets.PROCESS_GROUP_ID }}
         run: go test -tags=sequential_integration -v -p 1 ./...
 
   sonar_scan:

--- a/dynatrace/api/builtin/alerting/connectivityalerts/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/alerting/connectivityalerts/testdata/terraform/example_a.tf
@@ -1,8 +1,8 @@
-variable "PROCESS_GROUP_ID" {
-  type = string
+data "dynatrace_entity" "process_group" {
+  entity_selector = "type(\"PROCESS_GROUP\")"
 }
 
 resource "dynatrace_connectivity_alerts" "alert" {
   connectivity_alerts = false
-  process_group_id    = var.PROCESS_GROUP_ID
+  process_group_id    = data.dynatrace_entity.process_group.id
 }

--- a/dynatrace/api/builtin/availability/processgroupalerting/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/availability/processgroupalerting/testdata/terraform/example_a.tf
@@ -1,10 +1,10 @@
-variable "PROCESS_GROUP_ID" {
-  type = string
+data "dynatrace_entity" "process_group" {
+  entity_selector = "type(\"PROCESS_GROUP\")"
 }
 
 resource "dynatrace_pg_alerting" "alert" {
   enabled                    = true
   alerting_mode              = "ON_INSTANCE_COUNT_VIOLATION"
   minimum_instance_threshold = 5
-  process_group              = var.PROCESS_GROUP_ID
+  process_group              = data.dynatrace_entity.process_group.id
 }

--- a/dynatrace/api/builtin/devobs/agentoptin/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/devobs/agentoptin/testdata/terraform/example_a.tf
@@ -1,8 +1,8 @@
-variable "PROCESS_GROUP_ID" {
-  type = string
+data "dynatrace_entity" "process_group" {
+  entity_selector = "type(\"PROCESS_GROUP\")"
 }
 
 resource "dynatrace_devobs_agent_optin" "optin" {
-  scope   = var.PROCESS_GROUP_ID
+  scope   = data.dynatrace_entity.process_group.id
   enabled = false
 }

--- a/dynatrace/api/builtin/host/processgroups/monitoringstate/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/host/processgroups/monitoringstate/testdata/terraform/example_a.tf
@@ -1,9 +1,9 @@
-variable "PROCESS_GROUP_ID" {
-  type = string
+data "dynatrace_entity" "process_group" {
+  entity_selector = "type(\"PROCESS_GROUP\")"
 }
 
 resource "dynatrace_host_process_group_monitoring" "monitoring" {
   host_id          = "HOST-1234567890000000"
   monitoring_state = "MONITORING_ON"
-  process_group    = var.PROCESS_GROUP_ID
+  process_group    = data.dynatrace_entity.process_group.id
 }

--- a/dynatrace/api/builtin/processgroup/monitoring/state/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/processgroup/monitoring/state/testdata/terraform/example_a.tf
@@ -1,8 +1,8 @@
-variable "PROCESS_GROUP_ID" {
-  type = string
+data "dynatrace_entity" "process_group" {
+  entity_selector = "type(\"PROCESS_GROUP\")"
 }
 
 resource "dynatrace_process_group_monitoring" "monitoring" {
   monitoring_state = "MONITORING_ON"
-  process_group_id = var.PROCESS_GROUP_ID
+  process_group_id = data.dynatrace_entity.process_group.id
 }

--- a/dynatrace/api/builtin/rum/processgroup/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/rum/processgroup/testdata/terraform/example_a.tf
@@ -1,9 +1,9 @@
-variable "PROCESS_GROUP_ID" {
-  type = string
+data "dynatrace_entity" "process_group" {
+  entity_selector = "type(\"PROCESS_GROUP\")"
 }
 
 
 resource "dynatrace_process_group_rum" "rum" {
   enable           = false
-  process_group_id = var.PROCESS_GROUP_ID
+  process_group_id = data.dynatrace_entity.process_group.id
 }

--- a/dynatrace/api/v1/config/anomalies/processgroups/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/anomalies/processgroups/testdata/terraform/example_a.tf
@@ -1,9 +1,9 @@
-variable "PROCESS_GROUP_ID" {
-  type = string
+data "dynatrace_entity" "process_group" {
+  entity_selector = "type(\"PROCESS_GROUP\")"
 }
 
 resource "dynatrace_pg_anomalies" "anomaly" {
-  pg_id = var.PROCESS_GROUP_ID
+  pg_id = data.dynatrace_entity.process_group.id
   availability {
     method            = "OFF"
     minimum_threshold = 0


### PR DESCRIPTION
#### **Why** this PR?
To make tests more independent across different environments and not rely on a variable for a process group ID.

#### **What** has changed?
Instead of setting the process group ID via variable/env, a data source is now used. Previously, during the research, the wrong/deprecated data source was used for process groups that faded out after 3 days. The data source `dynatrace_entity` doesn't have this problem.

#### **How** does it do it?
By making use of the `dynatrace_entity` data source instead of using a variable that needs to be provided.
It doesn't matter which ID is taken. It's only important that it's a valid process group ID.

#### How is it **tested**?
Tests still pass that rely on a valid process group ID.

#### How does it affect **users**?
N/A (minor doc update)

**Issue:** CA-17769