### PR TITLE
chore: Update to go v1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace-oss/terraform-provider-dynatrace
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
#### **Why** this PR?
Update to building with go v1.26.4.

#### **What** has changed and **how** does it do it?
The go version in `go.mod` is now `1.26.4`

#### How is it **tested**?
The CI pipeline itself tests it

#### How does it affect **users**?
NA

**Issue:** NA
