### PR TITLE
refactor: GCP principal test output var renaming

### DIFF
--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcpdynatraceprincipal/service_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcpdynatraceprincipal/service_test.go
@@ -41,7 +41,7 @@ func TestAccResourceGcpPrincipal(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: resourceConfig,
-				Check:  resource.TestMatchOutput("records", regexp.MustCompile(`iam\.gserviceaccount\.com$`)),
+				Check:  resource.TestMatchOutput("principal_output", regexp.MustCompile(`iam\.gserviceaccount\.com$`)),
 			},
 		},
 	})

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcpdynatraceprincipal/testdata/resource.tf
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcpdynatraceprincipal/testdata/resource.tf
@@ -1,5 +1,5 @@
 resource "dynatrace_gcp_principal" "principal" {}
 
-output "records" {
+output "principal_output" {
   value = dynatrace_gcp_principal.principal.principal
 }


### PR DESCRIPTION
#### **Why** this PR?
This is a follow-up PR to #1132  to address minor issues.

#### **What** has changed?
The output variable in the GCP principal test has been renamed from `records` to `principal_output`

#### **How** does it do it?
N/A

#### How is it **tested**?
N/A

#### How does it affect **users**?
It doesn't

**Issue:** CA-19464
