### PR TITLE
fix: Resource `dynatrace_davis_anomaly_detectors` allows `actor` to be omitted

### DIFF
--- a/dynatrace/api/builtin/davis/anomalydetectors/settings/execution_settings.go
+++ b/dynatrace/api/builtin/davis/anomalydetectors/settings/execution_settings.go
@@ -31,10 +31,10 @@ type ExecutionSettings struct {
 func (me *ExecutionSettings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"actor": {
-			Type:        schema.TypeString,
-			Description: "UUID of a service user. Queries will be executed on behalf of the service user.",
-			Optional:    true, // diverts from schema. It's actually set automatically if not provided
-			Computed:    true,
+			Type:             schema.TypeString,
+			Description:      "UUID of a service user. Queries will be executed on behalf of the service user.",
+			Optional:         true,                                                                       // diverts from schema. It's actually set automatically if not provided
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool { return new == "" }, // suppress diff if not provided, because it will be set automatically
 		},
 		"delay": {
 			Type:        schema.TypeInt,

--- a/dynatrace/api/builtin/davis/anomalydetectors/testdata/terraform/example_no_actor.tf
+++ b/dynatrace/api/builtin/davis/anomalydetectors/testdata/terraform/example_no_actor.tf
@@ -1,0 +1,75 @@
+resource "dynatrace_davis_anomaly_detectors" "anomaly" {
+  description = ""
+  enabled     = true
+  source      = "Davis Anomaly Detection"
+  title       = "Detector with OAuth requirement #name#"
+  analyzer {
+    name = "dt.statistics.ui.anomaly_detection.SeasonalBaselineAnomalyDetectionAnalyzer"
+    input {
+      analyzer_input_field {
+        key   = "query.expression"
+        value = <<-EOT
+          fetch dt.system.query_executions
+                                 | filter status == "SUCCEEDED"
+                                 | fields timestamp, scanned_bytes, user.email
+                                 | fieldsAdd gb = toDouble(scanned_bytes) / (1024*1024*1024)
+                                 | fieldsAdd cost = gb * 0.00106
+                                 | summarize  cost_per_user = sum(cost), by:{user.email}
+                                 | filter cost_per_user >= 0.01
+                                 | makeTimeseries datapoints = sum(cost_per_user)
+                                   , by: {user.email}
+                                   , time: now() - 4m
+                                   , interval: 4m
+        EOT
+      }
+      analyzer_input_field {
+        key   = "tolerance"
+        value = "1"
+      }
+      analyzer_input_field {
+        key   = "dealertingSamples"
+        value = "5"
+      }
+      analyzer_input_field {
+        key   = "slidingWindow"
+        value = "5"
+      }
+      analyzer_input_field {
+        key   = "alertOnMissingData"
+        value = "false"
+      }
+      analyzer_input_field {
+        key   = "alertCondition"
+        value = "BELOW"
+      }
+      analyzer_input_field {
+        key   = "violatingSamples"
+        value = "3"
+      }
+    }
+  }
+  event_template {
+    properties {
+      property {
+        key   = "dt.source_entity"
+        value = "{dims:dt.source_entity}"
+      }
+      property {
+        key   = "event.type"
+        value = "CUSTOM_ALERT"
+      }
+      property {
+        key   = "event.description"
+        value = "Alert detected"
+      }
+      property {
+        key   = "event.name"
+        value = "Potential log data anomaly"
+      }
+    }
+  }
+  execution_settings {
+    query_offset = 3
+    delay        = 60
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
In cases where `execution_settings.actor` was omitted from `dynatrace_davis_anomaly_detectors`, updates would be made using the current value rather than omitting it in the payload. This was incorrect if the current value was different from the user ID associated with the credentials, leading to an error being returned from the API.

#### **What** has changed and **how** does it do it?
`Computed: true` on `actor` is replaced with a `DiffSuppressFunc` that suppresses diffs when the new config value is empty. This keeps `actor` optional in Terraform while allowing the API to always assign the effective user ID when the field is not provided.

#### How is it **tested**?
- Added `dynatrace/api/builtin/davis/anomalydetectors/testdata/terraform/example_no_actor.tf` to verify the omitted-actor case.

#### How does it affect **users**?
Users can now omit `execution_settings.actor` in `dynatrace_davis_anomaly_detectors` and let Dynatrace assign it automatically. This will work even if the actor has been assigned another value.

**Issue:** CA-19702