### PR TITLE
fix(dynatrace_metric_events): drop stale entity_filter on type switch

### DIFF
--- a/dynatrace/api/builtin/anomalydetection/metricevents/resource_unit_test.go
+++ b/dynatrace/api/builtin/anomalydetection/metricevents/resource_unit_test.go
@@ -1,0 +1,155 @@
+//go:build unit
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package metricevents_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	metricevents "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/anomalydetection/metricevents/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/resources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureService implements settings.CRUDService[*metricevents.Settings] and
+// records every payload it receives, so tests can assert on what the resource
+// lifecycle would have sent to the Settings 2.0 API.
+type captureService struct {
+	Stub *api.Stub
+	Err  error
+
+	CreateValue *metricevents.Settings
+	UpdateID    string
+	UpdateValue *metricevents.Settings
+	DeleteID    string
+	GetValue    *metricevents.Settings
+}
+
+func (s *captureService) List(_ context.Context) (api.Stubs, error) { return nil, nil }
+
+func (s *captureService) Get(_ context.Context, _ string, v *metricevents.Settings) error {
+	if s.GetValue != nil {
+		*v = *s.GetValue
+	}
+	return s.Err
+}
+
+func (s *captureService) SchemaID() string { return "builtin:anomaly-detection.metric-events" }
+
+func (s *captureService) Create(_ context.Context, v *metricevents.Settings) (*api.Stub, error) {
+	s.CreateValue = v
+	return s.Stub, s.Err
+}
+
+func (s *captureService) Update(_ context.Context, id string, v *metricevents.Settings) error {
+	s.UpdateID = id
+	s.UpdateValue = v
+	return s.Err
+}
+
+func (s *captureService) Delete(_ context.Context, id string) error {
+	s.DeleteID = id
+	return s.Err
+}
+
+func newTestGeneric(s *captureService) *resources.Generic {
+	factory := func(*rest.Credentials) settings.CRUDService[*metricevents.Settings] { return s }
+	return &resources.Generic{
+		Type:       export.ResourceTypes.MetricEvents,
+		Descriptor: export.NewResourceDescriptor(factory),
+	}
+}
+
+// baseInput returns a minimal valid raw map for dynatrace_metric_events.
+// Tests merge in the query_definition (and any other field) needed to exercise
+// their scenario.
+func baseInput() map[string]any {
+	return map[string]any{
+		"enabled": true,
+		"summary": "test event",
+		"event_template": []any{
+			map[string]any{
+				"title":       "title",
+				"description": "description",
+				"event_type":  "CUSTOM_ALERT",
+			},
+		},
+		"model_properties": []any{
+			map[string]any{
+				"alert_condition":    "ABOVE",
+				"alert_on_no_data":   false,
+				"dealerting_samples": 5,
+				"samples":            5,
+				"violating_samples":  3,
+				"type":               "STATIC_THRESHOLD",
+				"threshold":          0.0,
+			},
+		},
+	}
+}
+
+func providerConfig() *config.ProviderConfiguration {
+	return &config.ProviderConfiguration{EnvironmentURL: "https://example.com"}
+}
+
+// TestMetricEvents_Update_DropsStaleEmptyEntityFilter is the regression test
+// for the bug where switching `type` from METRIC_KEY to METRIC_SELECTOR shipped
+// an empty `entityFilter` to the API. An empty entity_filter can survive in
+// state when (a) the resource was first created with type=METRIC_KEY without
+// an entity_filter block (UnmarshalHCL auto-creates one), and (b) the
+// DiffSuppressFunc on entity_filter masks the 1->0 removal during plan.
+// The fix in UnmarshalHCL normalises that empty filter back to nil; this test
+// pins the contract by exercising the resource Update with a `d` shaped like
+// the one the SDK would hand us after suppression.
+func TestMetricEvents_Update_DropsStaleEmptyEntityFilter(t *testing.T) {
+	service := &captureService{Stub: &api.Stub{ID: "test-id"}}
+	gen := newTestGeneric(service)
+
+	input := baseInput()
+	input["query_definition"] = []any{
+		map[string]any{
+			"type":            "METRIC_SELECTOR",
+			"metric_selector": "builtin:host.cpu.usage:avg",
+			// Empty entity_filter block — what survives in `d` when the
+			// DiffSuppressFunc masks the removal of an auto-created filter.
+			"entity_filter": []any{
+				map[string]any{},
+			},
+		},
+	}
+
+	d := schema.TestResourceDataRaw(t, gen.Resource().Schema, input)
+	d.SetId("test-id")
+
+	diags := gen.Update(t.Context(), d, providerConfig())
+	require.False(t, diags.HasError(), "diagnostics: %v", diags)
+	require.NotNil(t, service.UpdateValue, "Update was not called on the service")
+
+	qd := service.UpdateValue.QueryDefinition
+	require.NotNil(t, qd, "QueryDefinition missing from Update payload")
+	assert.Nil(t, qd.EntityFilter, "empty entity_filter must be dropped when type=METRIC_SELECTOR; otherwise the API rejects the payload")
+}

--- a/dynatrace/api/builtin/anomalydetection/metricevents/settings/query_definition.go
+++ b/dynatrace/api/builtin/anomalydetection/metricevents/settings/query_definition.go
@@ -19,6 +19,7 @@ package metricevents
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
@@ -165,6 +166,11 @@ func (me *QueryDefinition) UnmarshalHCL(decoder hcl.Decoder) error {
 		"query_offset":     &me.QueryOffset,
 		"type":             &me.Type,
 	})
+	// An empty entity_filter can survive in state from an earlier auto-create + suppressed diff;
+	// drop it so a switch to METRIC_SELECTOR doesn't ship an empty entityFilter to the API.
+	if me.EntityFilter != nil && reflect.DeepEqual(*me.EntityFilter, EntityFilter{}) {
+		me.EntityFilter = nil
+	}
 	if me.Type == Types.MetricKey && me.EntityFilter == nil {
 		me.EntityFilter = new(EntityFilter)
 	}


### PR DESCRIPTION
#### **Why** this PR?

Fixes an API rejection when switching `dynatrace_metric_events` `query_definition.type` from `METRIC_KEY` to `METRIC_SELECTOR`. An empty `entityFilter` that the provider auto-creates on the initial Create (when no `entity_filter` block is configured) survives in state because the schema's `DiffSuppressFunc` masks its removal — and is then shipped in the type-switch Update payload,  which the API rejects.
 
#### **What** has changed and **How** does it do it?

The fix normalises an empty `EntityFilter` to nil at the top of `UnmarshalHCL`, before the existing auto-create. 
`METRIC_KEY` without an `entity_filter` block keeps working; `METRIC_SELECTOR` cleanly omits `entityFilter`. 
Previously the only workaround was destroying and recreating the resource. 

#### How is it **tested**?

Introduced a lifecycle test scaffolding (typed mock service capturing Create/Update payloads) that future bug regression tests for this resource can reuse. 

 - [x] `go test -tags=unit ./dynatrace/api/builtin/anomalydetection/metricevents/...` passes. 
 - [x] Verified the new test fails with the fix reverted (captured Update payload contains `&EntityFilter{}`). 
 - [x] `TF_ACC` acceptance suite for `dynatrace_metric_events` runs green against a tenant. 
 - [x] Manual smoke test: create with `type = METRIC_KEY` and no `entity_filter` block, edit to `type = METRIC_SELECTOR`, apply. 

#### How does it affect **users**?
Users will not really notice a change, other than that switching the type of a `dynatrace_metric_events` resource from `METRIC_KEY` to `METRIC_SELECTOR` works now.

**Issue:**
CA-19482 (sub-issue)
