### PR TITLE
test: fix flaky dynatrace_log_events test

### DIFF
--- a/dynatrace/api/builtin/logmonitoring/logevents/testcases/update-metadata-item-set/create.tf
+++ b/dynatrace/api/builtin/logmonitoring/logevents/testcases/update-metadata-item-set/create.tf
@@ -1,7 +1,7 @@
 resource "dynatrace_log_events" "events" {
   enabled = false
   query   = "matchesPhrase(content, \"terratest\")"
-  summary = "Created by Terraform"
+  summary = "Created by #name#"
   event_template {
     description = "Created by Terraform"
     event_type  = "INFO"

--- a/dynatrace/api/builtin/logmonitoring/logevents/testcases/update-metadata-item-set/update.tf
+++ b/dynatrace/api/builtin/logmonitoring/logevents/testcases/update-metadata-item-set/update.tf
@@ -1,7 +1,7 @@
 resource "dynatrace_log_events" "events" {
   enabled = false
   query   = "matchesPhrase(content, \"terratest\")"
-  summary = "Created by Terraform"
+  summary = "Created by #name#"
   event_template {
     description = "Created by Terraform"
     event_type  = "INFO"

--- a/dynatrace/api/builtin/logmonitoring/logevents/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/logmonitoring/logevents/testdata/terraform/example_a.tf
@@ -1,7 +1,7 @@
-resource "dynatrace_log_events" "#name#" {
+resource "dynatrace_log_events" "events" {
   enabled = false
   query   = "matchesPhrase(content, \"terratest\")"
-  summary = "Created by Terraform"
+  summary = "Created by #name#"
   event_template {
     description = "Created by Terraform"
     event_type  = "INFO"


### PR DESCRIPTION
#### **Why** this PR?
dynatrace_log_events potentially failed

#### **What** has changed?
It doesn't fail anymore due to the parallel execution of the test

#### **How** does it do it?
By making the summary unique instead of using a static string.

#### How is it **tested**?
It's about tests

#### How does it affect **users**?
N/A (slightly the docs)

**Issue:** NOISSUE