### PR TITLE
refactor: Update `github.com/dynatrace/dynatrace-configuration-as-code-core` and use `rest.RetryIfTooManyRequestsOrServiceUnavailable(...)`

### DIFF
--- a/dynatrace/rest/retry_options.go
+++ b/dynatrace/rest/retry_options.go
@@ -1,6 +1,6 @@
 /*
  * @license
- * Copyright 2025 Dynatrace LLC
+ * Copyright 2026 Dynatrace LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,14 +17,9 @@
 package rest
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
-var defaultRetryOptions = &rest.RetryOptions{MaxRetries: 30, DelayAfterRetry: 10 * time.Second, ShouldRetryFunc: shouldRetry}
-
-func shouldRetry(resp *http.Response) bool {
-	return resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable
-}
+var defaultRetryOptions = &rest.RetryOptions{MaxRetries: 30, DelayAfterRetry: 10 * time.Second, ShouldRetryFunc: rest.RetryIfTooManyRequestsOrServiceUnavailable}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260511084641-0cbc4edbfda6
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260527132842-b648f788bc36
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260511084641-0cbc4edbfda6 h1:+si99Ls/WQuBJGSMRVn19U521l7I5AZMkm24IeEakpk=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260511084641-0cbc4edbfda6/go.mod h1:i7xYVSsz+Kzw/ra3p1+51to49j+GaaQ6s5RrZ8WJlSI=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260527132842-b648f788bc36 h1:awZjg1gjetJ2nvZBcfJ7Bnc396FYY7PNeonhVXDiHb4=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260527132842-b648f788bc36/go.mod h1:i7xYVSsz+Kzw/ra3p1+51to49j+GaaQ6s5RrZ8WJlSI=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
#### **Why** this PR?
Need to update `github.com/dynatrace/dynatrace-configuration-as-code-core` to take advantage of https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/312

#### **What** has changed?
With this update, clients from the core library will use the client-level retry behavior defined here

#### **How** does it do it?
Update `github.com/dynatrace/dynatrace-configuration-as-code-core`

#### How is it **tested**?
Existing tests

#### How does it affect **users**?
NA

**Issue:** CA-19525
