### PR TITLE
docs(workflow): clarify task positioning behavior

### DIFF
--- a/dynatrace/api/automation/workflows/settings/task.go
+++ b/dynatrace/api/automation/workflows/settings/task.go
@@ -59,7 +59,7 @@ func (me *Tasks) Schema(prefix string) map[string]*schema.Schema {
 		return map[string]*schema.Schema{
 			"task": {
 				Type:        schema.TypeList,
-				Description: "TODO: No documentation available",
+				Description: "A task within the workflow. Note: the order in which tasks are declared in HCL does not determine their layout - positions are not assigned incrementally based on declaration order. Set `position` explicitly on each task if you need a deterministic layout",
 				MinItems:    1,
 				Optional:    true,
 				Elem:        &schema.Resource{Schema: new(Task).Schema(prefix + ".0.task")},
@@ -69,7 +69,7 @@ func (me *Tasks) Schema(prefix string) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"task": {
 			Type:        schema.TypeSet,
-			Description: "TODO: No documentation available",
+			Description: "A task within the workflow. Note: the order in which tasks are declared in HCL does not determine their layout - positions are not assigned incrementally based on declaration order. Set `position` explicitly on each task if you need a deterministic layout",
 			MinItems:    1,
 			Optional:    true,
 			Elem:        &schema.Resource{Schema: new(Task).Schema(prefix + ".0.task")},

--- a/dynatrace/api/automation/workflows/settings/workflow.go
+++ b/dynatrace/api/automation/workflows/settings/workflow.go
@@ -108,7 +108,7 @@ func (me *Workflow) Schema() map[string]*schema.Schema {
 		},
 		"tasks": {
 			Type:        schema.TypeList,
-			Description: "The tasks to run for every execution of this workflow",
+			Description: "The tasks to run for every execution of this workflow. Note: the order in which tasks are declared in HCL does not determine their layout - positions are not assigned incrementally based on declaration order. Set `position` explicitly on each task if you need a deterministic layout",
 			MinItems:    1,
 			MaxItems:    1,
 			Required:    true,


### PR DESCRIPTION
#### **Why** this PR?
Even though workflow tasks have the type "SET", it isn't always clear to everyone that the position is not set based on the task order.
We have the tasks as a Set in our HCL representation, whereas the API accepts a dictionary (task name as the key)

#### **What** has changed?
Updated the documentation to clarify that the position is not incrementally set.

#### **How** does it do it?
By updating the description for tasks and task

#### How is it **tested**?
N/A

#### How does it affect **users**?
They should be less confused about the task position order.

**Issue:** DOCS-19830