### PR TITLE
test(dynatrace_http_monitor): skip integration tests

### DIFF
--- a/dynatrace/api/v1/config/synthetic/monitors/http/service_test.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/http/service_test.go
@@ -27,12 +27,16 @@ import (
 )
 
 func TestAccHTTPMonitors(t *testing.T) {
+	t.Skip("Skipping because the eventual consistency time is way too high")
+
 	api.TestAcc(t, api.TestAccOptions{ExternalProviders: map[string]resource.ExternalProvider{
 		"time": {Source: "hashicorp/time"},
 	}})
 }
 
 func TestAccTestCasesHTTPMonitors(t *testing.T) {
+	t.Skip("Skipping because the eventual consistency time is way too high")
+
 	api.TestAccTestCases(t, api.TestCaseAccOptions{ExternalProviders: map[string]resource.ExternalProvider{
 		"time": {Source: "hashicorp/time"},
 	}})


### PR DESCRIPTION
#### **Why** this PR?
The tests for `dynatrace_http_monitor` produce many flaky errors due to eventual consistency.

#### **What** has changed?
Tests are now skipped.
The eventual consistency time is way too high, leading to many flaky failing tests. While trying to find workarounds, waiting for a minute after create/update didn't solve it either.

#### **How** does it do it?
By adding t.Skip for affected tests.

#### How is it **tested**?
N/A

#### How does it affect **users**?
N/A

**Issue:** CA-19438