### PR TITLE
feat: implement Validate on settings20 service

### DIFF
--- a/dynatrace/api/builtin/rum/hostheaders/validate_test.go
+++ b/dynatrace/api/builtin/rum/hostheaders/validate_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package hostheaders_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	hostheadersvc "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/hostheaders"
+	hostheaders "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/hostheaders/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateDoesNotCreateObjects guards against settings20.Validate accidentally
+// omitting the validateOnly=true query parameter and creating a real settings object.
+// builtin:rum.host-headers is used as the test vehicle because it has no custom
+// validators, no side-effects, and a single plain-text field.
+func TestValidateDoesNotCreateObjects(t *testing.T) {
+	envURL := os.Getenv("DYNATRACE_ENV_URL")
+	apiToken := os.Getenv("DYNATRACE_API_TOKEN")
+	if envURL == "" || apiToken == "" {
+		t.Skip("Environment Variables DYNATRACE_ENV_URL and DYNATRACE_API_TOKEN must be specified")
+	}
+
+	headerName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	credentials := &rest.Credentials{URL: envURL, Token: apiToken}
+	service := settings20.Service[*hostheaders.Settings](credentials, hostheadersvc.SchemaID, hostheadersvc.SchemaVersion)
+
+	// If Validate accidentally creates an object, clean it up so subsequent
+	// test runs are not polluted.
+	t.Cleanup(func() {
+		cleanupContext := context.Background()
+		stubsAfterTest, err := service.List(cleanupContext)
+		if err != nil {
+			return
+		}
+		for _, stub := range stubsAfterTest {
+			if stub.Name == headerName {
+				err = service.Delete(cleanupContext, stub.ID)
+				require.NoError(t, err, fmt.Sprintf("Test cleanup failed for settings object %s. Manual cleanup necessary", stub.ID))
+			}
+		}
+	})
+
+	validator, ok := service.(settings.Validator[*hostheaders.Settings])
+	require.True(t, ok, "settings20 service must implement settings.Validator")
+
+	err := validator.Validate(t.Context(), &hostheaders.Settings{HeaderName: headerName})
+	assert.NoError(t, err)
+
+	stubsAfter, err := service.List(t.Context())
+	require.NoError(t, err)
+
+	for _, stub := range stubsAfter {
+		assert.NotEqual(t, headerName, stub.Name, "Validate must not create any settings objects")
+	}
+}

--- a/dynatrace/settings/services/settings20/service.go
+++ b/dynatrace/settings/services/settings20/service.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
@@ -31,11 +32,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
-
-	"net/url"
 )
-
-
 
 func Service[T settings.Settings](credentials *rest.Credentials, schemaID string, schemaVersion string, options ...*ServiceOptions[T]) settings.ListIDCRUDService[T] {
 	var opts *ServiceOptions[T]
@@ -344,8 +341,25 @@ func (me *service[T]) List(ctx context.Context) (api.Stubs, error) {
 	return stubs, nil
 }
 
-func (me *service[T]) Validate(v T) error {
-	return nil // Settings 2.0 doesn't offer validation
+func (me *service[T]) Validate(ctx context.Context, v T) error {
+	soc := SettingsObjectCreate{
+		SchemaID:      me.schemaID,
+		SchemaVersion: me.schemaVersion,
+		Scope:         settings.GetScope(v),
+		Value:         v,
+	}
+	if insertAfter := settings.GetInsertAfter(v); insertAfter != nil {
+		soc.InsertAfter = *insertAfter
+	}
+
+	var req rest.Request
+	if me.skipRepairInput() {
+		req = me.client.Post(ctx, "/api/v2/settings/objects?validateOnly=true", []SettingsObjectCreate{soc}).Expect(200)
+	} else {
+		req = me.client.Post(ctx, "/api/v2/settings/objects?validateOnly=true&repairInput=true", []SettingsObjectCreate{soc}).Expect(200)
+	}
+
+	return req.Finish()
 }
 
 func (me *service[T]) Create(ctx context.Context, v T) (*api.Stub, error) {

--- a/dynatrace/settings/services/settings20/service.go
+++ b/dynatrace/settings/services/settings20/service.go
@@ -341,6 +341,9 @@ func (me *service[T]) List(ctx context.Context) (api.Stubs, error) {
 	return stubs, nil
 }
 
+// Validate submits v to the Settings 2.0 API with validateOnly=true, which runs
+// all synchronous schema validators without persisting any object. It returns an
+// error if the payload violates the schema; nil means the payload is valid.
 func (me *service[T]) Validate(ctx context.Context, v T) error {
 	soc := SettingsObjectCreate{
 		SchemaID:      me.schemaID,
@@ -353,11 +356,11 @@ func (me *service[T]) Validate(ctx context.Context, v T) error {
 	}
 
 	var req rest.Request
-	if me.skipRepairInput() {
-		req = me.client.Post(ctx, "/api/v2/settings/objects?validateOnly=true", []SettingsObjectCreate{soc}).Expect(200)
-	} else {
-		req = me.client.Post(ctx, "/api/v2/settings/objects?validateOnly=true&repairInput=true", []SettingsObjectCreate{soc}).Expect(200)
+	postUrl := "/api/v2/settings/objects?validateOnly=true"
+	if !me.skipRepairInput() {
+		postUrl = postUrl + "&repairInput=true"
 	}
+	req = me.client.Post(ctx, postUrl, []SettingsObjectCreate{soc}).Expect(200)
 
 	return req.Finish()
 }


### PR DESCRIPTION
#### **Why** this PR?
The settings20 service's `Validate` method was previously a no-op stub with a comment saying Settings 2.0 doesn't offer validation - that is no longer true, and the stub would silently swallow the call.

#### **What** has changed?
`settings20.service[T].Validate` is now a real implementation instead of a no-op. The method signature has also been corrected to match the existing `settings.Validator[T]` interface, which already required a `context.Context` parameter that the stub was missing.

#### **How** does it do it?
POSTs the settings payload to `/api/v2/settings/objects?validateOnly=true`. The endpoint validates the payload against the schema and runs synchronous validators without persisting any object.

#### How is it **tested**?
A new integration test (`dynatrace/api/builtin/rum/hostheaders/validate_test.go`) lists all `builtin:rum.host-headers` objects after calling Validate, then asserts that the host header for which we called `Validate` is **not** in the list. `builtin:rum.host-headers` was chosen as the test vehicle because it has no custom validators, no side-effects, and a single plain-text field. A `t.Cleanup` block deletes any accidentally created objects to keep the environment clean if the assertion ever fails.

#### How does it affect **users**?
No user-facing change. `Validate` is an internal service method not exposed through any Terraform resource or data source.

**Issue:** CA-19461
