### PR TITLE
fix: Entity rule engine comparisons should use value enum types directly

### DIFF
--- a/dynatrace/api/v1/config/entityruleengine/comparison/application_type.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/application_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (atc *ApplicationType) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(atc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", atc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(atc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", atc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   atc.Negate,
+		"operator": atc.Operator,
+		"value":    atc.Value,
+	})
 }
 
 func (atc *ApplicationType) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (atc *ApplicationType) UnmarshalHCL(decoder hcl.Decoder) error {
 			atc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		atc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		atc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		atc.Operator = application_type.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		atc.Value = application_type.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &atc.Type,
+		"negate":   &atc.Negate,
+		"operator": &atc.Operator,
+		"value":    &atc.Value,
+	})
 }
 
 func (atc *ApplicationType) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/application_type/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/application_type/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package application_type
 
 // Value The value to compare to.
 type Value string
-
-func (atcv *Value) String() string {
-	return string(*atcv)
-}
-
-func (atcv Value) Ref() *Value {
-	return &atcv
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/azure_compute_mode.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/azure_compute_mode.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (acmc *AzureComputeMode) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(acmc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", acmc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(acmc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", acmc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   acmc.Negate,
+		"operator": acmc.Operator,
+		"value":    acmc.Value,
+	})
 }
 
 func (acmc *AzureComputeMode) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (acmc *AzureComputeMode) UnmarshalHCL(decoder hcl.Decoder) error {
 			acmc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		acmc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		acmc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		acmc.Operator = azure_compute_mode.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		acmc.Value = azure_compute_mode.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &acmc.Type,
+		"negate":   &acmc.Negate,
+		"operator": &acmc.Operator,
+		"value":    &acmc.Value,
+	})
 }
 
 func (acmc *AzureComputeMode) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/azure_compute_mode/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/azure_compute_mode/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package azure_compute_mode
 
 // Value The value to compare to.
 type Value string
-
-func (v *Value) String() string {
-	return string(*v)
-}
-
-func (v Value) Ref() *Value {
-	return &v
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/azure_sku.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/azure_sku.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (asc *AzureSku) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(asc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", asc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(asc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", asc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   asc.Negate,
+		"operator": asc.Operator,
+		"value":    asc.Value,
+	})
 }
 
 func (asc *AzureSku) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (asc *AzureSku) UnmarshalHCL(decoder hcl.Decoder) error {
 			asc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		asc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		asc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		asc.Operator = azure_sku.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		asc.Value = azure_sku.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &asc.Type,
+		"negate":   &asc.Negate,
+		"operator": &asc.Operator,
+		"value":    &asc.Value,
+	})
 }
 
 func (asc *AzureSku) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/azure_sku/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/azure_sku/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package azure_sku
 
 // Value The value to compare to.
 type Value string
-
-func (v *Value) String() string {
-	return string(*v)
-}
-
-func (v Value) Ref() *Value {
-	return &v
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/bitness.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/bitness.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (bc *Bitness) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(bc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", bc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(bc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", bc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   bc.Negate,
+		"operator": bc.Operator,
+		"value":    bc.Value,
+	})
 }
 
 func (bc *Bitness) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (bc *Bitness) UnmarshalHCL(decoder hcl.Decoder) error {
 			bc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		bc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		bc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		bc.Operator = bitness.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		bc.Value = bitness.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &bc.Type,
+		"negate":   &bc.Negate,
+		"operator": &bc.Operator,
+		"value":    &bc.Value,
+	})
 }
 
 func (bc *Bitness) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/bitness/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/bitness/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,10 +20,6 @@ package bitness
 // Value The value to compare to.
 type Value string
 
-func (v Value) Ref() *Value {
-	return &v
-}
-
 // Values offers the known enum values
 var Values = struct {
 	V32 Value
@@ -31,8 +27,4 @@ var Values = struct {
 }{
 	"32",
 	"64",
-}
-
-func (bcv *Value) String() string {
-	return string(*bcv)
 }

--- a/dynatrace/api/v1/config/entityruleengine/comparison/cloud_type.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/cloud_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (ctc *CloudType) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(ctc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", ctc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(ctc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", ctc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   ctc.Negate,
+		"operator": ctc.Operator,
+		"value":    ctc.Value,
+	})
 }
 
 func (ctc *CloudType) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (ctc *CloudType) UnmarshalHCL(decoder hcl.Decoder) error {
 			ctc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		ctc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		ctc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		ctc.Operator = cloud_type.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		ctc.Value = cloud_type.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &ctc.Type,
+		"negate":   &ctc.Negate,
+		"operator": &ctc.Operator,
+		"value":    &ctc.Value,
+	})
 }
 
 func (ctc *CloudType) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/cloud_type/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/cloud_type/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package cloud_type
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/comparison_basic.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/comparison_basic.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,13 +78,11 @@ func (bcb *BaseComparison) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(bcb.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", bcb.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("type", string(bcb.Type)); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate": bcb.Negate,
+		"type":   bcb.Type,
+	})
 }
 
 func (bcb *BaseComparison) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -101,13 +99,11 @@ func (bcb *BaseComparison) UnmarshalHCL(decoder hcl.Decoder) error {
 			bcb.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		bcb.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		bcb.Negate = value.(bool)
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"negate": &bcb.Negate,
+		"type":   &bcb.Type,
+	})
 }
 
 func (bcb *BaseComparison) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/custom_application_type.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/custom_application_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (catc *CustomApplicationType) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(catc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", catc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(catc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", catc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   catc.Negate,
+		"operator": catc.Operator,
+		"value":    catc.Value,
+	})
 }
 
 func (catc *CustomApplicationType) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (catc *CustomApplicationType) UnmarshalHCL(decoder hcl.Decoder) error {
 			catc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		catc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		catc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		catc.Operator = custom_application_type.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		catc.Value = custom_application_type.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &catc.Type,
+		"negate":   &catc.Negate,
+		"operator": &catc.Operator,
+		"value":    &catc.Value,
+	})
 }
 
 func (catc *CustomApplicationType) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/custom_application_type/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/custom_application_type/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package custom_application_type
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (catcv *Value) String() string {
-	return string(*catcv)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/database_topology.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/database_topology.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (dtc *DatabaseTopology) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(dtc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", dtc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(dtc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", dtc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   dtc.Negate,
+		"operator": dtc.Operator,
+		"value":    dtc.Value,
+	})
 }
 
 func (dtc *DatabaseTopology) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (dtc *DatabaseTopology) UnmarshalHCL(decoder hcl.Decoder) error {
 			dtc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		dtc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		dtc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		dtc.Operator = database_topology.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		dtc.Value = database_topology.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &dtc.Type,
+		"negate":   &dtc.Negate,
+		"operator": &dtc.Operator,
+		"value":    &dtc.Value,
+	})
 }
 
 func (dtc *DatabaseTopology) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/database_topology/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/database_topology/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package database_topology
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/dcrum_decoder.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/dcrum_decoder.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (ddc *DCRumDecoder) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(ddc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", ddc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(ddc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", ddc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   ddc.Negate,
+		"operator": ddc.Operator,
+		"value":    ddc.Value,
+	})
 }
 
 func (ddc *DCRumDecoder) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (ddc *DCRumDecoder) UnmarshalHCL(decoder hcl.Decoder) error {
 			ddc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		ddc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		ddc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		ddc.Operator = dcrum_decoder.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		ddc.Value = dcrum_decoder.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &ddc.Type,
+		"negate":   &ddc.Negate,
+		"operator": &ddc.Operator,
+		"value":    &ddc.Value,
+	})
 }
 
 func (ddc *DCRumDecoder) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/dcrum_decoder/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/dcrum_decoder/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package dcrum_decoder
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/entity_id.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/entity_id.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (eic *EntityID) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(eic.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", eic.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(eic.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", eic.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   eic.Negate,
+		"operator": eic.Operator,
+		"value":    eic.Value,
+	})
 }
 
 func (eic *EntityID) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,17 +98,14 @@ func (eic *EntityID) UnmarshalHCL(decoder hcl.Decoder) error {
 			eic.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("value"); ok {
-		eic.Value = new(value.(string))
-	}
+
 	eic.Type = ComparisonBasicTypes.EntityID
-	if value, ok := decoder.GetOk("negate"); ok {
-		eic.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		eic.Operator = entity_id.Operator(value.(string))
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"negate":   &eic.Negate,
+		"operator": &eic.Operator,
+		"value":    &eic.Value,
+	})
 }
 
 func (eic *EntityID) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/hypervisor_type.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/hypervisor_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (htc *HypervisorType) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(htc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", htc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(htc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", htc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   htc.Negate,
+		"operator": htc.Operator,
+		"value":    htc.Value,
+	})
 }
 
 func (htc *HypervisorType) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (htc *HypervisorType) UnmarshalHCL(decoder hcl.Decoder) error {
 			htc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		htc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		htc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		htc.Operator = hypervisor_type.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		htc.Value = hypervisor_type.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &htc.Type,
+		"negate":   &htc.Negate,
+		"operator": &htc.Operator,
+		"value":    &htc.Value,
+	})
 }
 
 func (htc *HypervisorType) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/hypervisor_type/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/hypervisor_type/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package hypervisor_type
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/indexed_name.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/indexed_name.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (inc *IndexedName) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(inc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", inc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(inc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", inc.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   inc.Negate,
+		"operator": inc.Operator,
+		"value":    inc.Value,
+	})
 }
 
 func (inc *IndexedName) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (inc *IndexedName) UnmarshalHCL(decoder hcl.Decoder) error {
 			inc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		inc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		inc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		inc.Operator = indexed_name.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		inc.Value = new(value.(string))
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &inc.Type,
+		"negate":   &inc.Negate,
+		"operator": &inc.Operator,
+		"value":    &inc.Value,
+	})
 }
 
 func (inc *IndexedName) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/indexed_string.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/indexed_string.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (isc *IndexedString) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(isc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", isc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(isc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", isc.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   isc.Negate,
+		"operator": isc.Operator,
+		"value":    isc.Value,
+	})
 }
 
 func (isc *IndexedString) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (isc *IndexedString) UnmarshalHCL(decoder hcl.Decoder) error {
 			isc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		isc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		isc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		isc.Operator = indexed_string.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		isc.Value = new(value.(string))
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &isc.Type,
+		"negate":   &isc.Negate,
+		"operator": &isc.Operator,
+		"value":    &isc.Value,
+	})
 }
 
 func (isc *IndexedString) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/indexed_tag.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/indexed_tag.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -79,16 +79,12 @@ func (itc *IndexedTag) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(itc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", itc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(itc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", itc.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   itc.Negate,
+		"operator": itc.Operator,
+		"value":    itc.Value,
+	})
 }
 
 func (itc *IndexedTag) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -107,22 +103,13 @@ func (itc *IndexedTag) UnmarshalHCL(decoder hcl.Decoder) error {
 			itc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		itc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		itc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		itc.Operator = indexed_tag.Operator(value.(string))
-	}
-	if _, ok := decoder.GetOk("value.#"); ok {
-		itc.Value = new(tag.Info)
-		if err := itc.Value.UnmarshalHCL(hcl.NewDecoder(decoder, "value", 0)); err != nil {
-			return err
-		}
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &itc.Type,
+		"negate":   &itc.Negate,
+		"operator": &itc.Operator,
+		"value":    &itc.Value,
+	})
 }
 
 func (itc *IndexedTag) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/integer.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/integer.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/entityruleengine/comparison/integer"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
-
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -76,16 +74,12 @@ func (ic *Integer) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(ic.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", ic.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(ic.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", int(opt.Int32(ic.Value))); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   ic.Negate,
+		"operator": ic.Operator,
+		"value":    ic.Value,
+	})
 }
 
 func (ic *Integer) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -104,19 +98,13 @@ func (ic *Integer) UnmarshalHCL(decoder hcl.Decoder) error {
 			ic.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		ic.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		ic.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		ic.Operator = integer.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		ic.Value = new(int32(value.(int)))
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &ic.Type,
+		"negate":   &ic.Negate,
+		"operator": &ic.Operator,
+		"value":    &ic.Value,
+	})
 }
 
 func (ic *Integer) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/ip_address.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/ip_address.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,10 +22,9 @@ import (
 	"maps"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/entityruleengine/comparison/ip_address"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
-
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/opt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -82,19 +81,13 @@ func (iac *IPAddress) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(iac.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", iac.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(iac.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", iac.Value); err != nil {
-		return err
-	}
-	if err := properties.Encode("case_sensitive", opt.Bool(iac.CaseSensitive)); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":         iac.Negate,
+		"operator":       iac.Operator,
+		"value":          iac.Value,
+		"case_sensitive": iac.CaseSensitive,
+	})
 }
 
 func (iac *IPAddress) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -114,23 +107,14 @@ func (iac *IPAddress) UnmarshalHCL(decoder hcl.Decoder) error {
 			iac.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		iac.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		iac.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		iac.Operator = ip_address.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		iac.Value = new(value.(string))
-	}
-	if value, ok := decoder.GetOk("case_sensitive"); ok {
-		iac.CaseSensitive = new(value.(bool))
-	}
 
-	return nil
+	return decoder.DecodeAll(map[string]any{
+		"type":           &iac.Type,
+		"negate":         &iac.Negate,
+		"operator":       &iac.Operator,
+		"value":          &iac.Value,
+		"case_sensitive": &iac.CaseSensitive,
+	})
 }
 
 func (iac *IPAddress) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/mobile_platform.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/mobile_platform.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (mpc *MobilePlatform) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(mpc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", mpc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(mpc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", mpc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   mpc.Negate,
+		"operator": mpc.Operator,
+		"value":    mpc.Value,
+	})
 }
 
 func (mpc *MobilePlatform) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (mpc *MobilePlatform) UnmarshalHCL(decoder hcl.Decoder) error {
 			mpc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		mpc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		mpc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		mpc.Operator = mobile_platform.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		mpc.Value = mobile_platform.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &mpc.Type,
+		"negate":   &mpc.Negate,
+		"operator": &mpc.Operator,
+		"value":    &mpc.Value,
+	})
 }
 
 func (mpc *MobilePlatform) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/mobile_platform/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/mobile_platform/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package mobile_platform
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (mpcv *Value) String() string {
-	return string(*mpcv)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/os_architecture.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/os_architecture.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -75,16 +75,12 @@ func (oac *OSArchitecture) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(oac.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", oac.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(oac.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", oac.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   oac.Negate,
+		"operator": oac.Operator,
+		"value":    oac.Value,
+	})
 }
 
 func (oac *OSArchitecture) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -103,19 +99,13 @@ func (oac *OSArchitecture) UnmarshalHCL(decoder hcl.Decoder) error {
 			oac.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		oac.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		oac.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		oac.Operator = osarch.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		oac.Value = osarch.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &oac.Type,
+		"negate":   &oac.Negate,
+		"operator": &oac.Operator,
+		"value":    &oac.Value,
+	})
 }
 
 func (oac *OSArchitecture) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/os_type.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/os_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (otc *OSType) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(otc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", otc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(otc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", otc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   otc.Negate,
+		"operator": otc.Operator,
+		"value":    otc.Value,
+	})
 }
 
 func (otc *OSType) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (otc *OSType) UnmarshalHCL(decoder hcl.Decoder) error {
 			otc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		otc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		otc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		otc.Operator = ostype.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		otc.Value = ostype.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &otc.Type,
+		"negate":   &otc.Negate,
+		"operator": &otc.Operator,
+		"value":    &otc.Value,
+	})
 }
 
 func (otc *OSType) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/osarch/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/osarch/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package osarch
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/ostype/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/ostype/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package ostype
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/paas_type.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/paas_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (ptc *PaasType) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(ptc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", ptc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(ptc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", ptc.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   ptc.Negate,
+		"operator": ptc.Operator,
+		"value":    ptc.Value,
+	})
 }
 
 func (ptc *PaasType) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (ptc *PaasType) UnmarshalHCL(decoder hcl.Decoder) error {
 			ptc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		ptc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		ptc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		ptc.Operator = paastype.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		ptc.Value = paastype.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &ptc.Type,
+		"negate":   &ptc.Negate,
+		"operator": &ptc.Operator,
+		"value":    &ptc.Value,
+	})
 }
 
 func (ptc *PaasType) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/paas_type/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/paas_type/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package paastype
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (ptcv *Value) String() string {
-	return string(*ptcv)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/service_topology.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/service_topology.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (stc *ServiceTopology) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(stc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", stc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(stc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", stc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   stc.Negate,
+		"operator": stc.Operator,
+		"value":    stc.Value,
+	})
 }
 
 func (stc *ServiceTopology) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (stc *ServiceTopology) UnmarshalHCL(decoder hcl.Decoder) error {
 			stc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		stc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		stc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		stc.Operator = service_topology.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		stc.Value = service_topology.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &stc.Type,
+		"negate":   &stc.Negate,
+		"operator": &stc.Operator,
+		"value":    &stc.Value,
+	})
 }
 
 func (stc *ServiceTopology) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/service_topology/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/service_topology/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package service_topology
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/service_type.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/service_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,18 +74,12 @@ func (stc *ServiceType) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(stc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", stc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(stc.Operator)); err != nil {
-		return err
-	}
-	if stc.Value != nil {
-		if err := properties.Encode("value", stc.Value.String()); err != nil {
-			return err
-		}
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   stc.Negate,
+		"operator": stc.Operator,
+		"value":    stc.Value,
+	})
 }
 
 func (stc *ServiceType) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -104,19 +98,13 @@ func (stc *ServiceType) UnmarshalHCL(decoder hcl.Decoder) error {
 			stc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		stc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		stc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		stc.Operator = service_type.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		stc.Value = service_type.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &stc.Type,
+		"negate":   &stc.Negate,
+		"operator": &stc.Operator,
+		"value":    &stc.Value,
+	})
 }
 
 func (stc *ServiceType) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/service_type/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/service_type/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package service_type
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/simple_host_tech.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/simple_host_tech.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,16 +78,12 @@ func (shtc *SimpleHostTech) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(shtc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", shtc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(shtc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", shtc.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   shtc.Negate,
+		"operator": shtc.Operator,
+		"value":    shtc.Value,
+	})
 }
 
 func (shtc *SimpleHostTech) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -106,22 +102,13 @@ func (shtc *SimpleHostTech) UnmarshalHCL(decoder hcl.Decoder) error {
 			shtc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		shtc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		shtc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		shtc.Operator = tech.HostOperator(value.(string))
-	}
-	if _, ok := decoder.GetOk("value.#"); ok {
-		shtc.Value = new(tech.Host)
-		if err := shtc.Value.UnmarshalHCL(hcl.NewDecoder(decoder, "value", 0)); err != nil {
-			return err
-		}
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &shtc.Type,
+		"negate":   &shtc.Negate,
+		"operator": &shtc.Operator,
+		"value":    &shtc.Value,
+	})
 }
 
 func (shtc *SimpleHostTech) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/simple_tech.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/simple_tech.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,16 +78,12 @@ func (stc *SimpleTech) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(stc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", stc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(stc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", stc.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   stc.Negate,
+		"operator": stc.Operator,
+		"value":    stc.Value,
+	})
 }
 
 func (stc *SimpleTech) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -106,22 +102,13 @@ func (stc *SimpleTech) UnmarshalHCL(decoder hcl.Decoder) error {
 			stc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		stc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		stc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		stc.Operator = tech.Operator(value.(string))
-	}
-	if _, ok := decoder.GetOk("value.#"); ok {
-		stc.Value = new(tech.Simple)
-		if err := stc.Value.UnmarshalHCL(hcl.NewDecoder(decoder, "value", 0)); err != nil {
-			return err
-		}
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &stc.Type,
+		"negate":   &stc.Negate,
+		"operator": &stc.Operator,
+		"value":    &stc.Value,
+	})
 }
 
 func (stc *SimpleTech) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/string.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/string.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,19 +80,13 @@ func (sc *String) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(sc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", sc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(sc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("case_sensitive", sc.CaseSensitive); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", sc.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":         sc.Negate,
+		"operator":       sc.Operator,
+		"case_sensitive": sc.CaseSensitive,
+		"value":          sc.Value,
+	})
 }
 
 func (sc *String) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -107,27 +101,19 @@ func (sc *String) UnmarshalHCL(decoder hcl.Decoder) error {
 		delete(sc.Unknowns, "negate")
 		delete(sc.Unknowns, "operator")
 		delete(sc.Unknowns, "value")
+		delete(sc.Unknowns, "case_sensitive")
 		if len(sc.Unknowns) == 0 {
 			sc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		sc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		sc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		sc.Operator = stringc.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		sc.Value = new(value.(string))
-	}
-	if value, ok := decoder.GetOk("case_sensitive"); ok {
-		sc.CaseSensitive = value.(bool)
-	}
 
-	return nil
+	return decoder.DecodeAll(map[string]any{
+		"type":           &sc.Type,
+		"negate":         &sc.Negate,
+		"operator":       &sc.Operator,
+		"case_sensitive": &sc.CaseSensitive,
+		"value":          &sc.Value,
+	})
 }
 
 func (sc *String) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/synthetic_engine_type.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/synthetic_engine_type.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func (setc *SyntheticEngineType) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(setc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", setc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(setc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", setc.Value.String()); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   setc.Negate,
+		"operator": setc.Operator,
+		"value":    setc.Value,
+	})
 }
 
 func (setc *SyntheticEngineType) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -102,19 +98,13 @@ func (setc *SyntheticEngineType) UnmarshalHCL(decoder hcl.Decoder) error {
 			setc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		setc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		setc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		setc.Operator = synthetic_engine_type.Operator(value.(string))
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		setc.Value = synthetic_engine_type.Value(value.(string)).Ref()
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &setc.Type,
+		"negate":   &setc.Negate,
+		"operator": &setc.Operator,
+		"value":    &setc.Value,
+	})
 }
 
 func (setc *SyntheticEngineType) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/synthetic_engine_type/value.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/synthetic_engine_type/value.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,14 +19,6 @@ package synthetic_engine_type
 
 // Value The value to compare to.
 type Value string
-
-func (v Value) Ref() *Value {
-	return &v
-}
-
-func (v *Value) String() string {
-	return string(*v)
-}
 
 // Values offers the known enum values
 var Values = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/tag/tag_info.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/tag/tag_info.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -62,16 +62,12 @@ func (ti *Info) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(ti.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("context", string(ti.Context)); err != nil {
-		return err
-	}
-	if err := properties.Encode("key", ti.Key); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", ti.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"context": ti.Context,
+		"key":     ti.Key,
+		"value":   ti.Value,
+	})
 }
 
 func (ti *Info) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -89,16 +85,12 @@ func (ti *Info) UnmarshalHCL(decoder hcl.Decoder) error {
 			ti.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("context"); ok {
-		ti.Context = Context(value.(string))
-	}
-	if value, ok := decoder.GetOk("key"); ok {
-		ti.Key = value.(string)
-	}
-	if value, ok := decoder.GetOk("value"); ok {
-		ti.Value = new(value.(string))
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"context": &ti.Context,
+		"key":     &ti.Key,
+		"value":   &ti.Value,
+	})
 }
 
 // Context The origin of the tag, such as AWS or Cloud Foundry.

--- a/dynatrace/api/v1/config/entityruleengine/comparison/tag_comparison.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/tag_comparison.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,16 +78,12 @@ func (tc *Tag) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(tc.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("negate", tc.Negate); err != nil {
-		return err
-	}
-	if err := properties.Encode("operator", string(tc.Operator)); err != nil {
-		return err
-	}
-	if err := properties.Encode("value", tc.Value); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"negate":   tc.Negate,
+		"operator": tc.Operator,
+		"value":    tc.Value,
+	})
 }
 
 func (tc *Tag) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -106,22 +102,13 @@ func (tc *Tag) UnmarshalHCL(decoder hcl.Decoder) error {
 			tc.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		tc.Type = ComparisonBasicType(value.(string))
-	}
-	if value, ok := decoder.GetOk("negate"); ok {
-		tc.Negate = value.(bool)
-	}
-	if value, ok := decoder.GetOk("operator"); ok {
-		tc.Operator = tag.Operator(value.(string))
-	}
-	if _, ok := decoder.GetOk("value.#"); ok {
-		tc.Value = new(tag.Info)
-		if err := tc.Value.UnmarshalHCL(hcl.NewDecoder(decoder, "value", 0)); err != nil {
-			return err
-		}
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":     &tc.Type,
+		"negate":   &tc.Negate,
+		"operator": &tc.Operator,
+		"value":    &tc.Value,
+	})
 }
 
 func (tc *Tag) MarshalJSON() ([]byte, error) {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/tech/host.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/tech/host.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -57,13 +57,11 @@ func (sht *Host) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(sht.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("type", sht.Type.String()); err != nil {
-		return err
-	}
-	if err := properties.Encode("verbatim_type", sht.VerbatimType); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"type":          sht.Type,
+		"verbatim_type": sht.VerbatimType,
+	})
 }
 
 func (sht *Host) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -80,13 +78,11 @@ func (sht *Host) UnmarshalHCL(decoder hcl.Decoder) error {
 			sht.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		sht.Type = SimpleHostTechType(value.(string)).Ref()
-	}
-	if value, ok := decoder.GetOk("verbatim_type"); ok {
-		sht.VerbatimType = new(value.(string))
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":          &sht.Type,
+		"verbatim_type": &sht.VerbatimType,
+	})
 }
 
 func (sht *Host) MarshalJSON() ([]byte, error) {
@@ -136,14 +132,6 @@ func (sht *Host) UnmarshalJSON(data []byte) error {
 
 // SimpleHostTechType Predefined technology, if technology is not predefined, then the verbatim type must be set
 type SimpleHostTechType string
-
-func (v SimpleHostTechType) Ref() *SimpleHostTechType {
-	return &v
-}
-
-func (v *SimpleHostTechType) String() string {
-	return string(*v)
-}
 
 // SimpleHostTechTypes offers the known enum values
 var SimpleHostTechTypes = struct {

--- a/dynatrace/api/v1/config/entityruleengine/comparison/tech/simple.go
+++ b/dynatrace/api/v1/config/entityruleengine/comparison/tech/simple.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2020 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -57,13 +57,11 @@ func (st *Simple) MarshalHCL(properties hcl.Properties) error {
 	if err := properties.Unknowns(st.Unknowns); err != nil {
 		return err
 	}
-	if err := properties.Encode("type", st.Type.String()); err != nil {
-		return err
-	}
-	if err := properties.Encode("verbatim_type", st.VerbatimType); err != nil {
-		return err
-	}
-	return nil
+
+	return properties.EncodeAll(map[string]any{
+		"type":          st.Type,
+		"verbatim_type": st.VerbatimType,
+	})
 }
 
 func (st *Simple) UnmarshalHCL(decoder hcl.Decoder) error {
@@ -80,13 +78,11 @@ func (st *Simple) UnmarshalHCL(decoder hcl.Decoder) error {
 			st.Unknowns = nil
 		}
 	}
-	if value, ok := decoder.GetOk("type"); ok {
-		st.Type = SimpleTechType(value.(string)).Ref()
-	}
-	if value, ok := decoder.GetOk("verbatim_type"); ok {
-		st.VerbatimType = new(value.(string))
-	}
-	return nil
+
+	return decoder.DecodeAll(map[string]any{
+		"type":          &st.Type,
+		"verbatim_type": &st.VerbatimType,
+	})
 }
 
 func (st *Simple) MarshalJSON() ([]byte, error) {
@@ -136,14 +132,6 @@ func (st *Simple) UnmarshalJSON(data []byte) error {
 
 // SimpleTechType Predefined technology, if technology is not predefined, then the verbatim type must be set
 type SimpleTechType string
-
-func (v SimpleTechType) Ref() *SimpleTechType {
-	return &v
-}
-
-func (v *SimpleTechType) String() string {
-	return string(*v)
-}
 
 // SimpleTechTypes offers the known enum values
 var SimpleTechTypes = struct {

--- a/dynatrace/api/v1/config/naming/hosts/testdata/terraform/example_all_conditions.tf
+++ b/dynatrace/api/v1/config/naming/hosts/testdata/terraform/example_all_conditions.tf
@@ -1,0 +1,119 @@
+resource "dynatrace_host_naming" "all_conditions" {
+  name    = "#name#"
+  enabled = true
+  format  = "{AwsAutoScalingGroup:Name}"
+  conditions {
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_AZURE_COMPUTE_MODE"
+      }
+      azure_compute_mode {
+        negate   = true
+        operator = "EQUALS"
+        value    = "SHARED"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_AZURE_SKU"
+      }
+      azure_sku {
+        negate   = true
+        operator = "EQUALS"
+        value    = "BASIC"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_BITNESS"
+      }
+      bitness {
+        negate   = true
+        operator = "EQUALS"
+        value    = "64"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_CLOUD_TYPE"
+      }
+      cloud_type {
+        negate   = true
+        operator = "EQUALS"
+        value    = "AZURE"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_HYPERVISOR_TYPE"
+      }
+      hypervisor {
+        negate   = true
+        operator = "EQUALS"
+        value    = "HYPER_V"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_IP_ADDRESS"
+      }
+      ipaddress {
+        negate   = true
+        operator = "EQUALS"
+        value    = "value"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_OS_TYPE"
+      }
+      os_type {
+        negate   = true
+        operator = "EQUALS"
+        value    = "LINUX"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_PAAS_TYPE"
+      }
+      paas_type {
+        negate   = true
+        operator = "EQUALS"
+        value    = "KUBERNETES"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_TAGS"
+      }
+      tag {
+        negate   = true
+        operator = "EQUALS"
+        value {
+          context = "CONTEXTLESS"
+          key     = "key"
+          value   = "value"
+        }
+      }
+    }
+  }
+}
+

--- a/dynatrace/api/v1/config/naming/hosts/testdata/terraform/example_os_type_exists.tf
+++ b/dynatrace/api/v1/config/naming/hosts/testdata/terraform/example_os_type_exists.tf
@@ -1,0 +1,16 @@
+resource "dynatrace_host_naming" "host_naming_os_type_exists" {
+  name    = "#name#"
+  enabled = true
+  format  = "{Host:DetectedName} - {HostGroup:Name}"
+  conditions {
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "HOST_OS_TYPE"
+      }
+      os_type {
+        operator = "EXISTS"
+      }
+    }
+  }
+}

--- a/dynatrace/api/v1/config/naming/services/testdata/terraform/example_all_conditions.tf
+++ b/dynatrace/api/v1/config/naming/services/testdata/terraform/example_all_conditions.tf
@@ -1,0 +1,42 @@
+resource "dynatrace_service_naming" "naming" {
+  name    = "#name#"
+  enabled = true
+  format  = "format"
+  conditions {
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "SERVICE_DATABASE_TOPOLOGY"
+      }
+      database_topology {
+        negate   = true
+        operator = "EQUALS"
+        value    = "CLUSTER"
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "SERVICE_TOPOLOGY"
+      }
+      service_topology {
+        negate   = true
+        operator = "EQUALS"
+        value    = "FULLY_MONITORED "
+      }
+    }
+
+    condition {
+      key {
+        type      = "STATIC"
+        attribute = "SERVICE_TYPE"
+      }
+      service_type {
+        negate   = true
+        operator = "EQUALS"
+        value    = "CUSTOM_SERVICE"
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
A customer experienced a panic when exporting a `dynatrace_host_naming` resource with "OS type" "exists". Subsequent investigation revealed that entity rule engine comparisons with a `nil` value cause a panic.

#### **What** has changed?
This area of the code is very similar to that generated for settings schemas, however has not been updated for some time. Essentially, this PR updates it.

#### **How** does it do it?
Changes are made to the comparisons:
- They now operate on the Value types directly without using the `Value()` or `Ref()` methods. These methods are no longer used and so are removed.
- They are refactored to use `EncodeAll()` and `DecodeAll()`, simplifying the code.

#### How is it **tested**?
- Existing tests
- Add An explicit test with a host naming rule with os type exists


#### How does it affect **users**?
Host naming rules can be created with conditions using "exists" or "does not exist"

**Issue:** CA-19614
