### PR TITLE
fix(dynatrace_http_monitor): inconsistent GET

### DIFF
--- a/dynatrace/api/v1/config/synthetic/monitors/http/service.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service.go
@@ -34,6 +34,10 @@ import (
 const SchemaID = "v1:synthetic:monitors:http"
 const BasePath = "/api/v1/synthetic/monitors"
 
+const DesiredReadySuccesses = 5
+
+var ErrConsistencyRetry = errors.New("eventual consistency check")
+
 func Service(credentials *rest.Credentials) settings.CRUDService[*http.SyntheticMonitor] {
 	return &service{service: settings.NewAPITokenService(credentials, SchemaID, &settings.ServiceOptions[*http.SyntheticMonitor]{
 		Get:            settings.Path("/api/v1/synthetic/monitors/%s"),
@@ -42,6 +46,10 @@ func Service(credentials *rest.Credentials) settings.CRUDService[*http.Synthetic
 		Stubs:          &monitors.Monitors{},
 		HasNoValidator: true,
 	})}
+}
+
+func WithPredefinedService(s settings.CRUDService[*http.SyntheticMonitor]) *service {
+	return &service{service: s}
 }
 
 type service struct {
@@ -97,13 +105,26 @@ func (me *service) Update(ctx context.Context, id string, v *http.SyntheticMonit
 // 3. Retry several times, even if 1. and 2. succeeded. Server nodes may still be out of sync.
 func (me *service) validateReady(ctx context.Context, id string, v *http.SyntheticMonitor) error {
 	retryOnTags := len(v.Tags) > 0
-	consistencyRetryErr := errors.New("eventual consistency check")
-	desiredSuccesses := 5
-	successes := 0
 
-	var newVal *http.SyntheticMonitor
-	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
-		newVal = new(http.SyntheticMonitor)
+	err := retry.RetryContext(ctx, 1*time.Minute, me.ReadyCheck(ctx, id, retryOnTags))
+	if err != nil && errors.Is(err, ErrConsistencyRetry) {
+		// ignore our retry check errors (returned by timeout)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadyCheck returns a retry.RetryFunc that performs one readiness probe per
+// invocation. The returned closure holds the success counter, so the same
+// instance must be reused across retries (and can be invoked directly from
+// tests to drive each branch synchronously).
+func (me *service) ReadyCheck(ctx context.Context, id string, retryOnTags bool) retry.RetryFunc {
+	successes := 0
+	return func() *retry.RetryError {
+		newVal := new(http.SyntheticMonitor)
 		err := me.Get(ctx, id, newVal)
 
 		// may not exist immediately after creation (not synced across server nodes)
@@ -118,24 +139,15 @@ func (me *service) validateReady(ctx context.Context, id string, v *http.Synthet
 
 		// checks if tags are synced (consistent)
 		if retryOnTags && len(newVal.Tags) == 0 {
-			return retry.RetryableError(consistencyRetryErr)
+			return retry.RetryableError(ErrConsistencyRetry)
 		}
 
 		successes++
-		if successes < desiredSuccesses {
-			return retry.RetryableError(consistencyRetryErr)
+		if successes < DesiredReadySuccesses {
+			return retry.RetryableError(ErrConsistencyRetry)
 		}
 		return nil
-	})
-	if err != nil && errors.Is(err, consistencyRetryErr) {
-		// ignore our retry check errors (returned by timeout)
-		return nil
 	}
-	if err != nil {
-		return err
-	}
-	*v = *newVal
-	return nil
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {

--- a/dynatrace/api/v1/config/synthetic/monitors/http/service.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service.go
@@ -19,10 +19,13 @@ package http
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/synthetic/monitors"
 	http "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/synthetic/monitors/http/settings"
@@ -38,7 +41,6 @@ func Service(credentials *rest.Credentials) settings.CRUDService[*http.Synthetic
 		CreateURL:      func(v *http.SyntheticMonitor) string { return "/api/v1/synthetic/monitors" },
 		Stubs:          &monitors.Monitors{},
 		HasNoValidator: true,
-		CreateConfirm:  30,
 	})}
 }
 
@@ -58,7 +60,15 @@ func (me *service) Create(ctx context.Context, v *http.SyntheticMonitor) (*api.S
 	if v.NoScript != nil && *v.NoScript && v.Script == nil {
 		v.Script = GetTempScript()
 	}
-	return me.service.Create(ctx, v)
+	stub, err := me.service.Create(ctx, v)
+	if err != nil {
+		return nil, err
+	}
+	err = me.validateReady(ctx, stub.ID, v)
+	if err != nil {
+		return nil, err
+	}
+	return stub, nil
 }
 
 func (me *service) Update(ctx context.Context, id string, v *http.SyntheticMonitor) error {
@@ -69,7 +79,63 @@ func (me *service) Update(ctx context.Context, id string, v *http.SyntheticMonit
 		}
 		v.Script = monitorSettings.Script
 	}
-	return me.service.Update(ctx, id, v)
+	err := me.service.Update(ctx, id, v)
+	if err != nil {
+		return err
+	}
+	return me.validateReady(ctx, id, v)
+}
+
+// validateReady check when an HTTP monitor is ready to use/get after create/update.
+// Because of eventual consistency
+// - `tags` may not be returned.
+// - Get may return 404
+// - Even if Get returns non 404 and the expected tags, we can't rely on it because server nodes may not be synced.
+// That's why we need to
+// 1. Retry on 404
+// 2. Retry if tags are not present (if there should be any)
+// 3. Retry several times, even if 1. and 2. succeeded. Server nodes may still be out of sync.
+func (me *service) validateReady(ctx context.Context, id string, v *http.SyntheticMonitor) error {
+	retryOnTags := len(v.Tags) > 0
+	consistencyRetryErr := errors.New("eventual consistency check")
+	desiredSuccesses := 5
+	successes := 0
+
+	var newVal *http.SyntheticMonitor
+	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
+		newVal = new(http.SyntheticMonitor)
+		err := me.Get(ctx, id, newVal)
+
+		// may not exist immediately after creation (not synced across server nodes)
+		if rest.IsNotFoundError(err) {
+			return retry.RetryableError(err)
+		}
+
+		// other errors not related to inconsistency and 404
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+
+		// checks if tags are synced (consistent)
+		if retryOnTags && len(newVal.Tags) == 0 {
+			return retry.RetryableError(consistencyRetryErr)
+		}
+
+		successes++
+		if successes < desiredSuccesses {
+			return retry.RetryableError(consistencyRetryErr)
+		}
+		return nil
+	})
+	if err != nil && errors.Is(err, consistencyRetryErr) {
+		// ignore our retry check errors (returned by timeout)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	*v = *newVal
+	return nil
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {

--- a/dynatrace/api/v1/config/synthetic/monitors/http/service_test.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service_test.go
@@ -23,17 +23,12 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccHTTPMonitors(t *testing.T) {
-	api.TestAcc(t, api.TestAccOptions{ExternalProviders: map[string]resource.ExternalProvider{
-		"time": {Source: "hashicorp/time"},
-	}})
+	api.TestAcc(t)
 }
 
 func TestAccTestCasesHTTPMonitors(t *testing.T) {
-	api.TestAccTestCases(t, api.TestCaseAccOptions{ExternalProviders: map[string]resource.ExternalProvider{
-		"time": {Source: "hashicorp/time"},
-	}})
+	api.TestAccTestCases(t)
 }

--- a/dynatrace/api/v1/config/synthetic/monitors/http/service_unit_test.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service_unit_test.go
@@ -1,0 +1,352 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/synthetic/monitors"
+	http2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/synthetic/monitors/http"
+	httpSettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/synthetic/monitors/http/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	mocktesting "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockService = mocktesting.MockCRUDService[*httpSettings.SyntheticMonitor]
+
+func tempScriptMonitor() *httpSettings.SyntheticMonitor {
+	return &httpSettings.SyntheticMonitor{Script: http2.GetTempScript()}
+}
+
+func TestService_Get(t *testing.T) {
+	t.Run("Returns error when underlying Get fails", func(t *testing.T) {
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		err := svc.Get(t.Context(), "id-1", &httpSettings.SyntheticMonitor{})
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("Returns settings as-is when script is not the auto-generated one", func(t *testing.T) {
+		userDesc := "user-defined"
+		realScript := &httpSettings.Script{Requests: httpSettings.Requests{&httpSettings.Request{
+			Description: &userDesc,
+			URL:         "https://example.com",
+			Method:      "GET",
+		}}}
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				v.Script = realScript
+				return nil
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		v := &httpSettings.SyntheticMonitor{}
+		require.NoError(t, svc.Get(t.Context(), "id-1", v))
+		assert.Same(t, realScript, v.Script)
+		assert.Nil(t, v.NoScript)
+	})
+
+	t.Run("Substitutes auto-generated temp script with NoScript=true", func(t *testing.T) {
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				*v = *tempScriptMonitor()
+				return nil
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		v := &httpSettings.SyntheticMonitor{}
+		require.NoError(t, svc.Get(t.Context(), "id-1", v))
+		assert.Nil(t, v.Script)
+		require.NotNil(t, v.NoScript)
+		assert.True(t, *v.NoScript)
+	})
+}
+
+func TestService_Create(t *testing.T) {
+	t.Run("Returns error when underlying Create fails", func(t *testing.T) {
+		mock := &mockService{
+			CreateFunc: func(ctx context.Context, v *httpSettings.SyntheticMonitor) (*api.Stub, error) {
+				return nil, assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		_, err := svc.Create(t.Context(), &httpSettings.SyntheticMonitor{})
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("Substitutes temp script when NoScript=true and Script is nil", func(t *testing.T) {
+		var captured *httpSettings.SyntheticMonitor
+		mock := &mockService{
+			CreateFunc: func(ctx context.Context, v *httpSettings.SyntheticMonitor) (*api.Stub, error) {
+				captured = v
+				return nil, assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		_, err := svc.Create(t.Context(), &httpSettings.SyntheticMonitor{NoScript: new(true)})
+
+		require.ErrorIs(t, err, assert.AnError)
+		require.NotNil(t, captured)
+		require.NotNil(t, captured.Script)
+		require.Len(t, captured.Script.Requests, 1)
+		assert.Equal(t, *http2.GetTempScript().Requests[0].Description, *captured.Script.Requests[0].Description)
+	})
+
+	t.Run("Does not overwrite existing Script when NoScript=true", func(t *testing.T) {
+		existing := &httpSettings.Script{Requests: httpSettings.Requests{&httpSettings.Request{
+			URL:    "https://example.com",
+			Method: "GET",
+		}}}
+		var captured *httpSettings.SyntheticMonitor
+		mock := &mockService{
+			CreateFunc: func(ctx context.Context, v *httpSettings.SyntheticMonitor) (*api.Stub, error) {
+				captured = v
+				return nil, assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		noScript := true
+		_, err := svc.Create(t.Context(), &httpSettings.SyntheticMonitor{NoScript: &noScript, Script: existing})
+
+		require.ErrorIs(t, err, assert.AnError)
+		require.NotNil(t, captured)
+		assert.Same(t, existing, captured.Script)
+	})
+
+	t.Run("Propagates non-retryable Get error from validateReady", func(t *testing.T) {
+		mock := &mockService{
+			CreateFunc: func(ctx context.Context, v *httpSettings.SyntheticMonitor) (*api.Stub, error) {
+				return &api.Stub{ID: "new-id"}, nil
+			},
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		_, err := svc.Create(t.Context(), &httpSettings.SyntheticMonitor{})
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+}
+
+func TestService_Update(t *testing.T) {
+	t.Run("Returns error when underlying Update fails", func(t *testing.T) {
+		mock := &mockService{
+			UpdateFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		err := svc.Update(t.Context(), "id-1", &httpSettings.SyntheticMonitor{})
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("Pre-fetches existing script when NoScript=true and Script is nil", func(t *testing.T) {
+		existing := &httpSettings.Script{Requests: httpSettings.Requests{&httpSettings.Request{
+			URL:    "https://example.com",
+			Method: "GET",
+		}}}
+		var captured *httpSettings.SyntheticMonitor
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				v.Script = existing
+				return nil
+			},
+			UpdateFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				captured = v
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		noScript := true
+		err := svc.Update(t.Context(), "id-1", &httpSettings.SyntheticMonitor{NoScript: &noScript})
+
+		require.ErrorIs(t, err, assert.AnError)
+		require.NotNil(t, captured)
+		assert.Same(t, existing, captured.Script)
+	})
+
+	t.Run("Skips pre-fetch when Script is already provided", func(t *testing.T) {
+		getCalled := false
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				getCalled = true
+				return nil
+			},
+			UpdateFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		noScript := true
+		err := svc.Update(t.Context(), "id-1", &httpSettings.SyntheticMonitor{
+			NoScript: &noScript,
+			Script:   &httpSettings.Script{},
+		})
+		require.ErrorIs(t, err, assert.AnError)
+		assert.False(t, getCalled, "pre-fetch Get should not be called when Script is provided")
+	})
+
+	t.Run("Returns error when pre-fetch Get fails", func(t *testing.T) {
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		noScript := true
+		err := svc.Update(t.Context(), "id-1", &httpSettings.SyntheticMonitor{NoScript: &noScript})
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("Propagates non-retryable Get error from validateReady", func(t *testing.T) {
+		mock := &mockService{
+			UpdateFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return nil
+			},
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		err := svc.Update(t.Context(), "id-1", &httpSettings.SyntheticMonitor{})
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+}
+
+func TestService_Delete(t *testing.T) {
+	t.Run("Returns error when underlying Delete fails", func(t *testing.T) {
+		mock := &mockService{
+			DeleteFunc: func(ctx context.Context, id string) error {
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		err := svc.Delete(t.Context(), "id-1")
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("Returns nil and forwards id on success", func(t *testing.T) {
+		var capturedID string
+		mock := &mockService{
+			DeleteFunc: func(ctx context.Context, id string) error {
+				capturedID = id
+				return nil
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+		require.NoError(t, svc.Delete(t.Context(), "id-1"))
+		assert.Equal(t, "id-1", capturedID)
+	})
+}
+
+func TestService_ReadyCheck(t *testing.T) {
+	t.Run("Returns retryable error on 404", func(t *testing.T) {
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return rest.Error{Code: http.StatusNotFound}
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+
+		result := svc.ReadyCheck(t.Context(), "id-1", false)()
+		require.NotNil(t, result)
+		assert.True(t, result.Retryable)
+		assert.True(t, rest.IsNotFoundError(result.Err), "wrapped err should be a 404")
+	})
+
+	t.Run("Returns non-retryable error on other Get failure", func(t *testing.T) {
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				return assert.AnError
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+
+		result := svc.ReadyCheck(t.Context(), "id-1", false)()
+		require.NotNil(t, result)
+		assert.False(t, result.Retryable)
+		assert.ErrorIs(t, result.Err, assert.AnError)
+	})
+
+	t.Run("Returns retryable consistency error when tags expected but missing", func(t *testing.T) {
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				v.Tags = nil
+				return nil
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+
+		result := svc.ReadyCheck(t.Context(), "id-1", true)()
+		require.NotNil(t, result)
+		assert.True(t, result.Retryable)
+		assert.ErrorIs(t, result.Err, http2.ErrConsistencyRetry)
+	})
+
+	t.Run("Counts as success when tags expected and present", func(t *testing.T) {
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				v.Tags = monitors.TagsWithSourceInfo{{Key: "env"}}
+				return nil
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+
+		check := svc.ReadyCheck(t.Context(), "id-1", true)
+		for i := 1; i < http2.DesiredReadySuccesses; i++ {
+			result := check()
+			require.NotNil(t, result, "iteration %d", i)
+			assert.True(t, result.Retryable, "iteration %d should still be retrying", i)
+			assert.ErrorIs(t, result.Err, http2.ErrConsistencyRetry)
+		}
+		assert.Nil(t, check(), "final iteration should succeed")
+	})
+
+	t.Run("Returns nil only after desired number of successes", func(t *testing.T) {
+		callCount := 0
+		mock := &mockService{
+			GetFunc: func(ctx context.Context, id string, v *httpSettings.SyntheticMonitor) error {
+				callCount++
+				return nil
+			},
+		}
+		svc := http2.WithPredefinedService(mock)
+
+		check := svc.ReadyCheck(t.Context(), "id-1", false)
+		for i := 1; i < http2.DesiredReadySuccesses; i++ {
+			result := check()
+			require.NotNil(t, result, "iteration %d", i)
+			assert.True(t, result.Retryable)
+			assert.ErrorIs(t, result.Err, http2.ErrConsistencyRetry)
+		}
+		final := check()
+		assert.Nil(t, final)
+		assert.Equal(t, http2.DesiredReadySuccesses, callCount)
+	})
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testcases/update-custom-properties-and-request-headers-set/update.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testcases/update-custom-properties-and-request-headers-set/update.tf
@@ -50,8 +50,3 @@ resource "dynatrace_http_monitor" "advanced" {
     }
   }
 }
-
-resource "time_sleep" "wait_for_monitor" {
-  depends_on = [dynatrace_http_monitor.advanced]
-  create_duration = "10s"
-}

--- a/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_a.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/testdata/terraform/example_http_a.tf
@@ -432,8 +432,3 @@ resource "dynatrace_http_monitor" "monitor" {
     }
   }
 }
-
-resource "time_sleep" "wait_to_be_consistent" {
-  depends_on = [dynatrace_http_monitor.monitor]
-  create_duration = "10s"
-}

--- a/dynatrace/testing/mockcrudservice.go
+++ b/dynatrace/testing/mockcrudservice.go
@@ -1,0 +1,57 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testing
+
+import (
+	"context"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+)
+
+// MockCRUDService implements settings.CRUDService for testing
+type MockCRUDService[T settings.Settings] struct {
+	CreateFunc func(ctx context.Context, v T) (*api.Stub, error)
+	GetFunc    func(ctx context.Context, id string, v T) error
+	UpdateFunc func(ctx context.Context, id string, v T) error
+	ListFunc   func(ctx context.Context) (api.Stubs, error)
+	DeleteFunc func(ctx context.Context, id string) error
+}
+
+func (m *MockCRUDService[T]) Create(ctx context.Context, v T) (*api.Stub, error) {
+	return m.CreateFunc(ctx, v)
+}
+
+func (m *MockCRUDService[T]) Get(ctx context.Context, id string, v T) error {
+	return m.GetFunc(ctx, id, v)
+}
+
+func (m *MockCRUDService[T]) Update(ctx context.Context, id string, v T) error {
+	return m.UpdateFunc(ctx, id, v)
+}
+
+func (m *MockCRUDService[T]) List(ctx context.Context) (api.Stubs, error) {
+	return m.ListFunc(ctx)
+}
+
+func (m *MockCRUDService[T]) Delete(ctx context.Context, id string) error {
+	return m.DeleteFunc(ctx, id)
+}
+
+func (m *MockCRUDService[T]) SchemaID() string { return "" }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.projectName=terraform-provider-dynatrace
 
 sonar.language=go
 sonar.sources=.
-sonar.exclusions=**/*_test.go,  **/test_clientset.go, **/terraform.tfstate, **/*schema.json,
+sonar.exclusions=**/*_test.go,  **/test_clientset.go, **/terraform.tfstate, **/*schema.json, dynatrace/testing/**/*.go
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
#### **Why** this PR?
Because of eventual consistency reasons, the GET endpoint doesn't return all the data. This leads to failing tests and also inconsistencies when applying this resource (Get after apply).

#### **What** has changed?
Get after create/update of this resource is more consistent.

#### **How** does it do it?
Added retry logic to better assume when an object is ready to be fetched.
Similar to https://github.com/dynatrace-oss/terraform-provider-dynatrace/pull/1095

Because of eventual consistency
- `tags` may not be returned.
- Get may return 404
- Even if Get returns non-404 and the expected tags, we can't rely on it because server nodes may not be synced.

That's why we need to
1. Retry on 404
2. Retry if tags are not present (if there should be any)
3. Retry several times, even if 1. and 2. succeeded. Server nodes may still be out of sync.

#### How is it **tested**?
Unit tests added.
E2E tests should be more consistent (less flaky)

#### How does it affect **users**?
Get after create/update should not lead to a non-empty plan anymore

**Issue:** CA-19438