### PR TITLE
fix: reserve 5 s buffer before context deadline in retry budget

### DIFF
--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service_test.go
@@ -47,16 +47,6 @@ func TestGcpConnection(t *testing.T) {
 // gcp.RetryableAuthenticationErrorMessage. The Create retry only kicks in on that exact message, so
 // this test binds the asserted message and the message used by the retry together: if the API ever
 // changes the wording, this test fails and forces the constant to be updated in lockstep.
-//
-// KNOWN FLAKE (accepted for now): because the message is classified as retryable, the
-// permanently-failing service account is retried until the create timeout elapses, and the retry
-// budget currently coincides with the resource context deadline. If a request is in-flight when the
-// deadline fires, the final error can be a context-cancellation error instead of the API message,
-// causing ExpectError to miss (~6% of runs). A follow-up PR decouples the retry budget from the
-// context deadline (reserving a buffer so the final attempt completes against a live context),
-// which makes this deterministic. Until then this opt-in test (it requires acceptance env vars plus
-// DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT) is skipped, pending the GCP connection resource being
-// fully wired up in a follow-up PR.
 func TestAccGcpConnectionAuthenticationFailure(t *testing.T) {
 	t.Skip("Enable this test as soon as the GCP connection resource is wired.")
 

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/retry/retry.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/retry/retry.go
@@ -26,17 +26,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
-// RetryDeadlineBuffer is reserved before the context deadline so the final retry attempt can
-// complete against a still-live context. Without it, the retry budget would coincide with the
-// context deadline: a request in-flight at expiry would be cancelled and surface a generic
-// "context deadline exceeded" error instead of the real, actionable API error (and, for retries
-// driven by eventual consistency, would mask the underlying constraint violation).
+// RetryDeadlineBuffer is reserved before the context deadline so the final retry attempt
+// completes against a live context and returns the real API error, not "context deadline exceeded".
 const RetryDeadlineBuffer = 5 * time.Second
 
-// DurationUntilDeadlineOrDefault computes the retry budget: the duration until the context deadline
-// minus RetryDeadlineBuffer, or the provided defaultTimeout if no deadline is set. Reserving the
-// buffer ensures the retry loop gives up slightly before the context is cancelled, so the last
-// attempt finishes and returns the real error rather than a context-cancellation error.
+// DurationUntilDeadlineOrDefault returns the time until deadline minus RetryDeadlineBuffer,
+// or defaultTimeout if no deadline is set.
 func DurationUntilDeadlineOrDefault(ctx context.Context, defaultTimeout time.Duration) time.Duration {
 	dl, hasDeadline := ctx.Deadline()
 	if !hasDeadline {

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/retry/retry.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/retry/retry.go
@@ -26,18 +26,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
-// DurationUntilDeadlineOrDefault computes the duration until the context deadline,
-// or returns the provided defaultTimeout if no deadline is set.
+// RetryDeadlineBuffer is reserved before the context deadline so the final retry attempt can
+// complete against a still-live context. Without it, the retry budget would coincide with the
+// context deadline: a request in-flight at expiry would be cancelled and surface a generic
+// "context deadline exceeded" error instead of the real, actionable API error (and, for retries
+// driven by eventual consistency, would mask the underlying constraint violation).
+const RetryDeadlineBuffer = 5 * time.Second
+
+// DurationUntilDeadlineOrDefault computes the retry budget: the duration until the context deadline
+// minus RetryDeadlineBuffer, or the provided defaultTimeout if no deadline is set. Reserving the
+// buffer ensures the retry loop gives up slightly before the context is cancelled, so the last
+// attempt finishes and returns the real error rather than a context-cancellation error.
 func DurationUntilDeadlineOrDefault(ctx context.Context, defaultTimeout time.Duration) time.Duration {
 	dl, hasDeadline := ctx.Deadline()
 	if !hasDeadline {
-		// no deadline: use default
+		// no deadline: use default. There is no external context cancellation to race against, so
+		// no buffer is needed here.
 		return defaultTimeout
 	}
 
-	remaining := time.Until(dl)
+	remaining := time.Until(dl) - RetryDeadlineBuffer
 	if remaining <= 0 {
-		// already expired, no time left
+		// already expired, or too little time left to retry and still reserve the buffer
 		return 0
 	}
 

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/retry/retry_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/retry/retry_test.go
@@ -33,31 +33,38 @@ import (
 // TestDurationUntilDeadlineOrDefault_NoDeadline tests that DurationUntilDeadlineOrDefault returns the default timeout when the context has no deadline.
 func TestDurationUntilDeadlineOrDefault_NoDeadline(t *testing.T) {
 	defaultTimeout := 2 * time.Minute
-	ctx := context.Background()
 
-	retryTimeout := retry.DurationUntilDeadlineOrDefault(ctx, defaultTimeout)
+	retryTimeout := retry.DurationUntilDeadlineOrDefault(t.Context(), defaultTimeout)
 	assert.Equal(t, defaultTimeout, retryTimeout)
 }
 
-// TestDurationUntilDeadlineOrDefault_WithDeadline_Plenty tests that DurationUntilDeadlineOrDefault returns the remaining duration when the context has a deadline set well in the future.
+// TestDurationUntilDeadlineOrDefault_WithDeadline_Plenty tests that DurationUntilDeadlineOrDefault returns the remaining duration minus the reserved buffer when the context has a deadline set well in the future.
 func TestDurationUntilDeadlineOrDefault_WithDeadline_Plenty(t *testing.T) {
-	// caller provides 5 minutes; retryTimeout should be ~5 minutes
-	parent := context.Background()
+	// caller provides 5 minutes; retryTimeout should be ~5 minutes minus the reserved buffer
+	parent := t.Context()
 	deadline := time.Now().Add(5 * time.Minute)
 	ctxWithDL, cancelParent := context.WithDeadline(parent, deadline)
 	defer cancelParent()
 
 	retryTimeout := retry.DurationUntilDeadlineOrDefault(ctxWithDL, 2*time.Minute)
 
-	// expect ~5 minutes
-	expected := 5 * time.Minute
+	// expect ~5 minutes minus the reserved deadline buffer
+	expected := 5*time.Minute - retry.RetryDeadlineBuffer
 	assert.InDelta(t, expected.Milliseconds(), retryTimeout.Milliseconds(), 200, "expected approximately %v, got %v", expected, retryTimeout)
-
 }
 
-// TestDurationUntilDeadlineOrDefault_ExpiredDeadline tests that wDurationUntilDeadlineOrDefault returns zero when the context has an expired deadline.
+// TestDurationUntilDeadlineOrDefault_DeadlineWithinBuffer tests that DurationUntilDeadlineOrDefault returns zero when the time remaining until the deadline is smaller than the reserved buffer, so the retry loop does not start an attempt it cannot let finish before the context is cancelled.
+func TestDurationUntilDeadlineOrDefault_DeadlineWithinBuffer(t *testing.T) {
+	ctxWithDL, cancel := context.WithDeadline(t.Context(), time.Now().Add(retry.RetryDeadlineBuffer/2))
+	defer cancel()
+
+	retryTimeout := retry.DurationUntilDeadlineOrDefault(ctxWithDL, 2*time.Minute)
+	assert.Zero(t, retryTimeout, "expected zero retry timeout when the deadline is within the reserved buffer")
+}
+
+// TestDurationUntilDeadlineOrDefault_ExpiredDeadline tests that DurationUntilDeadlineOrDefault returns zero when the context has an expired deadline.
 func TestDurationUntilDeadlineOrDefault_ExpiredDeadline(t *testing.T) {
-	ctxWithExpiredDL, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	ctxWithExpiredDL, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
 	defer cancel()
 
 	retryTimeout := retry.DurationUntilDeadlineOrDefault(ctxWithExpiredDL, 2*time.Minute)


### PR DESCRIPTION
#### Why this PR?

Users who misconfigure a hyperscaler connection (wrong IAM policies, unimpersonable service account, etc.) sit in the retry loop until the create timeout and rely entirely on the final error message to understand what went wrong. Because the retry budget previously coincided with the context deadline, a request in-flight at expiry could be cancelled mid-flight, surfacing a generic "context deadline exceeded" instead of the real constraint-violation message — leaving users with no actionable information. This affects all three hyperscaler connection types (GCP, Azure, AWS) since they all share the same retry package. The race was also observable as a flake in `TestAccGcpConnectionAuthenticationFailure`, where `ExpectError` occasionally missed the expected message.

#### What has changed?

- retry.go: new exported constant `RetryDeadlineBuffer = 5 * time.Second` and `DurationUntilDeadlineOrDefault` now subtracts it from the remaining context time when computing the retry budget.
- retry_test.go: `context.Background()` replaced with `t.Context()`; expected value in `_WithDeadline_Plenty` updated to account for the buffer; new test `_DeadlineWithinBuffer` added; pre-existing typo in a doc comment fixed.
- gcp/service_test.go: the "KNOWN FLAKE" comment block removed from `TestAccGcpConnectionAuthenticationFailure` — the root cause it described is now resolved.

#### How does it do it?

`DurationUntilDeadlineOrDefault` returns `time.Until(deadline) - RetryDeadlineBuffer` instead of the raw remaining time. The retry loop therefore exhausts its budget 5 seconds before the context deadline, guaranteeing the last attempt runs against a still-live context and its error propagates cleanly.

#### How is it tested?

- Unit tests in retry_test.go cover: no deadline (returns default), deadline with plenty of time (returns remaining - RetryDeadlineBuffer), deadline within the buffer (returns zero), and an already-expired deadline (returns zero).
- The integration test `TestAccGcpConnectionAuthenticationFailure` (which validated the flaky behaviour end-to-end) remains skipped pending GCP environment setup, but its flake-description comment has been removed as the fix is in place.

#### How does it affect users?

Users with an invalid configuration (e.g. wrong IAM policies or an unimpersonable service account) will now consistently see the real API error message when the create timeout is reached, instead of occasionally receiving a generic "context deadline exceeded" error that provides no actionable information. 

The effective create timeout is reduced by 5 seconds, which is the deliberate cost of this fix.

**Issue:** CA-19463