### PR TITLE
test: fix flaky TestAccCalculatedServiceMetrics test

### DIFF
--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_a.tf
@@ -37,13 +37,13 @@ resource "dynatrace_management_zone_v2" "mzone" {
   }
 }
 
-resource "time_sleep" "wait_for_request_attribute" {
-  depends_on = [dynatrace_request_attribute.attribute]
-  create_duration = "10s"
+resource "time_sleep" "wait_for_creation" {
+  depends_on = [dynatrace_request_attribute.attribute, dynatrace_management_zone_v2.mzone]
+  create_duration = "15s"
 }
 
 resource "dynatrace_calculated_service_metric" "metric" {
-  depends_on = [time_sleep.wait_for_request_attribute]
+  depends_on = [time_sleep.wait_for_creation]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_b.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_b.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_b" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_c.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_c.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_c" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_d.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_d.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_d" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_e.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_e.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_e" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_f.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_f.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_f" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_g.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_g.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_g" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_h.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_h.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_h" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_i.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_i.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_i" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_j.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_j.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_j" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_k.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_k.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_k" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_l.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_l.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_l" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_m.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_m.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_m" {
-  depends_on = [time_sleep.wait_for_request_attributes]
+  depends_on = [time_sleep.wait_for_consistency]
   name             = "#name#"
   enabled          = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_n.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/example_n.tf
@@ -1,4 +1,5 @@
 resource "dynatrace_calculated_service_metric" "metric_n" {
+  depends_on = [time_sleep.wait_for_consistency]
   name = "#name#"
   enabled = true
   management_zones = [dynatrace_management_zone_v2.mzone.name]

--- a/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/request_attributes.tf
+++ b/dynatrace/api/v1/config/metrics/calculated/service/testdata/terraform/request_attributes.tf
@@ -57,7 +57,7 @@ resource "dynatrace_request_attribute" "behavior_class" {
   }
 }
 
-resource "time_sleep" "wait_for_request_attributes" {
-  depends_on = [dynatrace_request_attribute.attribute, dynatrace_request_attribute.accept_ranges, dynatrace_request_attribute.behavior_class]
-  create_duration = "10s"
+resource "time_sleep" "wait_for_consistency" {
+  depends_on = [dynatrace_request_attribute.attribute, dynatrace_request_attribute.accept_ranges, dynatrace_request_attribute.behavior_class, dynatrace_management_zone_v2.mzone]
+  create_duration = "15s"
 }


### PR DESCRIPTION
#### **Why** this PR?
Seems like that management zones aren't always available after creation: `API error: managementZones[0]: Unknown management zone.`. 

#### **What** has changed?
The test shouldn't be flaky anymore

#### **How** does it do it?
Added the management zone to the wait_time and increased the wait time by 5s.

#### How is it **tested**?
This is about tests

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
