### PR TITLE
feat: add dynatrace_gcp_principal data source

### DIFF
--- a/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/data_source.go
+++ b/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/data_source.go
@@ -1,0 +1,136 @@
+/**
+* @license
+* Copyright 2020 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package gcpdynatraceprincipal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	gcpdynatraceprincipal "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp"
+	gcpsettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	SchemaVersion = "0.0.3"
+	SchemaID      = "builtin:hyperscaler-authentication.connections.gcp-dynatrace-principal"
+
+	principalCreationTimeout = 5 * time.Minute
+)
+
+var errPrincipalNotProvisionedYet = errors.New("no Dynatrace GCP Principal found yet")
+
+var ValidConnection = gcpsettings.Settings{
+	Name: "temp",
+	Type: "serviceAccountImpersonation",
+	ServiceAccountImpersonation: new(gcpsettings.ServiceAccountImpersonation{
+		Consumers: []gcpsettings.ConsumersOfServiceAccountImpersonation{"SVC:com.dynatrace.bo"},
+	}),
+}
+
+func ensurePrincipalExists(ctx context.Context, credentials *rest.Credentials) (*api.Stub, error) {
+	listService := settings20.Service[*gcpdynatraceprincipal.Settings](credentials, SchemaID, SchemaVersion)
+
+	stubs, err := listService.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(stubs) == 0 {
+		if v, ok := gcp.Service(credentials).(settings.Validator[*gcpsettings.Settings]); ok {
+			if err = v.Validate(ctx, &ValidConnection); err != nil {
+				return nil, fmt.Errorf("failed to trigger Dynatrace GCP Principal creation. Please reach out to support: %w", err)
+			}
+		}
+
+		err = retry.RetryContext(ctx, principalCreationTimeout, func() *retry.RetryError {
+			var listErr error
+			stubs, listErr = listService.List(ctx)
+			if listErr != nil {
+				return retry.NonRetryableError(fmt.Errorf("Dynatrace GCP Principal provisioning failed. Please reach out to support: %w", listErr))
+			}
+			if len(stubs) == 0 {
+				return retry.RetryableError(errPrincipalNotProvisionedYet)
+			}
+			return nil
+		})
+		if err != nil {
+			if errors.Is(err, errPrincipalNotProvisionedYet) {
+				return nil, fmt.Errorf("Dynatrace GCP Principal was not provisioned within %v. Please reach out to support", principalCreationTimeout)
+			}
+			return nil, err
+		}
+	}
+
+	// There can only be one principal, so we take the first (and only one) in the list.
+	return stubs[0], nil
+}
+
+// Attribute keys
+const (
+	attrPrincipal = "principal"
+)
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: logging.EnableDSCtx(DataSourceRead),
+		Description: "Returns the Dynatrace GCP Principal",
+		Schema: map[string]*schema.Schema{
+			attrPrincipal: {
+				Type:        schema.TypeString,
+				Description: "Dynatrace GCP Principal",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	creds, err := config.Credentials(m, config.CredValDefault)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	principalStub, err := ensurePrincipalExists(ctx, creds)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	principal, ok := principalStub.Value.(*gcpdynatraceprincipal.Settings)
+	if !ok || principal == nil {
+		return diag.FromErr(fmt.Errorf("unexpected value type returned for Dynatrace GCP Principal. Please reach out to support"))
+	}
+
+	d.SetId(principalStub.ID)
+	if err := d.Set(attrPrincipal, principal.Principal); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/data_source_test.go
+++ b/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/data_source_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package gcpdynatraceprincipal_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccDatasourceGcpPrincipal(t *testing.T) {
+	t.Skip("Enable this test as soon as the dynatrace_gcp_principal datasource is referenced in provider.go")
+
+	datasourceConfig, _ := api.ReadTfConfig(t, "testdata/datasource.tf")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"dynatrace": func() (*schema.Provider, error) {
+				return provider.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: datasourceConfig,
+				Check:  resource.TestMatchOutput("records", regexp.MustCompile(`iam\.gserviceaccount\.com$`)),
+			},
+		},
+	})
+}

--- a/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/schema.json
+++ b/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/schema.json
@@ -1,0 +1,39 @@
+{
+	"allowedScopes": [
+		"environment"
+	],
+	"description": "GCP Dynatrace Principal for Dynatrace integrations",
+	"displayName": "GCP Dynatrace Principal",
+	"documentation": "",
+	"dynatrace": "1",
+	"enums": {},
+	"maturity": "EARLY_ADOPTER",
+	"maxObjects": 1,
+	"metadata": {
+		"$ref": "#/types/Metadata"
+	},
+	"multiObject": true,
+	"ordered": false,
+	"properties": {
+		"principal": {
+			"constraints": [
+				{
+					"maxLength": 100,
+					"minLength": 1,
+					"type": "LENGTH"
+				}
+			],
+			"default": "",
+			"description": "Dynatrace GCP Service Account",
+			"displayName": "Dynatrace Principal",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "NEVER",
+			"nullable": false,
+			"type": "text"
+		}
+	},
+	"schemaId": "builtin:hyperscaler-authentication.connections.gcp-dynatrace-principal",
+	"types": {},
+	"version": "0.0.3"
+}

--- a/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/settings/settings.go
+++ b/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/settings/settings.go
@@ -1,0 +1,54 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package gcpdynatraceprincipal
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type Settings struct {
+	Principal string `json:"principal"` // Dynatrace GCP Service Account
+}
+
+func (me *Settings) Name() string {
+	return "dynatrace_gcp_principal"
+}
+
+func (me *Settings) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"principal": {
+			Type:        schema.TypeString,
+			Description: "Dynatrace GCP Service Account",
+			ForceNew:    true,
+			Required:    true,
+		},
+	}
+}
+
+func (me *Settings) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"principal": me.Principal,
+	})
+}
+
+func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"principal": &me.Principal,
+	})
+}

--- a/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/testdata/datasource.tf
+++ b/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/testdata/datasource.tf
@@ -1,0 +1,6 @@
+data "dynatrace_gcp_principal" "principal" {
+}
+
+output "records" {
+  value = data.dynatrace_gcp_principal.principal.principal
+}

--- a/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/validate_test.go
+++ b/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/validate_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package gcpdynatraceprincipal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal"
+	gcpservice "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp"
+	gcpsettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Guards against schema drift in ValidConnection. The data source triggers Dynatrace GCP
+// Principal creation as a side effect of submitting ValidConnection to the validate endpoint;
+// if the payload is rejected, no principal will ever be created.
+func TestValidateIsSuccessfulForGcpConnection(t *testing.T) {
+	envURL := os.Getenv("DYNATRACE_ENV_URL")
+	apiToken := os.Getenv("DYNATRACE_API_TOKEN")
+	if envURL == "" || apiToken == "" {
+		t.Skip("Environment Variables DYNATRACE_ENV_URL and DYNATRACE_API_TOKEN must be specified")
+	}
+
+	credentials := &rest.Credentials{URL: envURL, Token: apiToken}
+	service := settings20.Service[*gcpsettings.Settings](credentials, gcpservice.SchemaID, gcpservice.SchemaVersion)
+
+	validator, ok := service.(settings.Validator[*gcpsettings.Settings])
+	require.True(t, ok, "settings20 service must implement settings.Validator")
+
+	err := validator.Validate(t.Context(), &gcpdynatraceprincipal.ValidConnection)
+	assert.NoError(t, err, "ValidConnection in data_source.go was rejected by the API — update the fixture or principal creation might never be triggered.")
+}


### PR DESCRIPTION
#### Why this PR?

The `dynatrace_gcp_principal` data source is a prerequisite for setting up GCP integrations: users need the
Dynatrace-managed GCP service account identity before they can grant it IAM permissions in their GCP project.
Without a dedicated data source, there is no way to retrieve this value via Terraform.

#### What has changed?

- New package datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal containing the data source implementation, its internal settings type, and the API schema snapshot (schema.json).

#### How does it do it?

The data source calls the Settings 2.0 list endpoint for `builtin:hyperscaler-authentication.connections.gcp-dynatrace-principal`.
If no principal exists yet, it triggers creation as a side effect by submitting a dummy GCP connection payload (`ValidConnection`)
to the validate endpoint — which causes Dynatrace to provision the principal asynchronously.
It then polls the list endpoint every 5 seconds (up to 5 minutes) until the principal appears,
and returns its service account email.

#### How is it tested?

 - `TestAccDatasourceGcpPrincipal` (integration): runs a full Terraform plan/apply against a real environment and asserts the output matches the GCP service account email pattern (iam.gserviceaccount.com$).
 - `TestValidateIsSuccessfulForGcpConnection` (integration): submits `ValidConnection` directly to the validate endpoint, guarding against schema drift that would silently break principal creation.
 - Both tests are gated behind the `integration` build tag and require `DYNATRACE_ENV_URL` / `DYNATRACE_API_TOKEN`.

The tests are currently skipped, as neither the connection resource nor the principal datasource are wired in the provider yet. Enabling the tests will happen in the same pull request where the wiring happens, i.e. with the release of the feature.

#### How does it affect users?

Currently, it does _not_ affect users as the data source is not yet registered in the provider. This will happen in a follow-up.
Once the data source is registered, users can reference the Dynatrace GCP Principal in their Terraform configuration:

```
data "dynatrace_gcp_principal" "principal" {}

# e.g. grant it a role in GCP

resource "google_service_account_iam_member" "binding" {
  service_account_id = "..."
  role = "roles/iam.serviceAccountTokenCreator"
  member = "serviceAccount:${data.dynatrace_gcp_principal.principal.principal}"
}
```
The first apply may take a while if the principal does not yet exist in the environment.

**Issue:** CA-19461