### PR TITLE
feat: add retry to GCP connection and make impersonation fields ForceNew

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,6 +168,7 @@ jobs:
           DT_CLIENT_ID: ${{ secrets.DT_CLIENT_ID }}
           DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
+          TF_VAR_DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT: ${{ secrets.DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT }}
         run: go test -tags=integration -v -p 1 ${{ matrix.config.path }}
 
   sequential-integration-tests:

--- a/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/data_source.go
+++ b/datasources/hyperscalerauthentication/connections/gcpdynatraceprincipal/data_source.go
@@ -67,6 +67,8 @@ func ensurePrincipalExists(ctx context.Context, credentials *rest.Credentials) (
 			if err = v.Validate(ctx, &ValidConnection); err != nil {
 				return nil, fmt.Errorf("failed to trigger Dynatrace GCP Principal creation. Please reach out to support: %w", err)
 			}
+		} else {
+			return nil, settings.ErrValidatorNotImplemented(gcp.SchemaID)
 		}
 
 		err = retry.RetryContext(ctx, principalCreationTimeout, func() *retry.RetryError {

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service.go
@@ -18,7 +18,13 @@
 package gcp
 
 import (
-	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/settings"
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	serviceSettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/settings"
+	retrycommon "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/retry"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
@@ -27,6 +33,69 @@ import (
 const SchemaVersion = "0.0.5"
 const SchemaID = "builtin:hyperscaler-authentication.connections.gcp"
 
-func Service(credentials *rest.Credentials) settings.CRUDService[*service.Settings] {
-	return settings20.Service[*service.Settings](credentials, SchemaID, SchemaVersion)
+// RetryableAuthenticationErrorMessage is the substring of the constraint-violation message the
+// Dynatrace API returns while the service account impersonation cannot yet authenticate (e.g. the
+// IAM policy change on the GCP side has not propagated yet). Create retries for as long as the API
+// keeps returning this message. The acceptance test asserts on the same constant, binding the
+// retried message and the asserted message together: if the API ever changes the wording, the test
+// fails and forces this constant to be updated in lockstep.
+const RetryableAuthenticationErrorMessage = "GCP authentication failed"
+
+func Service(credentials *rest.Credentials) settings.CRUDService[*serviceSettings.Settings] {
+	return &service{
+		service: settings20.Service[*serviceSettings.Settings](credentials, SchemaID, SchemaVersion),
+	}
+}
+
+type service struct {
+	service settings.CRUDService[*serviceSettings.Settings]
+}
+
+func (me *service) List(ctx context.Context) (api.Stubs, error) {
+	return me.service.List(ctx)
+}
+
+func (me *service) Get(ctx context.Context, id string, v *serviceSettings.Settings) error {
+	return me.service.Get(ctx, id, v)
+}
+
+func (me *service) Validate(ctx context.Context, v *serviceSettings.Settings) error {
+	if validator, ok := me.service.(settings.Validator[*serviceSettings.Settings]); ok {
+		return validator.Validate(ctx, v)
+	}
+
+	return settings.ErrValidatorNotImplemented(me.SchemaID())
+}
+
+func (me *service) SchemaID() string {
+	return me.service.SchemaID()
+}
+
+// Create is wrapped in a retry: the service account impersonation relies on the provided
+// service account ID, and the corresponding IAM policy changes on the GCP side may not have
+// propagated yet. We retry until they eventually do (or the create timeout elapses).
+func (me *service) Create(ctx context.Context, v *serviceSettings.Settings) (*api.Stub, error) {
+	var stub *api.Stub
+	err := retry.RetryContext(ctx, retrycommon.DurationUntilDeadlineOrDefault(ctx, serviceSettings.DefaultCreateTimeout), func() *retry.RetryError {
+		var err error
+		stub, err = me.service.Create(ctx, v)
+
+		return settings.ClassifyConstraintRetryError(err, RetryableAuthenticationErrorMessage)
+
+	})
+	if err != nil {
+		return nil, err
+	}
+	return stub, nil
+}
+
+// Update only ever changes the connection name; service_account_id and the rest of the
+// impersonation config are ForceNew, so they go through Create/Delete instead. A rename does
+// not depend on IAM propagation, so no retry is needed here.
+func (me *service) Update(ctx context.Context, id string, v *serviceSettings.Settings) error {
+	return me.service.Update(ctx, id, v)
+}
+
+func (me *service) Delete(ctx context.Context, id string) error {
+	return me.service.Delete(ctx, id)
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service_test.go
@@ -20,10 +20,15 @@
 package gcp_test
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestGcpConnection(t *testing.T) {
@@ -33,6 +38,50 @@ func TestGcpConnection(t *testing.T) {
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"google": {VersionConstraint: "7.33.0", Source: "hashicorp/google"},
 			"time":   {VersionConstraint: "0.14.0", Source: "hashicorp/time"},
+		},
+	})
+}
+
+// TestAccGcpConnectionAuthenticationFailure verifies that the Dynatrace API still rejects an
+// unauthorized service account impersonation with a constraint violation whose message contains
+// gcp.RetryableAuthenticationErrorMessage. The Create retry only kicks in on that exact message, so
+// this test binds the asserted message and the message used by the retry together: if the API ever
+// changes the wording, this test fails and forces the constant to be updated in lockstep.
+//
+// KNOWN FLAKE (accepted for now): because the message is classified as retryable, the
+// permanently-failing service account is retried until the create timeout elapses, and the retry
+// budget currently coincides with the resource context deadline. If a request is in-flight when the
+// deadline fires, the final error can be a context-cancellation error instead of the API message,
+// causing ExpectError to miss (~6% of runs). A follow-up PR decouples the retry budget from the
+// context deadline (reserving a buffer so the final attempt completes against a live context),
+// which makes this deterministic. Until then this opt-in test (it requires acceptance env vars plus
+// DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT) is skipped, pending the GCP connection resource being
+// fully wired up in a follow-up PR.
+func TestAccGcpConnectionAuthenticationFailure(t *testing.T) {
+	t.Skip("Enable this test as soon as the GCP connection resource is wired.")
+
+	if !api.AccEnvsGiven(t) {
+		return
+	}
+
+	if envutils.DTGCPTestUnimpersonableServiceAccount.Get() == "" {
+		t.Skipf("%s is not set; skipping GCP authentication failure test", envutils.DTGCPTestUnimpersonableServiceAccount.Key)
+	}
+
+	config, _ := api.ReadTfConfig(t, "testdata-auth-failure/gcp_connection.tf")
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta(gcp.RetryableAuthenticationErrorMessage)),
+			},
 		},
 	})
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/settings/service_account_impersonation.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/settings/service_account_impersonation.go
@@ -33,12 +33,14 @@ func (me *ServiceAccountImpersonation) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.openpipeline`",
 			Optional:    true, // minobjects == 0
+			ForceNew:    true, // Changing consumers after creation would lead to validation errors on the API side
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		"service_account_id": {
 			Type:        schema.TypeString,
 			Description: "Id of your Service Account",
-			Optional:    true, // nullable
+			Required:    true, // Even though the schema does not require it, we want the user to provide it already on creation
+			ForceNew:    true, // Changing the service account after it has been set once would lead to validation errors on the API side
 		},
 	}
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/settings/settings.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/settings/settings.go
@@ -19,15 +19,24 @@ package gcp
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const DefaultCreateTimeout = 2 * time.Minute
+
 type Settings struct {
 	Name                        string                       `json:"name"` // The name of the connection
 	ServiceAccountImpersonation *ServiceAccountImpersonation `json:"serviceAccountImpersonation,omitempty"`
 	Type                        Type                         `json:"type"` // GCP Authentication mechanism to be used by the connection. Possible values: `serviceAccountImpersonation`
+}
+
+func (me *Settings) Timeouts() *schema.ResourceTimeout {
+	return &schema.ResourceTimeout{
+		Create: schema.DefaultTimeout(DefaultCreateTimeout),
+	}
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/testdata-auth-failure/gcp_connection.tf
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/testdata-auth-failure/gcp_connection.tf
@@ -1,0 +1,22 @@
+variable "DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT" {
+    type        = string
+    description = "The service account that should be used for the auth failure test. This service account must not allow impersonation by the DT GCP principal."
+    sensitive = true
+}
+
+resource "dynatrace_gcp_connection" "auth_failure" {
+  name = "#name#"
+  type = "serviceAccountImpersonation"
+  service_account_impersonation {
+    service_account_id = var.DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT
+    consumers = [
+      "SVC:com.dynatrace.da"
+    ]
+  }
+
+  # Bound the create retry: the service account can never authenticate, so without a short timeout
+  # the permanently-failing impersonation would be retried for the full DefaultCreateTimeout.
+  timeouts {
+    create = "10s"
+  }
+}

--- a/dynatrace/settings/errors.go
+++ b/dynatrace/settings/errors.go
@@ -1,0 +1,28 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package settings
+
+import "fmt"
+
+// ErrValidatorNotImplemented reports that the service for the given schema was expected to implement
+// Validator but does not. This is an internal invariant violation (a provider bug) rather than a
+// user configuration error, so it directs the reader to reach out to support. The schema ID is
+// included to pinpoint which service is affected without resorting to a stack trace.
+func ErrValidatorNotImplemented(schemaID string) error {
+	return fmt.Errorf("internal provider bug: the service for schema %q was expected to support validation but does not. Please reach out to support", schemaID)
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -521,6 +521,16 @@ var TFAcc = StringEnvVar{
 	DefaultValue: "",
 }
 
+// DTGCPTestUnimpersonableServiceAccount represents a GCP service account that no Dynatrace GCP
+// Principal can impersonate. Used in tests to check API behavior when triggering authorization
+// errors. The key is intentionally the TF_VAR_-prefixed name: the same value populates the
+// Terraform variable of the same name in the test config, so one env var drives both the
+// skip-guard and the .tf input.
+var DTGCPTestUnimpersonableServiceAccount = StringEnvVar{
+	Key:          "TF_VAR_DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT",
+	DefaultValue: "",
+}
+
 // --- Migration ---
 
 // Migration enables migration mode.


### PR DESCRIPTION
#### Why this PR?
- GCP service account impersonation depends on a user-provided service account ID whose IAM policy changes on the GCP side may not have propagated by the time the Dynatrace connection is created, causing the create to fail transiently. GCP
  connections previously had no retry on create (unlike Azure/AWS).
- Wrapping the GCP service in a struct (needed for the retry) would otherwise hide the underlying Validate capability that the GCP Principal data source relies on to trigger principal provisioning, so the wrapper must forward it.

#### What has changed?

  - dynatrace_gcp_connection create now retries while the API reports authentication failure.
  - New exported constant `RetryableAuthenticationErrorMessage` ("GCP authentication failed") in the gcp package.
  - Settings now expose a create `Timeouts()` with `DefaultCreateTimeout = 2 * time.Minute`.
  - `service_account_impersonation.service_account_id` is now `Required` + `ForceNew`; `consumers` is now `ForceNew`.
  - New `settings.ErrValidatorNotImplemented(schemaID)` helper, used by both the GCP service wrapper and the GCP Principal data source to replace an ad-hoc duplicated message.
  - New `envutils.DTGCPTestUnimpersonableServiceAccount` env var, a (skipped) acceptance test, its testdata-auth-failure/ config, and CI secret `DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT` wiring in tests.yml.

#### How does it do it?

  - The plain delegating Service() is replaced by a wrapper whose Create runs through retry.RetryContext, retrying only on a 400 constraint violation carrying RetryableAuthenticationErrorMessage (via settings.ClassifyConstraintRetryError),
  bounded by the create timeout.
  - Update stays plain delegation: every impersonation field is ForceNew, so updates only ever rename the connection, which does not depend on IAM propagation.
  - The wrapper forwards Validate to the underlying service, falling back to ErrValidatorNotImplemented (an internal-provider-bug error that names the schema ID and points to support) if it ever does not implement validation.
  - The retry-trigger message and the test assertion share one constant, so an API wording change is caught.

#### How is it tested?

  - Acceptance test `TestAccGcpConnectionAuthenticationFailure` drives a connection with an unimpersonable, TF_VAR-injected service account ID and asserts via `ExpectError` that the API returns the message the retry keys on.
  - The test is currently `t.Skip`'d (and its CI secret pre-wired) pending the GCP connection resource being fully wired up in a follow-up PR; it carries a documented known-flake note about the retry budget coinciding with the context
  deadline.

####  How does it affect users?
  
 Currently, it doesn't, as `dynatrace_gcp_connection` is not yet wired up in the provider. Once it is, users will see the following changes:
 
  - `dynatrace_gcp_connection` create is now resilient to GCP IAM propagation delays, retrying for up to 2 minutes instead of failing immediately.
  - `service_account_id` is now required at creation and changing it (or consumers) forces resource replacement rather than an in-place update.

**Issue:** CA-19635
