### PR TITLE
test: skip deprecated resource `dynatrace_resource_attributes`

### DIFF
--- a/dynatrace/api/builtin/resourceattribute/service_test.go
+++ b/dynatrace/api/builtin/resourceattribute/service_test.go
@@ -26,9 +26,11 @@ import (
 )
 
 func TestAccResourceAttributes(t *testing.T) {
+	t.Skip("Deprecated")
 	api.TestAcc(t)
 }
 
 func TestAccTestCasesResourceAttributes(t *testing.T) {
+	t.Skip("Deprecated")
 	api.TestAccTestCases(t)
 }


### PR DESCRIPTION
#### **Why** this PR?
The schema `builtin:resource-attribute` is no longer available. This breaks our tests.
A depreciation notice for the resource was already in place. Therefore, no other actions are needed.

#### **What** has changed?
Related tests are now skipped.

#### **How** does it do it?
`t.Skip` for affected tests

#### How is it **tested**?
Not anymore. It's removed/deprecated.

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
