### PR TITLE
feat(dynatrace_failure_detection_parameters): updated to v1.0.8

### DIFF
--- a/dynatrace/api/builtin/failuredetection/environment/parameters/schema.json
+++ b/dynatrace/api/builtin/failuredetection/environment/parameters/schema.json
@@ -2,6 +2,12 @@
 	"allowedScopes": [
 		"environment"
 	],
+	"deletionConstraints": [
+		{
+			"customValidatorId": "failure-detection-params-delete-validator",
+			"type": "CUSTOM_VALIDATOR_REF"
+		}
+	],
 	"description": "Failure detection parameters that determine whether a service call is considered successful or failed. Use [failure detection rules](/ui/settings/builtin:failure-detection.environment.rules) to configure which services these parameters apply to.\n\nThese settings are not applied to [Unified services](https://dt-url.net/gy03cmt).\n\nTo programmatically manage these settings, see [API Reference](https://docs.dynatrace.com/docs/shortlink/service-failure-detection#settings-api).",
 	"displayName": "Failure detection parameters",
 	"documentation": "",
@@ -82,13 +88,6 @@
 			"type": "text"
 		}
 	},
-	"schemaConstraints": [
-		{
-			"customValidatorId": "failure-detection-params-delete-validator",
-			"skipAsyncValidation": false,
-			"type": "CUSTOM_VALIDATOR_REF"
-		}
-	],
 	"schemaGroups": [
 		"group:service-monitoring",
 		"group:failure-detection"
@@ -577,5 +576,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.0.7"
+	"version": "1.0.8"
 }

--- a/dynatrace/api/builtin/failuredetection/environment/parameters/service.go
+++ b/dynatrace/api/builtin/failuredetection/environment/parameters/service.go
@@ -29,13 +29,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
-const SchemaVersion = "1.0.7"
+const SchemaVersion = "1.0.8"
 const SchemaID = "builtin:failure-detection.environment.parameters"
 const defaultTimeout = 10 * time.Second
 
-// During "create" and potentially "update" there is a "delete"-error happening that is not related to the object that should be created.
-// Seems like the delete-constraint is done at the wrong place, and that there is some eventual consistency.
+// There is a potential "delete"-error happening due to eventual consistency.
 // error: builtin:failure-detection.environment.parameters: Failure detection rule EnvironmentFailureDetectionRules {your-values-here} refers to this parameter ID: <uuid>.
+// The related object is deleted but not propagated to the server node.
 const retryErr = "refers to this parameter"
 
 type service struct {
@@ -46,28 +46,18 @@ func Service(credentials *rest.Credentials) settings.CRUDService[*parameters.Set
 	return &service{settings20.Service[*parameters.Settings](credentials, SchemaID, SchemaVersion)}
 }
 func (me *service) Create(ctx context.Context, v *parameters.Settings) (*api.Stub, error) {
-	var apiStub *api.Stub
-	err := retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
-		var err error
-		apiStub, err = me.service.Create(ctx, v)
-		return settings.ClassifyConstraintRetryError(err, retryErr)
-	})
-
-	if err != nil {
-		return nil, err
-	}
-	return apiStub, nil
+	return me.service.Create(ctx, v)
 }
 
 func (me *service) Update(ctx context.Context, id string, v *parameters.Settings) error {
-	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
-		err := me.service.Update(ctx, id, v)
-		return settings.ClassifyConstraintRetryError(err, retryErr)
-	})
+	return me.service.Update(ctx, id, v)
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return me.service.Delete(ctx, id)
+	return retry.RetryContext(ctx, defaultTimeout, func() *retry.RetryError {
+		err := me.service.Delete(ctx, id)
+		return settings.ClassifyConstraintRetryError(err, retryErr)
+	})
 }
 
 func (me *service) Get(ctx context.Context, id string, v *parameters.Settings) error {


### PR DESCRIPTION
#### **Why** this PR?
To stay up to date and to correctly retry based on the new constraint (regarding eventual consistency)

#### **What** has changed?
The delete constraint is now correctly a delete constraint instead of a schema constraint. The eventual consistency is still visible, but now correctly only for the delete

#### **How** does it do it?
By adding retry logic to the delete (before: create and update)

#### How is it **tested**?
This fixes our current flaky tests for this one.

#### How does it affect **users**?
Potential errors regarding delete constraints should not happen anymore.

**Issue:** NOISSUE
