### PR TITLE
chore: extend Snyk ignore expiry for msg-pack

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -27,5 +27,5 @@ ignore:
   SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACK-15702236: &msg-pack-ignore
     - '*':
         reason: 'Transitive dependency via terraform-plugin-sdk/v2; no fixed version available upstream.'
-        expires: 2026-06-06T00:00:00.000Z
+        expires: 2026-07-06T00:00:00.000Z
   SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACKV5-15702238: *msg-pack-ignore


### PR DESCRIPTION
#### **Why** this PR?
The vulnerability is still not fixed.

#### **What** has changed?
Extended ignore for another month

#### **How** does it do it?
By setting the ignore time to 2026-07-06

#### How is it **tested**?
N/A

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
