### PR TITLE
chore: change outdated error message

### DIFF
--- a/dynatrace/api/builtin/monitoring/slo/service.go
+++ b/dynatrace/api/builtin/monitoring/slo/service.go
@@ -81,7 +81,7 @@ func (me *service) Create(ctx context.Context, v *slo.Settings) (*api.Stub, erro
 		if err := service.Delete(ctx, *stub.LegacyID); err != nil {
 			return nil, err
 		}
-		return nil, errors.New("SLO creation failed, unable to retrieve ID. Please create a GitHub issue.")
+		return nil, errors.New("SLO creation failed, unable to retrieve ID.")
 	}
 
 	return stub, nil


### PR DESCRIPTION
#### Why this PR? 

The error message shown when SLO creation fails to retrieve an ID directed users to file a GitHub issue.
As the GitHub issues have been deactivated, this part of the error message is removed.

#### What has changed? 

- slo/service.go: removed "Please create a GitHub issue." from error message.

#### How does it do it? 

Single string replacement in the error returned when the legacy SLO ID cannot be retrieved after creation. 

#### How is it tested? 

No test change required — the message is a user-facing string with no associated assertion. 

#### How does it affect users? 

Users who hit the SLO ID-retrieval failure path will not see the call to action directing to the GitHub issue tracker any more.

**Issue:** none
