### PR TITLE
feat: platform slo data source

### DIFF
--- a/datasources/slo/platform/data_source.go
+++ b/datasources/slo/platform/data_source.go
@@ -1,0 +1,95 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package platformslo
+
+import (
+	"context"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	sloservice "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/slo"
+	slosettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/slo/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSource() *schema.Resource {
+	scm := hcl.SetComputedSchema(new(slosettings.SLO).Schema())
+	scm["name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Name of the SLO",
+		Required:    true,
+	}
+
+	return &schema.Resource{
+		ReadContext: logging.EnableDSCtx(DataSourceRead),
+		Schema:      scm,
+	}
+}
+
+func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	name := d.Get("name").(string)
+
+	creds, err := config.Credentials(m, config.CredValDefault)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	service := sloservice.Service(creds)
+	var stubs api.Stubs
+	if stubs, err = service.List(ctx); err != nil {
+		return diag.FromErr(err)
+	}
+
+	stub := findStubByName(stubs, name)
+	if stub == nil {
+		d.SetId("")
+		return diag.Diagnostics{}
+	}
+
+	var v slosettings.SLO
+	if err = service.Get(ctx, stub.ID, &v); err != nil {
+		return diag.FromErr(err)
+	}
+
+	marshalled := hcl.Properties{}
+	if err = v.MarshalHCL(marshalled); err != nil {
+		return diag.FromErr(err)
+	}
+
+	for k, val := range marshalled {
+		err = d.Set(k, val)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId(stub.ID)
+	return diag.Diagnostics{}
+}
+
+func findStubByName(stubs api.Stubs, name string) *api.Stub {
+	for _, stub := range stubs {
+		if name == stub.Name {
+			return stub
+		}
+	}
+	return nil
+}

--- a/datasources/slo/platform/data_source_test.go
+++ b/datasources/slo/platform/data_source_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package platformslo_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccDataSource(t *testing.T) {
+	api.TestAcc(t)
+}

--- a/datasources/slo/platform/testdata/terraform/example.tf
+++ b/datasources/slo/platform/testdata/terraform/example.tf
@@ -1,0 +1,36 @@
+resource "dynatrace_platform_slo" "slo" {
+  name        = "#name#"
+  description = "Sample custom SLO"
+  tags        = [ "ExampleKey:ExampleValue" ]
+  criteria {
+    criteria_detail {
+      target         = 96
+      timeframe_from = "now-30d"
+      timeframe_to   = "now"
+      warning        = 99
+    }
+  }
+  custom_sli {
+    indicator =<<-EOT
+      timeseries { total=sum(dt.service.request.count) ,failures=sum(dt.service.request.failure_count) }, by: { dt.entity.service }
+      | fieldsAdd tags=entityAttr(dt.entity.service, "tags")
+      | filter in(tags, "criticality:Gold")
+      | fieldsAdd entityName = entityName(dt.entity.service)
+      | fieldsAdd sli=(((total[]-failures[])/total[])*(100))
+      | fieldsRemove total, failures, tags
+    EOT
+  }
+}
+
+data "dynatrace_platform_slo" "slo" {
+  name = dynatrace_platform_slo.slo.name
+}
+
+
+output "id" {
+  value = data.dynatrace_platform_slo.slo.id
+}
+
+output "sli" {
+  value = data.dynatrace_platform_slo.slo.custom_sli[0].indicator
+}

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -20,8 +20,10 @@
 package api
 
 import (
+	"errors"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 )
 
@@ -102,7 +105,8 @@ func readTestData(t *testing.T) []string {
 	return allFiles
 }
 
-// TestAcc executes all test files in the `testdata` folder ("testdata/*/*.tf").
+// TestAcc executes all test files in the `testdata` folder ("testdata/*/*.tf")
+// and validates all defined "output" to not be empty.
 // Fail conditions could be
 // - API errors during create and cleanup (GET, POST, DELETE)
 // - Inconsistencies (GET after apply)
@@ -205,14 +209,8 @@ func TestAccTestCases(t *testing.T, opts ...TestCaseAccOptions) {
 		t.Run(testCase.Name, func(t *testing.T) {
 			t.Helper()
 
-			providerFactories := map[string]func() (*schema.Provider, error){
-				"dynatrace": func() (*schema.Provider, error) {
-					return provider.Provider(), nil
-				},
-			}
-
 			resource.Test(t, resource.TestCase{
-				ProviderFactories: providerFactories,
+				ProviderFactories: GetProviderFactories(),
 				ExternalProviders: options.ExternalProviders,
 				Steps:             testCase.TestCases,
 			})
@@ -237,11 +235,7 @@ func TestAccTestCase(t *testing.T, folder string, opts ...TestCaseAccOptions) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"dynatrace": func() (*schema.Provider, error) {
-				return provider.Provider(), nil
-			},
-		},
+		ProviderFactories: GetProviderFactories(),
 		ExternalProviders: options.ExternalProviders,
 		Steps:             getTestCase(t, folder, "").TestCases,
 	})
@@ -272,19 +266,33 @@ func TestAccParallel(t *testing.T, opts ...TestAccOptions) {
 
 func createTestCaseWithOptions(t *testing.T, config string, opts []TestAccOptions) resource.TestCase {
 	t.Helper()
-	providerFactories := map[string]func() (*schema.Provider, error){
-		"dynatrace": func() (*schema.Provider, error) {
-			return provider.Provider(), nil
-		},
-	}
 	var options TestAccOptions
 	if len(opts) > 0 {
 		options = opts[0]
 	}
 
 	return resource.TestCase{
-		ProviderFactories: providerFactories,
+		ProviderFactories: GetProviderFactories(),
 		ExternalProviders: options.ExternalProviders,
-		Steps:             []resource.TestStep{{Config: config, ExpectNonEmptyPlan: options.ExpectNonEmptyPlan}},
+		Steps: []resource.TestStep{{
+			Config: config, ExpectNonEmptyPlan: options.ExpectNonEmptyPlan,
+			Check: func(s *terraform.State) error {
+				var errs []error
+				for key := range s.RootModule().Outputs {
+					err := resource.TestMatchOutput(key, regexp.MustCompile(`.+`))(s)
+					errs = append(errs, err)
+				}
+				return errors.Join(errs...)
+			},
+		}},
+	}
+}
+
+// GetProviderFactories returns our provider factory for use in resource.TestCase.
+func GetProviderFactories() map[string]func() (*schema.Provider, error) {
+	return map[string]func() (*schema.Provider, error){
+		"dynatrace": func() (*schema.Provider, error) {
+			return provider.Provider(), nil
+		},
 	}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -63,6 +63,7 @@ import (
 	serviceds "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/service"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/slo"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/slo/objectivetemplates"
+	platformslo "github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/slo/platform"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/synthetic/locations"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/synthetic/nodes"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/datasources/tenant"
@@ -254,6 +255,7 @@ func Provider() *schema.Provider {
 			"dynatrace_request_naming":                  requestnaming.DataSource(),
 			"dynatrace_dashboard":                       dashboard.DataSource(),
 			"dynatrace_slo":                             slo.DataSource(),
+			"dynatrace_platform_slo":                    platformslo.DataSource(),
 			"dynatrace_azure_supported_services":        azure_supported_services.DataSource(),
 			"dynatrace_aws_supported_services":          aws_supported_services.DataSource(),
 			"dynatrace_failure_detection_parameters":    failure_detection_parameters.DataSource(),

--- a/templates/data-sources/platform_slo.md.tmpl
+++ b/templates/data-sources/platform_slo.md.tmpl
@@ -1,0 +1,38 @@
+---
+layout: ""
+page_title: "dynatrace_platform_slo Data Source - terraform-provider-dynatrace"
+subcategory: "Service-level Objective"
+description: |-
+  The data source `dynatrace_platform_slo` covers queries for platform service-level objectives.
+---
+
+# dynatrace_platform_slo (Data Source)
+
+-> **Dynatrace SaaS only**
+
+-> This data source requires the OAuth permission **View SLOs** (`slo:slos:read`)
+
+The `dynatrace_platform_slo` data source allows to get an SLO and all its data by its name.
+
+## Dynatrace Documentation
+
+- Service-Level Objectives overview - https://docs.dynatrace.com/docs/deliver/service-level-objectives
+
+## Example Usage
+
+```terraform
+data "dynatrace_platform_slo" "example" {
+  name = "Terraform"
+}
+
+output "id" {
+  value = data.dynatrace_platform_slo.example.id
+}
+
+output "sli" {
+  value = data.dynatrace_platform_slo.example.custom_sli[0].indicator
+}
+
+```
+
+{{ .SchemaMarkdown | trimspace }}

--- a/terraform/hcl/computed.go
+++ b/terraform/hcl/computed.go
@@ -1,0 +1,46 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hcl
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+// setComputedItem modifies a provided HCL schema item by setting it to computed and adjusting incompatible properties (MinItems, MaxItems, Optional and Required)
+// to ensure the schema remains valid when items are set to computed.
+func setComputedItem(item *schema.Schema) *schema.Schema {
+	item.MinItems = 0
+	item.MaxItems = 0
+	item.Optional = false
+	item.Required = false
+	item.Computed = true
+	return item
+}
+
+// SetComputedSchema modifies and returns a provided HCL schema by setting all of its items to computed.
+// It also recursively modifies nested schemas and takes care of incompatible properties (MinItems, MaxItems, Optional and Required)
+// to ensure the schema remains valid when items are set to computed.
+// use case: data sources that require Computed to be set
+func SetComputedSchema(item map[string]*schema.Schema) map[string]*schema.Schema {
+	for k, v := range item {
+		item[k] = setComputedItem(v)
+		if item[k].Elem != nil {
+			if nested, ok := item[k].Elem.(*schema.Resource); ok {
+				nested.Schema = SetComputedSchema(nested.Schema)
+			}
+		}
+	}
+	return item
+}

--- a/terraform/hcl/computed_test.go
+++ b/terraform/hcl/computed_test.go
@@ -1,0 +1,164 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hcl_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+// assertComputed asserts that the given schema item is in the expected "computed" state.
+func assertComputed(t *testing.T, name string, item *schema.Schema) {
+	t.Helper()
+	assert.True(t, item.Computed, "%s: expected Computed to be true", name)
+	assert.False(t, item.Optional, "%s: expected Optional to be false", name)
+	assert.False(t, item.Required, "%s: expected Required to be false", name)
+	assert.Zero(t, item.MinItems, "%s: expected MinItems to be 0", name)
+	assert.Zero(t, item.MaxItems, "%s: expected MaxItems to be 0", name)
+}
+
+func TestSetComputedSchema_SetsTopLevelItemsComputed(t *testing.T) {
+	in := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"count": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			MinItems: 1,
+			MaxItems: 5,
+		},
+	}
+
+	out := hcl.SetComputedSchema(in)
+
+	for name, item := range out {
+		assertComputed(t, name, item)
+	}
+}
+
+func TestSetComputedSchema_ReturnsSameMap(t *testing.T) {
+	in := map[string]*schema.Schema{
+		"name": {Type: schema.TypeString, Required: true},
+	}
+
+	out := hcl.SetComputedSchema(in)
+
+	// SetComputedSchema mutates and returns the provided map.
+	assert.Len(t, out, len(in))
+	assert.Same(t, in["name"], out["name"], "expected the schema items to be mutated in place")
+}
+
+func TestSetComputedSchema_RecursesIntoNestedResource(t *testing.T) {
+	in := map[string]*schema.Schema{
+		"block": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"inner": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+
+	out := hcl.SetComputedSchema(in)
+
+	block := out["block"]
+	assertComputed(t, "block", block)
+
+	nested, ok := block.Elem.(*schema.Resource)
+	assert.True(t, ok, "expected nested Elem to remain a *schema.Resource")
+	assertComputed(t, "block.inner", nested.Schema["inner"])
+}
+
+func TestSetComputedSchema_RecursesIntoDeeplyNestedResource(t *testing.T) {
+	in := map[string]*schema.Schema{
+		"outer": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"middle": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"leaf": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out := hcl.SetComputedSchema(in)
+
+	outer := out["outer"].Elem.(*schema.Resource)
+	middle := outer.Schema["middle"]
+	assertComputed(t, "outer.middle", middle)
+
+	leaf := middle.Elem.(*schema.Resource).Schema["leaf"]
+	assertComputed(t, "outer.middle.leaf", leaf)
+}
+
+func TestSetComputedSchema_LeavesNonResourceElemUntouched(t *testing.T) {
+	elem := &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+		MaxItems: 3,
+	}
+	in := map[string]*schema.Schema{
+		"tags": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem:     elem,
+		},
+	}
+
+	out := hcl.SetComputedSchema(in)
+
+	// The top-level item is made computed...
+	assertComputed(t, "tags", out["tags"])
+
+	// ...but a plain *schema.Schema Elem is not recursed into.
+	assert.Same(t, elem, out["tags"].Elem, "expected the Elem pointer to be preserved")
+	assert.False(t, elem.Computed, "expected non-resource Elem to remain unchanged")
+	assert.True(t, elem.Required, "expected non-resource Elem Required to remain true")
+}
+
+func TestSetComputedSchema_EmptySchema(t *testing.T) {
+	in := map[string]*schema.Schema{}
+
+	out := hcl.SetComputedSchema(in)
+
+	assert.Empty(t, out, "expected an empty schema to remain empty")
+}


### PR DESCRIPTION
#### **Why** this PR?
Users had no way to reference an existing platform SLO that wasn't managed by Terraform, forcing them to hardcode IDs or duplicate some logic (e.g. DQLs).

#### **What** has changed?
Adds a new `dynatrace_platform_slo` data source (plus docs and an integration test).

#### **How** does it do it?
It reuses the `dynatrace_platform_slo` resource schema (set to computed) with `name` as the lookup key.
On read, it lists all SLOs, matches by name, fetches the full object, and marshals every property into state.

#### How is it **tested**?
Integration test (`TestAccDataSource`) backed by an example that creates an SLO and reads it back, asserting on its `id` and `custom_sli.indicator`.

#### How does it affect **users**?
Users can now look up an existing platform SLO by name and consume all of its properties.

**Issue:** CA-19712
