### PR TITLE
chore: Exclude `.agents`, `.claude` and `.opencode` folders from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ test.log
 .DS_Store
 *.env
 __debug_bin*
+.agents/*
+.opencode/*
+.claude/*
 
 # generated files
 schemaSupport.json


### PR DESCRIPTION
#### **Why** this PR?
While working with agents locally, I'd like to not have the configurations in source control.

#### **What** has changed and **how** does it do it?
`.agents`, `.claude` and `.opencode` folders are excluded from source control.

#### How is it **tested**?
NA

#### How does it affect **users**?
NA

**Issue:** NA
