### PR TITLE
refactor: IAM client uses standard request processing

### DIFF
--- a/datasources/iam/environments/service.go
+++ b/datasources/iam/environments/service.go
@@ -79,21 +79,20 @@ type Response struct {
 
 func (ec *environmentsService) Get(ctx context.Context) ([]Environment, error) {
 	u, err := url.JoinPath(baseURL, ec.AccountID(), "environments")
-
 	if err != nil {
 		return nil, err
 	}
 
 	client := iam.NewIAMClient(ctx, ec)
-	responseBytes, err := client.GET(ctx, u, rest2.RequestOptions{}, 200)
+	response, err := client.GET(ctx, u, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	var result Response
-	if err = json.Unmarshal(responseBytes, &result); err != nil {
+	var environmentResponse Response
+	if err = json.Unmarshal(response.Data, &environmentResponse); err != nil {
 		return nil, err
 	}
 
-	return result.Data, nil
+	return environmentResponse.Data, nil
 }

--- a/dynatrace/api/iam/base_policy_service_client.go
+++ b/dynatrace/api/iam/base_policy_service_client.go
@@ -58,44 +58,38 @@ func NewBasePolicyService(clientID string, accountID string, clientSecret string
 }
 
 func (me *BasePolicyServiceClient) CREATE(ctx context.Context, level PolicyLevel, levelID string, policy *Policy) (string, error) {
-	var err error
-	var responseBytes []byte
-
 	client := NewIAMClient(ctx, me)
-	if responseBytes, err = client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", level, levelID), policy, rest2.RequestOptions{}, 201); err != nil {
+	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", level, levelID), policy, rest2.RequestOptions{})
+	if err != nil {
 		return "", err
 	}
 
 	stub := PolicyStub{}
-	if err = json.Unmarshal(responseBytes, &stub); err != nil {
+	if err = json.Unmarshal(response.Data, &stub); err != nil {
 		return "", err
 	}
 	return stub.UUID, nil
 }
 
 func (me *BasePolicyServiceClient) GET(ctx context.Context, level PolicyLevel, levelID string, uuid string) (*Policy, error) {
-	var err error
-	var responseBytes []byte
-
 	client := NewIAMClient(ctx, me)
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", level, levelID, uuid), rest2.RequestOptions{}, 200); err != nil {
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", level, levelID, uuid), rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
 
-	var response Policy
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	var policyResponse Policy
+	if err = json.Unmarshal(response.Data, &policyResponse); err != nil {
 		return nil, err
 	}
-	return &response, nil
+	return &policyResponse, nil
 }
 
 func (me *BasePolicyServiceClient) UPDATE(ctx context.Context, level PolicyLevel, levelID string, policy *Policy, uuid string) error {
-	var err error
-
 	client := NewIAMClient(ctx, me)
 
-	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", level, levelID, uuid), policy, rest2.RequestOptions{}, 200); err != nil {
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", level, levelID, uuid), policy, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -112,25 +106,21 @@ type ListPoliciesResponse struct {
 }
 
 func (me *BasePolicyServiceClient) List(ctx context.Context, level PolicyLevel, levelID string) ([]PolicyStub, error) {
-	var err error
-	var responseBytes []byte
-
-	if responseBytes, err = NewIAMClient(ctx, me).GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", level, levelID), rest2.RequestOptions{}, 200); err != nil {
+	response, err := NewIAMClient(ctx, me).GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", level, levelID), rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
 
-	var response ListPoliciesResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	var policiesResponse ListPoliciesResponse
+	if err = json.Unmarshal(response.Data, &policiesResponse); err != nil {
 		return nil, err
 	}
-	return response.Items, nil
+	return policiesResponse.Items, nil
 }
 
 func (me *BasePolicyServiceClient) LIST(ctx context.Context, level PolicyLevel, levelID string) ([]string, error) {
-	var err error
-
-	var userStubs []PolicyStub
-	if userStubs, err = me.List(ctx, level, levelID); err != nil {
+	userStubs, err := me.List(ctx, level, levelID)
+	if err != nil {
 		return nil, err
 	}
 	ids := []string{}
@@ -141,6 +131,6 @@ func (me *BasePolicyServiceClient) LIST(ctx context.Context, level PolicyLevel, 
 }
 
 func (me *BasePolicyServiceClient) DELETE(ctx context.Context, level PolicyLevel, levelID string, uuid string) error {
-	_, err := NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", level, levelID, uuid), rest2.RequestOptions{}, 204)
+	_, err := NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", level, levelID, uuid), rest2.RequestOptions{})
 	return err
 }

--- a/dynatrace/api/iam/bindings/service.go
+++ b/dynatrace/api/iam/bindings/service.go
@@ -111,8 +111,9 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 		v.Environment = levelID
 	}
 	v.GroupID = groupID
+
 	for idx, policyID := range v.PolicyIDs {
-		v.PolicyIDs[idx] = fmt.Sprintf("%s#-#%s#-#%s", policyID, levelType, levelID)
+		v.PolicyIDs[idx] = policies.Join(policyID, levelType, levelID)
 	}
 	return nil
 }
@@ -207,7 +208,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	for _, policy := range policyBindingsResponse.PolicyBindings {
 		for _, group := range policy.Groups {
 			if _, exists := groupIds[group]; !exists {
-				id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", me.AccountID())
+				id := join(group, "account", me.AccountID())
 				stubs = append(stubs, &api.Stub{ID: id, Name: "PolicyBindings-" + id})
 				groupIds[group] = true
 			}
@@ -229,7 +230,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 		for _, policy := range policyBindingsResponse.PolicyBindings {
 			for _, group := range policy.Groups {
 				if _, exists := groupIds[group]; !exists {
-					id := fmt.Sprintf("%s#-#%s#-#%s", group, "environment", environment.ID)
+					id := join(group, "environment", environment.ID)
 					stubs = append(stubs, &api.Stub{ID: id, Name: "PolicyBindings-" + id})
 					groupIds[group] = true
 				}
@@ -269,14 +270,18 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 func splitID(id string) (groupID string, levelType string, levelID string, err error) {
 	parts := strings.Split(id, "#-#")
 	if len(parts) != 3 {
-		return "", "", "", fmt.Errorf("%s is not a valid ID for a policy", id)
+		return "", "", "", fmt.Errorf("%s is not a valid ID for a policy binding", id)
 	}
 	return parts[0], parts[1], parts[2], nil
 }
 
 func joinID(binding *bindings.PolicyBinding) string {
 	levelType, levelID := getLevel(binding)
-	return fmt.Sprintf("%s#-#%s#-#%s", binding.GroupID, levelType, levelID)
+	return join(binding.GroupID, levelType, levelID)
+}
+
+func join(groupID string, levelType string, levelID string) string {
+	return fmt.Sprintf("%s#-#%s#-#%s", groupID, levelType, levelID)
 }
 
 func getLevel(binding *bindings.PolicyBinding) (string, string) {

--- a/dynatrace/api/iam/bindings/service.go
+++ b/dynatrace/api/iam/bindings/service.go
@@ -249,7 +249,11 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	for _, policyID := range binding.PolicyIDs {
-		if _, err = iam.NewIAMClient(ctx, me).DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyID, groupID), rest2.RequestOptions{}, []int{204, 400}); err != nil {
+		policyUUID, _, _, err := policies.SplitID(policyID, levelType, levelID)
+		if err != nil {
+			return err
+		}
+		if _, err = iam.NewIAMClient(ctx, me).DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), rest2.RequestOptions{}, []int{204, 400}); err != nil {
 			return err
 		}
 	}

--- a/dynatrace/api/iam/bindings/service.go
+++ b/dynatrace/api/iam/bindings/service.go
@@ -20,7 +20,9 @@ package bindings
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -29,6 +31,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/policies"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
@@ -82,8 +85,7 @@ type PolicyCreateResponse struct {
 
 func (me *BindingServiceClient) Create(ctx context.Context, v *bindings.PolicyBinding) (*api.Stub, error) {
 	id := joinID(v)
-	var err error
-	if err = me.Update(ctx, id, v); err != nil {
+	if err := me.Update(ctx, id, v); err != nil {
 		return nil, err
 	}
 	return &api.Stub{ID: id, Name: "PolicyBindings-" + id}, nil
@@ -94,14 +96,13 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 	if err != nil {
 		return err
 	}
-	var responseBytes []byte
-
 	client := iam.NewIAMClient(ctx, me)
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{}, 200); err != nil {
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{})
+	if err != nil {
 		return err
 	}
-	if err = json.Unmarshal(responseBytes, &v); err != nil {
+	if err = json.Unmarshal(response.Data, &v); err != nil {
 		return err
 	}
 	if levelType == "account" {
@@ -138,7 +139,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, bindings 
 	}
 	bindings.PolicyIDs = policyIDs
 
-	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), bindings, rest2.RequestOptions{}, 204); err != nil {
+	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), bindings, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -165,46 +166,45 @@ type ListPolicyUUIDsForGroupResponse struct {
 }
 
 func (me *BindingServiceClient) GetPolicyUUIDsForGroup(ctx context.Context, groupID string, levelType string, levelID string) ([]string, error) {
-	var err error
-	var responseBytes []byte
 	client := iam.NewIAMClient(ctx, me)
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{}, 200); err != nil {
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
 
-	var response ListPolicyUUIDsForGroupResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	var listResponse ListPolicyUUIDsForGroupResponse
+	if err = json.Unmarshal(response.Data, &listResponse); err != nil {
 		return nil, err
 	}
-	return response.PolicyUUIDs, nil
+	return listResponse.PolicyUUIDs, nil
 }
 
 func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	var err error
-	var responseBytes []byte
 	client := iam.NewIAMClient(ctx, me)
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", me.AccountID()), rest2.RequestOptions{}, 200); err != nil {
+	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", me.AccountID()), rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
 
 	var envResponse ListEnvResponse
-	if err = json.Unmarshal(responseBytes, &envResponse); err != nil {
+	if err = json.Unmarshal(response.Data, &envResponse); err != nil {
 		return nil, err
 	}
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.AccountID()), rest2.RequestOptions{}, 200); err != nil {
+	response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.AccountID()), rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
 
-	var response ListPolicyBindingsResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	var policyBindingsResponse ListPolicyBindingsResponse
+	if err = json.Unmarshal(response.Data, &policyBindingsResponse); err != nil {
 		return nil, err
 	}
 
 	var stubs api.Stubs
 	groupIds := map[string]bool{}
-	for _, policy := range response.PolicyBindings {
+	for _, policy := range policyBindingsResponse.PolicyBindings {
 		for _, group := range policy.Groups {
 			if _, exists := groupIds[group]; !exists {
 				id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", me.AccountID())
@@ -215,17 +215,18 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	}
 
 	for _, environment := range envResponse.Data {
-		if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/bindings", environment.ID), rest2.RequestOptions{}, 200); err != nil {
+		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/bindings", environment.ID), rest2.RequestOptions{})
+		if err != nil {
 			return nil, err
 		}
 
-		var response ListPolicyBindingsResponse
-		if err = json.Unmarshal(responseBytes, &response); err != nil {
+		var policyBindingsResponse ListPolicyBindingsResponse
+		if err = json.Unmarshal(response.Data, &policyBindingsResponse); err != nil {
 			return nil, err
 		}
 
 		groupIds := map[string]bool{}
-		for _, policy := range response.PolicyBindings {
+		for _, policy := range policyBindingsResponse.PolicyBindings {
 			for _, group := range policy.Groups {
 				if _, exists := groupIds[group]; !exists {
 					id := fmt.Sprintf("%s#-#%s#-#%s", group, "environment", environment.ID)
@@ -253,7 +254,12 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 		if err != nil {
 			return err
 		}
-		if _, err = iam.NewIAMClient(ctx, me).DELETE_MULTI_RESPONSE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), rest2.RequestOptions{}, []int{204, 400}); err != nil {
+		if _, err = iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), rest2.RequestOptions{}); err != nil {
+
+			// The API currently returns a 400 Bad Request when the binding does not exist
+			if apiErr, ok := errors.AsType[coreapi.APIError](err); ok && apiErr.StatusCode == http.StatusBadRequest {
+				continue
+			}
 			return err
 		}
 	}

--- a/dynatrace/api/iam/boundaries/service.go
+++ b/dynatrace/api/iam/boundaries/service.go
@@ -99,21 +99,21 @@ func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
 
 	for page := 1; ; page++ {
 		params.Set("page", strconv.Itoa(page))
-		responseBytes, err := client.GET(ctx, endpoint, rest2.RequestOptions{QueryParams: params}, 200)
+		response, err := client.GET(ctx, endpoint, rest2.RequestOptions{QueryParams: params})
 		if err != nil {
 			return nil, err
 		}
 
-		var response ListPolicyBoundariesResponse
-		if err = json.Unmarshal(responseBytes, &response); err != nil {
+		var policyBoundariesResponse ListPolicyBoundariesResponse
+		if err = json.Unmarshal(response.Data, &policyBoundariesResponse); err != nil {
 			return nil, err
 		}
 
-		for _, boundary := range response.PolicyBoundaries {
+		for _, boundary := range policyBoundariesResponse.PolicyBoundaries {
 			stubs = append(stubs, &api.Stub{ID: boundary.UUID, Name: boundary.Name})
 		}
 
-		if len(response.PolicyBoundaries) < maxPageSize {
+		if len(policyBoundariesResponse.PolicyBoundaries) < maxPageSize {
 			break
 		}
 	}
@@ -122,12 +122,12 @@ func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *BoundaryServiceClient) Get(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
-	responseBytes, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id), rest2.RequestOptions{}, 200)
+	response, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
 
-	return json.Unmarshal(responseBytes, v)
+	return json.Unmarshal(response.Data, v)
 }
 
 func (me *BoundaryServiceClient) SchemaID() string {
@@ -135,36 +135,34 @@ func (me *BoundaryServiceClient) SchemaID() string {
 }
 
 func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.PolicyBoundary) (*api.Stub, error) {
-	responseBytes, err := me.iamClientGetter.New(ctx).POST(
+	response, err := me.iamClientGetter.New(ctx).POST(
 		ctx,
 		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", me.accountID),
 		v,
 		rest2.RequestOptions{},
-		201,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	response := struct {
+	uuidNameResponse := struct {
 		UUID string `json:"uuid"`
 		Name string `json:"name"`
 	}{}
 
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	if err = json.Unmarshal(response.Data, &uuidNameResponse); err != nil {
 		return nil, err
 	}
 
-	return &api.Stub{ID: response.UUID, Name: response.Name}, nil
+	return &api.Stub{ID: uuidNameResponse.UUID, Name: uuidNameResponse.Name}, nil
 }
 
 func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
-	_, err := me.iamClientGetter.New(ctx).PUT_MULTI_RESPONSE(
+	_, err := me.iamClientGetter.New(ctx).PUT(
 		ctx,
 		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id),
 		v,
 		rest2.RequestOptions{},
-		[]int{201, 204},
 	)
 	return err
 }
@@ -175,7 +173,6 @@ func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
 		ctx,
 		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id),
 		rest2.RequestOptions{},
-		204,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "Policy boundary is in use") {
@@ -184,7 +181,6 @@ func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
 					ctx,
 					fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id),
 					rest2.RequestOptions{},
-					204,
 				)
 			})
 			return nil

--- a/dynatrace/api/iam/boundaries/service_unit_test.go
+++ b/dynatrace/api/iam/boundaries/service_unit_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/stretchr/testify/assert"
@@ -60,8 +61,8 @@ func assertPageRequest(t *testing.T, reqURL string, options rest2.RequestOptions
 func TestBoundaryServiceClient_List(t *testing.T) {
 	t.Run("Returns error on GET failure", func(t *testing.T) {
 		mock := &testing2.MockIAMClient{
-			GETFunc: func(_ context.Context, _ string, _ rest2.RequestOptions, _ int) ([]byte, error) {
-				return nil, assert.AnError
+			GETFunc: func(_ context.Context, _ string, _ rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, assert.AnError
 			},
 		}
 		_, err := newTestClient(mock).List(t.Context())
@@ -70,8 +71,8 @@ func TestBoundaryServiceClient_List(t *testing.T) {
 
 	t.Run("Returns error on invalid JSON response", func(t *testing.T) {
 		mock := &testing2.MockIAMClient{
-			GETFunc: func(_ context.Context, _ string, _ rest2.RequestOptions, _ int) ([]byte, error) {
-				return []byte("not-json"), nil
+			GETFunc: func(_ context.Context, _ string, _ rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte("not-json")}, nil
 			},
 		}
 		_, err := newTestClient(mock).List(t.Context())
@@ -81,8 +82,8 @@ func TestBoundaryServiceClient_List(t *testing.T) {
 
 	t.Run("Returns empty stubs for empty response", func(t *testing.T) {
 		mock := &testing2.MockIAMClient{
-			GETFunc: func(_ context.Context, _ string, _ rest2.RequestOptions, _ int) ([]byte, error) {
-				return boundaryPageResponse(nil), nil
+			GETFunc: func(_ context.Context, _ string, _ rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: boundaryPageResponse(nil)}, nil
 			},
 		}
 		stubs, err := newTestClient(mock).List(t.Context())
@@ -97,10 +98,10 @@ func TestBoundaryServiceClient_List(t *testing.T) {
 		}
 		callCount := 0
 		mock := &testing2.MockIAMClient{
-			GETFunc: func(_ context.Context, reqURL string, options rest2.RequestOptions, _ int) ([]byte, error) {
+			GETFunc: func(_ context.Context, reqURL string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				assertPageRequest(t, reqURL, options, 1)
-				return boundaryPageResponse(items), nil
+				return api.Response{Data: boundaryPageResponse(items)}, nil
 			},
 		}
 
@@ -126,17 +127,17 @@ func TestBoundaryServiceClient_List(t *testing.T) {
 
 		callCount := 0
 		mock := &testing2.MockIAMClient{
-			GETFunc: func(_ context.Context, reqURL string, options rest2.RequestOptions, _ int) ([]byte, error) {
+			GETFunc: func(_ context.Context, reqURL string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				switch callCount {
 				case 1:
 					assertPageRequest(t, reqURL, options, 1)
-					return boundaryPageResponse(fullPage), nil
+					return api.Response{Data: boundaryPageResponse(fullPage)}, nil
 				case 2:
 					assertPageRequest(t, reqURL, options, 2)
-					return boundaryPageResponse(page2), nil
+					return api.Response{Data: boundaryPageResponse(page2)}, nil
 				default:
-					return nil, fmt.Errorf("unexpected page request %d", callCount)
+					return api.Response{}, fmt.Errorf("unexpected page request %d", callCount)
 				}
 			},
 		}
@@ -151,12 +152,12 @@ func TestBoundaryServiceClient_List(t *testing.T) {
 		fullPage := make([]PolicyBoundary, maxPageSize)
 		callCount := 0
 		mock := &testing2.MockIAMClient{
-			GETFunc: func(_ context.Context, _ string, _ rest2.RequestOptions, _ int) ([]byte, error) {
+			GETFunc: func(_ context.Context, _ string, _ rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
-					return boundaryPageResponse(fullPage), nil
+					return api.Response{Data: boundaryPageResponse(fullPage)}, nil
 				}
-				return nil, assert.AnError
+				return api.Response{}, assert.AnError
 			},
 		}
 

--- a/dynatrace/api/iam/groups/service.go
+++ b/dynatrace/api/iam/groups/service.go
@@ -94,23 +94,21 @@ func (me *GroupServiceClient) Name() string {
 // FederatedAttributeValues []string           `json:"federatedAttributeValues"`
 // Permissions              groups.Permissions `json:"permissions"`
 func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (*api.Stub, error) {
-	var err error
-	var responseBytes []byte
-
 	client := iam.NewIAMClient(ctx, me)
-	if responseBytes, err = client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", me.AccountID()), []*groups.Group{group}, rest2.RequestOptions{}, 201); err != nil {
+	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", me.AccountID()), []*groups.Group{group}, rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
 
 	responseGroups := []*ListGroup{}
-	if err = json.Unmarshal(responseBytes, &responseGroups); err != nil {
+	if err = json.Unmarshal(response.Data, &responseGroups); err != nil {
 		return nil, err
 	}
 	groupID := responseGroups[0].UUID
 	groupName := responseGroups[0].Name
 
 	if len(group.Permissions) > 0 {
-		if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), groupID), group.Permissions, rest2.RequestOptions{}, 200); err != nil {
+		if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), groupID), group.Permissions, rest2.RequestOptions{}); err != nil {
 			return nil, err
 		}
 	}
@@ -125,10 +123,8 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 }
 
 func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *groups.Group) error {
-	var err error
-
 	client := iam.NewIAMClient(ctx, me)
-	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.AccountID(), uuid), group, rest2.RequestOptions{}, 200); err != nil {
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.AccountID(), uuid), group, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -137,7 +133,7 @@ func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *gr
 	if len(group.Permissions) > 0 {
 		permissions = group.Permissions
 	}
-	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), uuid), permissions, rest2.RequestOptions{}, 200); err != nil {
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), uuid), permissions, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -161,11 +157,11 @@ func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	client := iam.NewIAMClient(ctx, me)
 	var groupStubs ListGroupsResponse
 	accountID := me.AccountID()
-	responseBytes, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", accountID), rest2.RequestOptions{}, 200)
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", accountID), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(responseBytes, &groupStubs); err != nil {
+	if err := json.Unmarshal(response.Data, &groupStubs); err != nil {
 		return nil, err
 	}
 
@@ -180,11 +176,11 @@ func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Grou
 	var groupStub ListGroup
 	accountID := me.AccountID()
 	client := iam.NewIAMClient(ctx, me)
-	responseBytes, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", accountID, id), rest2.RequestOptions{}, 200)
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", accountID, id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
-	if err = json.Unmarshal(responseBytes, &groupStub); err != nil {
+	if err = json.Unmarshal(response.Data, &groupStub); err != nil {
 		return err
 	}
 
@@ -196,7 +192,7 @@ func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Grou
 }
 
 func (me *GroupServiceClient) Delete(ctx context.Context, id string) error {
-	_, err := iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.AccountID(), id), rest2.RequestOptions{}, 200)
+	_, err := iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.AccountID(), id), rest2.RequestOptions{})
 
 	// data sources MAY have cached a list of group IDs
 	// Updating the (publicly available) revision signals to them that either a CREATE or DELETE has happened since

--- a/dynatrace/api/iam/iam_client.go
+++ b/dynatrace/api/iam/iam_client.go
@@ -21,11 +21,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
@@ -33,17 +31,19 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"golang.org/x/oauth2/clientcredentials"
 
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/auth"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
+// IAMClient performs HTTP requests against the IAM REST API. Each method returns an api.Response
+// for any successful (2xx) response. Any non-2xx response is returned as an api.APIError, which
+// call sites can inspect (e.g. via errors.AsType) when a specific non-2xx code is expected.
 type IAMClient interface {
-	POST(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error)
-	PUT(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error)
-	PUT_MULTI_RESPONSE(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCodes []int) ([]byte, error)
-	GET(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error)
-	DELETE(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error)
-	DELETE_MULTI_RESPONSE(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCodes []int) ([]byte, error)
+	POST(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
+	PUT(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
+	GET(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
+	DELETE(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
 }
 
 type iamClient struct {
@@ -76,40 +76,45 @@ func NewIAMClient(ctx context.Context, a Authenticator) IAMClient {
 	return &iamClient{a, client}
 }
 
-func (me *iamClient) POST(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+func (me *iamClient) POST(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 	body, err := marshalPayload(payload)
 	if err != nil {
-		return nil, err
+		return api.Response{}, err
 	}
-	return handleResponse(me.client.POST(ctx, url, body, options))([]int{expectedResponseCode})
+	httpResponse, err := me.client.POST(ctx, url, body, options)
+	if err != nil {
+		return api.Response{}, err
+	}
+	return api.NewResponseFromHTTPResponse(httpResponse)
+
 }
 
-func (me *iamClient) PUT(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+func (me *iamClient) PUT(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 	body, err := marshalPayload(payload)
 	if err != nil {
-		return nil, err
+		return api.Response{}, err
 	}
-	return handleResponse(me.client.PUT(ctx, url, body, options))([]int{expectedResponseCode})
-}
-
-func (me *iamClient) PUT_MULTI_RESPONSE(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCodes []int) ([]byte, error) {
-	body, err := marshalPayload(payload)
+	httpResponse, err := me.client.PUT(ctx, url, body, options)
 	if err != nil {
-		return nil, err
+		return api.Response{}, err
 	}
-	return handleResponse(me.client.PUT(ctx, url, body, options))(expectedResponseCodes)
+	return api.NewResponseFromHTTPResponse(httpResponse)
 }
 
-func (me *iamClient) GET(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-	return handleResponse(me.client.GET(ctx, url, options))([]int{expectedResponseCode})
+func (me *iamClient) GET(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+	httpResponse, err := me.client.GET(ctx, url, options)
+	if err != nil {
+		return api.Response{}, err
+	}
+	return api.NewResponseFromHTTPResponse(httpResponse)
 }
 
-func (me *iamClient) DELETE(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-	return handleResponse(me.client.DELETE(ctx, url, options))([]int{expectedResponseCode})
-}
-
-func (me *iamClient) DELETE_MULTI_RESPONSE(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCodes []int) ([]byte, error) {
-	return handleResponse(me.client.DELETE(ctx, url, options))(expectedResponseCodes)
+func (me *iamClient) DELETE(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+	httpResponse, err := me.client.DELETE(ctx, url, options)
+	if err != nil {
+		return api.Response{}, err
+	}
+	return api.NewResponseFromHTTPResponse(httpResponse)
 }
 
 // marshalPayload serializes a request payload to a JSON body. A nil payload yields a nil body.
@@ -122,27 +127,4 @@ func marshalPayload(payload any) (io.Reader, error) {
 		return nil, err
 	}
 	return bytes.NewReader(requestBody), nil
-}
-
-// handleResponse reads the response body and validates the status code against the expected
-// codes. It is curried so it can wrap a rest client call directly, e.g.
-// handleResponse(client.GET(...))(expectedResponseCodes).
-func handleResponse(response *http.Response, err error) func(expectedResponseCodes []int) ([]byte, error) {
-	return func(expectedResponseCodes []int) ([]byte, error) {
-		if err != nil {
-			return nil, err
-		}
-		defer response.Body.Close()
-
-		responseBytes, err := io.ReadAll(response.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		if slices.Contains(expectedResponseCodes, response.StatusCode) {
-			return responseBytes, nil
-		}
-
-		return nil, rest.Error{Code: response.StatusCode, Message: fmt.Sprintf("response code %d (expected: %d)", response.StatusCode, expectedResponseCodes)}
-	}
 }

--- a/dynatrace/api/iam/permissions/service.go
+++ b/dynatrace/api/iam/permissions/service.go
@@ -75,8 +75,6 @@ func (me *PermissionServiceClient) Name() string {
 }
 
 func (me *PermissionServiceClient) Create(ctx context.Context, permission *permissions.Permission) (*api.Stub, error) {
-	var err error
-
 	client := iam.NewIAMClient(ctx, me)
 	scope := ""
 	scopeType := ""
@@ -96,7 +94,7 @@ func (me *PermissionServiceClient) Create(ctx context.Context, permission *permi
 		ScopeType: scopeType,
 		Name:      permission.Name,
 	}}
-	if _, err = client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), permission.GroupID), payload, rest2.RequestOptions{}, 201); err != nil {
+	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), permission.GroupID), payload, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -108,30 +106,24 @@ type GetGroupPermissionsResponse struct {
 }
 
 func (me *PermissionServiceClient) Get(ctx context.Context, id string, v *permissions.Permission) error {
-	var err error
-	var responseBytes []byte
-
 	client := iam.NewIAMClient(ctx, me)
 
-	parts := strings.Split(id, "#-#")
-	if len(parts) < 4 {
-		return fmt.Errorf("'%s' is not a valid permission ID", id)
-	}
-	groupID := parts[0]
-	name := parts[1]
-	scope := parts[2]
-	scopeType := parts[3]
-
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), groupID), rest2.RequestOptions{}, 200); err != nil {
+	groupID, name, scope, scopeType, err := splitID(id)
+	if err != nil {
 		return err
 	}
 
-	var response GetGroupPermissionsResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), groupID), rest2.RequestOptions{})
+	if err != nil {
 		return err
 	}
-	if len(response.Permissions) > 0 {
-		for _, permission := range response.Permissions {
+
+	var groupPermissionsResponse GetGroupPermissionsResponse
+	if err = json.Unmarshal(response.Data, &groupPermissionsResponse); err != nil {
+		return err
+	}
+	if len(groupPermissionsResponse.Permissions) > 0 {
+		for _, permission := range groupPermissionsResponse.Permissions {
 			permissionID := permission.ToID(groupID)
 			if permissionID == id {
 				v.GroupID = groupID
@@ -171,17 +163,17 @@ func (me *PermissionServiceClient) List(ctx context.Context) (api.Stubs, error) 
 
 		accountID := me.AccountID()
 
-		var response GetGroupPermissionsResponse
-		responseBytes, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", accountID, groupID), rest2.RequestOptions{}, 200)
+		var groupPermissionsResponse GetGroupPermissionsResponse
+		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", accountID, groupID), rest2.RequestOptions{})
 		if err != nil {
 			return nil, err
 		}
-		if err = json.Unmarshal(responseBytes, &response); err != nil {
+		if err = json.Unmarshal(response.Data, &groupPermissionsResponse); err != nil {
 			return nil, err
 		}
 
-		if len(response.Permissions) > 0 {
-			for _, permission := range response.Permissions {
+		if len(groupPermissionsResponse.Permissions) > 0 {
+			for _, permission := range groupPermissionsResponse.Permissions {
 				permissionID := strings.Join([]string{groupID, permission.Name, permission.Scope, permission.ScopeType}, "#-#")
 				stubs = append(stubs, &api.Stub{ID: permissionID, Name: permissionID})
 			}
@@ -192,23 +184,27 @@ func (me *PermissionServiceClient) List(ctx context.Context) (api.Stubs, error) 
 }
 
 func (me *PermissionServiceClient) Delete(ctx context.Context, id string) error {
-	parts := strings.Split(id, "#-#")
-	if len(parts) < 4 {
-		return fmt.Errorf("'%s' is not a valid permission ID", id)
+	groupID, name, scope, scopeType, err := splitID(id)
+	if err != nil {
+		return err
 	}
-	groupID := parts[0]
-	name := parts[1]
-	scope := parts[2]
-	scopeType := parts[3]
 
 	queryParams := url.Values{}
 	queryParams.Set("scope", scope)
 	queryParams.Set("permission-name", name)
 	queryParams.Set("scope-type", scopeType)
 
-	_, err := iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), groupID), rest2.RequestOptions{QueryParams: queryParams}, 200)
+	_, err = iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.AccountID(), groupID), rest2.RequestOptions{QueryParams: queryParams})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("Permission %s not found", id)) {
 		return nil
 	}
 	return err
+}
+
+func splitID(id string) (groupID string, name string, scope string, scopeType string, err error) {
+	parts := strings.Split(id, "#-#")
+	if len(parts) < 4 {
+		return "", "", "", "", fmt.Errorf("'%s' is not a valid permission ID", id)
+	}
+	return parts[0], parts[1], parts[2], parts[3], nil
 }

--- a/dynatrace/api/iam/policies/policy_level.go
+++ b/dynatrace/api/iam/policies/policy_level.go
@@ -21,12 +21,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
@@ -49,25 +49,23 @@ func GetEnvironmentIDs(ctx context.Context, auth iam.Authenticator) ([]string, e
 // and `levelID` it returns false, without returning an error
 // An error is returned ONLY if querying for the existence of the policy failed for another reason than `404 Not Found`
 func CheckPolicyExists(ctx context.Context, auth iam.Authenticator, levelType string, levelID string, policyUUID string) (bool, string, error) {
-	var err error
-
-	response := struct {
+	levelPolicy := struct {
 		UUID string `json:"uuid"`
 		Name string `json:"name"`
 	}{}
 	client := iam.NewIAMClient(ctx, auth)
-	var responseBytes []byte
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, policyUUID), rest2.RequestOptions{}, 200); err != nil {
-		// TODO: this is dirty. The IAM client unfortunately doesn't produce special kinds errors. string compare is the only option atm
-		if strings.HasPrefix(err.Error(), "response code 404") {
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, policyUUID), rest2.RequestOptions{})
+	if err != nil {
+		// A 404 Not Found means the policy is not defined at the given level - that is not an error here
+		if coreapi.IsNotFoundError(err) {
 			return false, "", nil
 		}
 		return false, "", err
 	}
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	if err = json.Unmarshal(response.Data, &levelPolicy); err != nil {
 		return false, "", err
 	}
-	return true, response.Name, nil
+	return true, levelPolicy.Name, nil
 }
 
 // FetchPolicyLevel determines the `levelType` and `levelID` of a policy identified by its UUID
@@ -232,16 +230,16 @@ func fetchGlobalPolicies(ctx context.Context, auth iam.Authenticator) (results c
 			defer close(results)
 		}()
 
-		var response ListPoliciesResponse
-		responseBytes, err := client.GET(ctx, "/iam/v1/repo/global/global/policies", rest2.RequestOptions{}, 200)
+		var policyList ListPoliciesResponse
+		response, err := client.GET(ctx, "/iam/v1/repo/global/global/policies", rest2.RequestOptions{})
 		if err != nil {
 			return
 		}
-		if err := json.Unmarshal(responseBytes, &response); err != nil {
+		if err := json.Unmarshal(response.Data, &policyList); err != nil {
 			return
 		}
 
-		for _, policy := range response.Policies {
+		for _, policy := range policyList.Policies {
 			results <- &api.Stub{ID: fmt.Sprintf("%s#-#%s#-#%s", policy.UUID, "global", "global"), Name: policy.Name}
 		}
 	}()
@@ -317,14 +315,12 @@ func fetchAllPolicyLevels(ctx context.Context, auth iam.Authenticator) (m map[st
 func getEnvironmentIDs(ctx context.Context, auth iam.Authenticator) ([]string, error) {
 	client := iam.NewIAMClient(ctx, auth)
 
-	var err error
-
 	var envResponse ListEnvResponse
-	var responseBytes []byte
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", auth.AccountID()), rest2.RequestOptions{}, 200); err != nil {
+	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", auth.AccountID()), rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
-	if err = json.Unmarshal(responseBytes, &envResponse); err != nil {
+	if err = json.Unmarshal(response.Data, &envResponse); err != nil {
 		return nil, err
 	}
 

--- a/dynatrace/api/iam/policies/service.go
+++ b/dynatrace/api/iam/policies/service.go
@@ -20,7 +20,6 @@ package policies
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -31,6 +30,7 @@ import (
 	policies "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/policies/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
+	api2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
@@ -87,21 +87,19 @@ type PolicyCreateResponse struct {
 }
 
 func (me *PolicyServiceClient) Create(ctx context.Context, v *policies.Policy) (*api.Stub, error) {
-	var err error
-	var responseBytes []byte
-
 	levelType, levelID := getLevel(v)
 
 	client := iam.NewIAMClient(ctx, me)
-	if responseBytes, err = client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", levelType, levelID), v, rest2.RequestOptions{}, 201); err != nil {
+	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", levelType, levelID), v, rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
 	var pcr PolicyCreateResponse
-	if err = json.Unmarshal(responseBytes, &pcr); err != nil {
+	if err = json.Unmarshal(response.Data, &pcr); err != nil {
 		return nil, err
 	}
 	v.UUID = pcr.UUID
-	RegisterPolicyLevel(ctx, me, PolicyLevel{UUID: v.UUID, LevelType: levelType, LevelID: levelID})
+	_ = RegisterPolicyLevel(ctx, me, PolicyLevel{UUID: v.UUID, LevelType: levelType, LevelID: levelID})
 	return &api.Stub{ID: joinID(pcr.UUID, v), Name: v.Name}, nil
 }
 
@@ -140,26 +138,26 @@ func (me *PolicyServiceClient) get(ctx context.Context, id string, v *policies.P
 		return nil
 	}
 
-	var responseBytes []byte
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{}, 200); err != nil {
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{})
+	if err != nil {
 		return err
 	}
-	if err = json.Unmarshal(responseBytes, v); err != nil {
+	if err = json.Unmarshal(response.Data, v); err != nil {
 		return err
 	}
 	if levelType == "account" {
 		v.Account = levelID
 		if len(levelID) == 0 {
-			return errors.New(fmt.Sprintf("Policy `%s` has level type `%s`, but level id is empty", id, levelType))
+			return fmt.Errorf("Policy `%s` has level type `%s`, but level id is empty", id, levelType)
 		}
 	} else if levelType == "environment" {
 		v.Environment = levelID
 		if len(levelID) == 0 {
-			return errors.New(fmt.Sprintf("Policy `%s` has level type `%s`, but level id is empty", id, levelType))
+			return fmt.Errorf("Policy `%s` has level type `%s`, but level id is empty", id, levelType)
 		}
 	}
 	v.UUID = uuid
-	RegisterPolicyLevel(ctx, me, PolicyLevel{UUID: v.UUID, LevelType: levelType, LevelID: levelID})
+	_ = RegisterPolicyLevel(ctx, me, PolicyLevel{UUID: v.UUID, LevelType: levelType, LevelID: levelID})
 	return nil
 }
 
@@ -176,7 +174,7 @@ func (me *PolicyServiceClient) Update(ctx context.Context, id string, user *poli
 	}
 	client := iam.NewIAMClient(ctx, me)
 
-	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), user, rest2.RequestOptions{}, 204); err != nil {
+	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), user, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -206,16 +204,16 @@ func listForEnvironment(ctx context.Context, auth iam.Authenticator, environment
 		defer close(results)
 		client := iam.NewIAMClient(ctx, auth)
 
-		var response ListPoliciesResponse
-		var responseBytes []byte
-		if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/policies", environmentID), rest2.RequestOptions{}, 200); err != nil {
+		var response api2.Response
+		if response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/policies", environmentID), rest2.RequestOptions{}); err != nil {
 			return
 		}
-		if err = json.Unmarshal(responseBytes, &response); err != nil {
+		var policiesResponse ListPoliciesResponse
+		if err = json.Unmarshal(response.Data, &policiesResponse); err != nil {
 			return
 		}
 
-		for _, policy := range response.Policies {
+		for _, policy := range policiesResponse.Policies {
 			results <- &api.Stub{ID: Join(policy.UUID, "environment", environmentID), Name: policy.Name}
 		}
 	}()
@@ -224,8 +222,8 @@ func listForEnvironment(ctx context.Context, auth iam.Authenticator, environment
 
 func listForEnvironments(ctx context.Context, auth iam.Authenticator) (results chan *api.Stub, err error) {
 	results = make(chan *api.Stub)
-	var environmentIDs []string
-	if environmentIDs, err = GetEnvironmentIDs(ctx, auth); err != nil {
+	environmentIDs, err := GetEnvironmentIDs(ctx, auth)
+	if err != nil {
 		return nil, err
 	}
 	var wg sync.WaitGroup
@@ -259,16 +257,18 @@ func listForAccount(ctx context.Context, auth iam.Authenticator) (results chan *
 	results = make(chan *api.Stub)
 	go func() {
 		defer close(results)
-		var response ListPoliciesResponse
-		var responseBytes []byte
-		if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/policies", auth.AccountID()), rest2.RequestOptions{}, 200); err != nil {
-			return
-		}
-		if err = json.Unmarshal(responseBytes, &response); err != nil {
+
+		var response api2.Response
+		if response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/policies", auth.AccountID()), rest2.RequestOptions{}); err != nil {
 			return
 		}
 
-		for _, policy := range response.Policies {
+		var policiesResponse ListPoliciesResponse
+		if err = json.Unmarshal(response.Data, &policiesResponse); err != nil {
+			return
+		}
+
+		for _, policy := range policiesResponse.Policies {
 			results <- &api.Stub{ID: Join(policy.UUID, "account", auth.AccountID()), Name: policy.Name}
 		}
 	}()
@@ -353,21 +353,16 @@ func (me *PolicyServiceClient) ListWithGlobals(ctx context.Context) (api.Stubs, 
 }
 
 func (me *PolicyServiceClient) Delete(ctx context.Context, id string) error {
-	var levelType string
-	var levelID string
-	var err error
-	var uuid string
-
-	uuid, _, _, err = SplitIDNoDefaults(id)
+	uuid, _, _, err := SplitIDNoDefaults(id)
 	if err != nil {
 		return err
 	}
-	levelType, levelID, _, err = ResolvePolicyLevel(ctx, me, uuid)
+	levelType, levelID, _, err := ResolvePolicyLevel(ctx, me, uuid)
 	if err != nil {
 		return err
 	}
 
-	_, err = iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{}, 204)
+	_, err = iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{})
 	return err
 }
 

--- a/dynatrace/api/iam/serviceusers/service.go
+++ b/dynatrace/api/iam/serviceusers/service.go
@@ -106,25 +106,25 @@ type createResponse struct {
 }
 
 func (me *serviceUserServiceClient) Create(ctx context.Context, serviceUser *serviceusers.ServiceUser) (*api.Stub, error) {
-	responseBytes, err := me.iamClientGetter.New(ctx).POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users", me.accountID), serviceUser, rest2.RequestOptions{}, 201)
+	response, err := me.iamClientGetter.New(ctx).POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users", me.accountID), serviceUser, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	var response createResponse
-	if err := json.Unmarshal(responseBytes, &response); err != nil {
+	var createResp createResponse
+	if err := json.Unmarshal(response.Data, &createResp); err != nil {
 		return nil, err
 	}
 
-	if err := me.updateGroupAssignments(ctx, response.Email, serviceUser.Groups); err != nil {
-		deleteErr := me.Delete(ctx, response.UID)
+	if err := me.updateGroupAssignments(ctx, createResp.Email, serviceUser.Groups); err != nil {
+		deleteErr := me.Delete(ctx, createResp.UID)
 		if deleteErr != nil {
 			return nil, fmt.Errorf("failed to create service user: %v; additionally failed to clean up service user: %v", err, deleteErr)
 		}
 		return nil, err
 	}
 
-	return &api.Stub{ID: response.UID, Name: response.Name}, nil
+	return &api.Stub{ID: createResp.UID, Name: createResp.Name}, nil
 }
 
 // getServiceUserResponse represents the response from getting a service user
@@ -136,24 +136,24 @@ type getServiceUserResponse struct {
 }
 
 func (me *serviceUserServiceClient) Get(ctx context.Context, id string, v *serviceusers.ServiceUser) error {
-	responseBytes, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, id), rest2.RequestOptions{}, 200)
+	response, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
 
-	var response getServiceUserResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	var getResp getServiceUserResponse
+	if err = json.Unmarshal(response.Data, &getResp); err != nil {
 		return err
 	}
 
-	groups, err := me.getUserGroups(ctx, response.Email)
+	groups, err := me.getUserGroups(ctx, getResp.Email)
 	if err != nil {
 		return err
 	}
 
-	v.Email = response.Email
-	v.Name = response.Name
-	v.Description = response.Description
+	v.Email = getResp.Email
+	v.Name = getResp.Name
+	v.Description = getResp.Description
 	v.Groups = groups
 
 	return nil
@@ -170,18 +170,18 @@ type getUserPartialResponse struct {
 }
 
 func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email string) ([]string, error) {
-	responseBytes, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.accountID, email), rest2.RequestOptions{}, 200)
+	response, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.accountID, email), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	var response getUserPartialResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	var getResp getUserPartialResponse
+	if err = json.Unmarshal(response.Data, &getResp); err != nil {
 		return nil, err
 	}
 
-	groups := make([]string, 0, len(response.Groups))
-	for _, group := range response.Groups {
+	groups := make([]string, 0, len(getResp.Groups))
+	for _, group := range getResp.Groups {
 		groups = append(groups, group.UUID)
 	}
 
@@ -190,7 +190,7 @@ func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email str
 
 func (me *serviceUserServiceClient) Update(ctx context.Context, id string, serviceUser *serviceusers.ServiceUser) error {
 	// Update the service user details
-	if _, err := me.iamClientGetter.New(ctx).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, id), serviceUser, rest2.RequestOptions{}, 200); err != nil {
+	if _, err := me.iamClientGetter.New(ctx).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, id), serviceUser, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -203,7 +203,7 @@ func (me *serviceUserServiceClient) updateGroupAssignments(ctx context.Context, 
 	if groups == nil {
 		groups = []string{}
 	}
-	_, err := me.iamClientGetter.New(ctx).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.accountID, serviceUserEmail), groups, rest2.RequestOptions{}, 200)
+	_, err := me.iamClientGetter.New(ctx).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.accountID, serviceUserEmail), groups, rest2.RequestOptions{})
 	return err
 }
 
@@ -230,23 +230,23 @@ func (me *serviceUserServiceClient) GetAll(ctx context.Context) ([]ServiceUserSt
 	options := rest2.RequestOptions{}
 
 	for {
-		responseBytes, err := client.GET(ctx, endpoint, options, 200)
+		response, err := client.GET(ctx, endpoint, options)
 		if err != nil {
 			return nil, err
 		}
 
-		var response listServiceUsersResponse
-		if err := json.Unmarshal(responseBytes, &response); err != nil {
+		var listResp listServiceUsersResponse
+		if err := json.Unmarshal(response.Data, &listResp); err != nil {
 			return nil, err
 		}
 
-		stubs = append(stubs, response.Items...)
+		stubs = append(stubs, listResp.Items...)
 
 		// Handle pagination
-		if response.NextPage == "" {
+		if listResp.NextPage == "" {
 			break
 		}
-		options.QueryParams = url.Values{"nextPageKey": {response.NextPage}}
+		options.QueryParams = url.Values{"nextPageKey": {listResp.NextPage}}
 	}
 
 	return stubs, nil
@@ -270,6 +270,6 @@ func (me *serviceUserServiceClient) List(ctx context.Context) (api.Stubs, error)
 }
 
 func (me *serviceUserServiceClient) Delete(ctx context.Context, uid string) error {
-	_, err := me.iamClientGetter.New(ctx).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, uid), rest2.RequestOptions{}, 200)
+	_, err := me.iamClientGetter.New(ctx).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, uid), rest2.RequestOptions{})
 	return err
 }

--- a/dynatrace/api/iam/serviceusers/service_test.go
+++ b/dynatrace/api/iam/serviceusers/service_test.go
@@ -27,6 +27,7 @@ import (
 
 	serviceusers "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers/settings"
 	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 
 	"github.com/stretchr/testify/assert"
@@ -46,13 +47,13 @@ func createTestServiceUserServiceClient(client *testing2.MockIAMClient) *service
 func TestService_Create(t *testing.T) {
 	t.Run("successful creation", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
-				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
+				return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`)}, nil
 			},
-			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", testAccountID, "test@example.com"), url)
-				return nil, nil
+				return api.Response{}, nil
 			},
 		}
 
@@ -71,14 +72,14 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("successful creation with empty groups", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
-				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
+				return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`)}, nil
 			},
-			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", testAccountID, "test@example.com"), url)
 				assert.Equal(t, []string{}, payload)
-				return nil, nil
+				return api.Response{}, nil
 			},
 		}
 
@@ -96,8 +97,8 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("creation fails on POST", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("POST failed")
+			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("POST failed")
 			},
 		}
 
@@ -112,14 +113,14 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("creation fails on group assignment and cleanup succeeds", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
+			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`)}, nil
 			},
-			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("group assignment failed")
+			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("group assignment failed")
 			},
-			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, nil
+			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, nil
 			},
 		}
 
@@ -135,14 +136,14 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("creation fails on group assignment and cleanup fails", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`), nil
+			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`)}, nil
 			},
-			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("group assignment failed")
+			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("group assignment failed")
 			},
-			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("delete failed")
+			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("delete failed")
 			},
 		}
 
@@ -158,8 +159,8 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("creation fails on invalid JSON response", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{invalid json`), nil
+			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
@@ -178,18 +179,18 @@ func TestService_Get(t *testing.T) {
 	t.Run("successful get with groups", func(t *testing.T) {
 		getCallCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				getCallCount++
 				if getCallCount == 1 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", testAccountID, "test-uid"), url)
-					return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`), nil
+					return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`)}, nil
 				}
 				if getCallCount == 2 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", testAccountID, "test@example.com"), url)
-					return []byte(`{"uid":"test-uid","groups":[{"uuid":"group-1","groupName":"Group 1"},{"uuid":"group-2","groupName":"Group 2"}]}`), nil
+					return api.Response{Data: []byte(`{"uid":"test-uid","groups":[{"uuid":"group-1","groupName":"Group 1"},{"uuid":"group-2","groupName":"Group 2"}]}`)}, nil
 				}
 				assert.FailNow(t, "unexpected call to GET")
-				return nil, errors.New("unexpected call to GET")
+				return api.Response{}, errors.New("unexpected call to GET")
 			},
 		}
 
@@ -208,18 +209,18 @@ func TestService_Get(t *testing.T) {
 	t.Run("successful get without groups", func(t *testing.T) {
 		getCallCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				getCallCount++
 				if getCallCount == 1 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", testAccountID, "test-uid"), url)
-					return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`), nil
+					return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`)}, nil
 				}
 				if getCallCount == 2 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", testAccountID, "test@example.com"), url)
-					return []byte(`{"uid":"test-uid","groups":[]}`), nil
+					return api.Response{Data: []byte(`{"uid":"test-uid","groups":[]}`)}, nil
 				}
 				assert.FailNow(t, "unexpected call to GET")
-				return nil, errors.New("unexpected call to GET")
+				return api.Response{}, errors.New("unexpected call to GET")
 			},
 		}
 
@@ -235,8 +236,8 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("get fails on service user fetch", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("GET failed")
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("GET failed")
 			},
 		}
 
@@ -250,16 +251,16 @@ func TestService_Get(t *testing.T) {
 	t.Run("get fails on user groups fetch", func(t *testing.T) {
 		getCallCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				getCallCount++
 				if getCallCount == 1 {
-					return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`), nil
+					return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`)}, nil
 				}
 				if getCallCount == 2 {
-					return nil, errors.New("groups fetch failed")
+					return api.Response{}, errors.New("groups fetch failed")
 				}
 				assert.FailNow(t, "unexpected call to GET")
-				return nil, errors.New("unexpected call to GET")
+				return api.Response{}, errors.New("unexpected call to GET")
 			},
 		}
 
@@ -272,8 +273,8 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("get returns error when service user not found", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("Service user test-uid does not exist")
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("Service user test-uid does not exist")
 			},
 		}
 
@@ -286,8 +287,8 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("get fails on invalid JSON for service user", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{invalid json`), nil
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
@@ -301,16 +302,16 @@ func TestService_Get(t *testing.T) {
 	t.Run("get fails on invalid JSON for user groups", func(t *testing.T) {
 		getCallCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				getCallCount++
 				if getCallCount == 1 {
-					return []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`), nil
+					return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User","description":"Test description"}`)}, nil
 				}
 				if getCallCount == 2 {
-					return []byte(`{invalid json`), nil
+					return api.Response{Data: []byte(`{invalid json`)}, nil
 				}
 				assert.FailNow(t, "unexpected call to GET")
-				return nil, errors.New("unexpected call to GET")
+				return api.Response{}, errors.New("unexpected call to GET")
 			},
 		}
 
@@ -325,15 +326,15 @@ func TestService_Get(t *testing.T) {
 func TestService_GetAll(t *testing.T) {
 	t.Run("successful get all without pagination", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
-				return []byte(`{
+				return api.Response{Data: []byte(`{
 					"count": 2,
 					"results": [
 						{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": "Desc 1"},
 						{"uid": "uid-2", "email": "user2@example.com", "name": "User 2", "description": "Desc 2"}
 					]
-				}`), nil
+				}`)}, nil
 			},
 		}
 
@@ -354,30 +355,30 @@ func TestService_GetAll(t *testing.T) {
 	t.Run("successful get all with pagination", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 						"count": 2,
 						"results": [
 							{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": "Desc 1"}
 						],
 						"nextPageKey": "page2"
-					}`), nil
+					}`)}, nil
 				}
 				if callCount == 2 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
 					assert.Equal(t, "page2", options.QueryParams.Get("nextPageKey"))
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 						"count": 2,
 						"results": [
 							{"uid": "uid-2", "email": "user2@example.com", "name": "User 2", "description": "Desc 2"}
 						]
-					}`), nil
+					}`)}, nil
 				}
 				assert.FailNow(t, "unexpected call to GET")
-				return nil, errors.New("unexpected call to GET")
+				return api.Response{}, errors.New("unexpected call to GET")
 			},
 		}
 
@@ -393,30 +394,30 @@ func TestService_GetAll(t *testing.T) {
 	t.Run("successful get all with multiple pagination pages", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 						"count": 3,
 						"results": [{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": ""}],
 						"nextPageKey": "page2"
-					}`), nil
+					}`)}, nil
 				}
 				if callCount == 2 {
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 						"count": 3,
 						"results": [{"uid": "uid-2", "email": "user2@example.com", "name": "User 2", "description": ""}],
 						"nextPageKey": "page3"
-					}`), nil
+					}`)}, nil
 				}
 				if callCount == 3 {
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 						"count": 3,
 						"results": [{"uid": "uid-3", "email": "user3@example.com", "name": "User 3", "description": ""}]
-					}`), nil
+					}`)}, nil
 				}
 				assert.FailNow(t, "unexpected call to GET")
-				return nil, errors.New("unexpected call to GET")
+				return api.Response{}, errors.New("unexpected call to GET")
 			},
 		}
 
@@ -429,8 +430,8 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("get all fails", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("GET failed")
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("GET failed")
 			},
 		}
 
@@ -442,16 +443,16 @@ func TestService_GetAll(t *testing.T) {
 	t.Run("get all fails on second page", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 						"count": 2,
 						"results": [{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": ""}],
 						"nextPageKey": "page2"
-					}`), nil
+					}`)}, nil
 				}
-				return nil, errors.New("pagination failed")
+				return api.Response{}, errors.New("pagination failed")
 			},
 		}
 
@@ -462,11 +463,11 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("get all empty", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{
 					"count": 0,
 					"results": []
-				}`), nil
+				}`)}, nil
 			},
 		}
 
@@ -478,8 +479,8 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("get all fails on invalid JSON response", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{invalid json`), nil
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
@@ -491,16 +492,16 @@ func TestService_GetAll(t *testing.T) {
 	t.Run("get all fails on invalid JSON response on second page", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 						"count": 2,
 						"results": [{"uid": "uid-1", "email": "user1@example.com", "name": "User 1", "description": ""}],
 						"nextPageKey": "page2"
-					}`), nil
+					}`)}, nil
 				}
-				return []byte(`{invalid json`), nil
+				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
@@ -513,14 +514,14 @@ func TestService_GetAll(t *testing.T) {
 func TestService_List(t *testing.T) {
 	t.Run("successful list without pagination", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{
 					"count": 2,
 					"results": [
 						{"uid": "uid-1", "email": "user1@example.com", "name": "User 1"},
 						{"uid": "uid-2", "email": "user2@example.com", "name": "User 2"}
 					]
-				}`), nil
+				}`)}, nil
 			},
 		}
 
@@ -537,30 +538,30 @@ func TestService_List(t *testing.T) {
 	t.Run("successful list with pagination", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 						"count": 2,
 						"results": [
 							{"uid": "uid-1", "email": "user1@example.com", "name": "User 1"}
 						],
 						"nextPageKey": "page2"
-					}`), nil
+					}`)}, nil
 				}
 				if callCount == 2 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
 					assert.Equal(t, "page2", options.QueryParams.Get("nextPageKey"))
-					return []byte(`{
+					return api.Response{Data: []byte(`{
 					"count": 2,
 					"results": [
 						{"uid": "uid-2", "email": "user2@example.com", "name": "User 2"}
 					]
-				}`), nil
+				}`)}, nil
 				}
 				assert.FailNow(t, "unexpected call to GET")
-				return nil, errors.New("unexpected call to GET")
+				return api.Response{}, errors.New("unexpected call to GET")
 			},
 		}
 
@@ -573,8 +574,8 @@ func TestService_List(t *testing.T) {
 
 	t.Run("list fails", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("GET failed")
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("GET failed")
 			},
 		}
 
@@ -585,11 +586,11 @@ func TestService_List(t *testing.T) {
 
 	t.Run("list empty", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{
 					"count": 0,
 					"results": []
-				}`), nil
+				}`)}, nil
 			},
 		}
 
@@ -601,8 +602,8 @@ func TestService_List(t *testing.T) {
 
 	t.Run("list fails on invalid JSON response", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return []byte(`{invalid json`), nil
+			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
@@ -616,20 +617,20 @@ func TestService_Update(t *testing.T) {
 	t.Run("successful update", func(t *testing.T) {
 		putCallCount := 0
 		mockClient := &testing2.MockIAMClient{
-			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				putCallCount++
 				if putCallCount == 1 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", testAccountID, "test-uid"), url)
-					return nil, nil
+					return api.Response{}, nil
 				}
 
 				if putCallCount == 2 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", testAccountID, "test@example.com"), url)
-					return nil, nil
+					return api.Response{}, nil
 				}
 
 				assert.FailNow(t, "unexpected call to PUT")
-				return nil, errors.New("unexpected call to PUT")
+				return api.Response{}, errors.New("unexpected call to PUT")
 			},
 		}
 
@@ -648,8 +649,8 @@ func TestService_Update(t *testing.T) {
 
 	t.Run("update fails on user details", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("PUT failed")
+			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("PUT failed")
 			},
 		}
 
@@ -666,18 +667,18 @@ func TestService_Update(t *testing.T) {
 	t.Run("update fails on group assignment", func(t *testing.T) {
 		putCallCount := 0
 		mockClient := &testing2.MockIAMClient{
-			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				putCallCount++
 				if putCallCount == 1 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", testAccountID, "test-uid"), url)
-					return nil, nil
+					return api.Response{}, nil
 				}
 				if putCallCount == 2 {
 					assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", testAccountID, "test@example.com"), url)
-					return nil, errors.New("group assignment failed")
+					return api.Response{}, errors.New("group assignment failed")
 				}
 				assert.FailNow(t, "unexpected call to PUT")
-				return nil, errors.New("unexpected call to PUT")
+				return api.Response{}, errors.New("unexpected call to PUT")
 			},
 		}
 
@@ -696,9 +697,9 @@ func TestService_Update(t *testing.T) {
 func TestService_Delete(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
+			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", testAccountID, "test-uid"), url)
-				return nil, nil
+				return api.Response{}, nil
 			},
 		}
 
@@ -709,8 +710,8 @@ func TestService_Delete(t *testing.T) {
 
 	t.Run("delete fails", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("DELETE failed")
+			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("DELETE failed")
 			},
 		}
 
@@ -721,8 +722,8 @@ func TestService_Delete(t *testing.T) {
 
 	t.Run("delete errors if service user does not exist", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
-			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-				return nil, errors.New("User test-uid does not exist")
+			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+				return api.Response{}, errors.New("User test-uid does not exist")
 			},
 		}
 

--- a/dynatrace/api/iam/users/service.go
+++ b/dynatrace/api/iam/users/service.go
@@ -75,12 +75,6 @@ func (me *UserServiceClient) SchemaID() string {
 func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api.Stub, error) {
 	client := iam.NewIAMClient(ctx, me)
 	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.AccountID()), user, rest2.RequestOptions{}); err != nil {
-		if err.Error() == "User already exists" {
-			if err = me.Update(ctx, user.Email, user); err != nil {
-				return nil, err
-			}
-			return &api.Stub{ID: user.Email, Name: user.Email}, nil
-		}
 		return nil, err
 	}
 

--- a/dynatrace/api/iam/users/service.go
+++ b/dynatrace/api/iam/users/service.go
@@ -73,10 +73,8 @@ func (me *UserServiceClient) SchemaID() string {
 }
 
 func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api.Stub, error) {
-	var err error
-
 	client := iam.NewIAMClient(ctx, me)
-	if _, err = client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.AccountID()), user, rest2.RequestOptions{}, 201); err != nil {
+	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.AccountID()), user, rest2.RequestOptions{}); err != nil {
 		if err.Error() == "User already exists" {
 			if err = me.Update(ctx, user.Email, user); err != nil {
 				return nil, err
@@ -90,7 +88,7 @@ func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.AccountID(), user.Email), groups, rest2.RequestOptions{}, 200); err != nil {
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.AccountID(), user.Email), groups, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -108,26 +106,24 @@ type GetUserGroupsResponse struct {
 }
 
 func (me *UserServiceClient) Get(ctx context.Context, email string, v *users.User) error {
-	var err error
-	var responseBytes []byte
-
 	client := iam.NewIAMClient(ctx, me)
 
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.AccountID(), email), rest2.RequestOptions{}, 200); err != nil {
-		if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.AccountID(), email), rest2.RequestOptions{})
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 			return rest.Error{Code: 404, Message: err.Error()}
 		}
 		return err
 	}
 
-	var response GetUserGroupsResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	var userGroups GetUserGroupsResponse
+	if err = json.Unmarshal(response.Data, &userGroups); err != nil {
 		return err
 	}
 	v.Email = email
 	v.Groups = []string{}
-	v.UID = response.UID
-	for _, group := range response.Groups {
+	v.UID = userGroups.UID
+	for _, group := range userGroups.Groups {
 		v.Groups = append(v.Groups, group.UUID)
 	}
 
@@ -135,13 +131,11 @@ func (me *UserServiceClient) Get(ctx context.Context, email string, v *users.Use
 }
 
 func (me *UserServiceClient) Update(ctx context.Context, email string, user *users.User) error {
-	var err error
-
 	groups := []string{}
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err = iam.NewIAMClient(ctx, me).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.AccountID(), user.Email), groups, rest2.RequestOptions{}, 200); err != nil {
+	if _, err := iam.NewIAMClient(ctx, me).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.AccountID(), user.Email), groups, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -159,26 +153,24 @@ type ListUsersResponse struct {
 }
 
 func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	var err error
-	var responseBytes []byte
-
-	if responseBytes, err = iam.NewIAMClient(ctx, me).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.AccountID()), rest2.RequestOptions{}, 200); err != nil {
+	response, err := iam.NewIAMClient(ctx, me).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.AccountID()), rest2.RequestOptions{})
+	if err != nil {
 		return nil, err
 	}
 
-	var response ListUsersResponse
-	if err = json.Unmarshal(responseBytes, &response); err != nil {
+	var listResp ListUsersResponse
+	if err = json.Unmarshal(response.Data, &listResp); err != nil {
 		return nil, err
 	}
 	var stubs api.Stubs
-	for _, item := range response.Items {
+	for _, item := range listResp.Items {
 		stubs = append(stubs, &api.Stub{ID: item.Email, Name: item.Email})
 	}
 	return stubs, nil
 }
 
 func (me *UserServiceClient) Delete(ctx context.Context, email string) error {
-	_, err := iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.AccountID(), email), rest2.RequestOptions{}, 200)
+	_, err := iam.NewIAMClient(ctx, me).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.AccountID(), email), rest2.RequestOptions{})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 		return nil
 	}

--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -80,8 +80,7 @@ type PolicyCreateResponse struct {
 
 func (me *BindingServiceClient) Create(ctx context.Context, v *bindings.PolicyBinding) (*api.Stub, error) {
 	id := joinID(v)
-	var err error
-	if err = me.Update(ctx, id, v); err != nil {
+	if err := me.Update(ctx, id, v); err != nil {
 		return nil, err
 	}
 	return &api.Stub{ID: id, Name: "PolicyV2Bindings-" + id}, nil
@@ -135,12 +134,13 @@ func (me *BindingServiceClient) getGroupPolicyBindings(ctx context.Context, id s
 	client := iam.NewIAMClient(ctx, me)
 
 	var policyBindings GroupPolicyBindings
-	var responseBytes []byte
+
 	queryParams := url.Values{"details": []string{"true"}}
-	if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{QueryParams: queryParams}, 200); err != nil {
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{QueryParams: queryParams})
+	if err != nil {
 		return GroupPolicyBindings{}, err
 	}
-	if err = json.Unmarshal(responseBytes, &policyBindings); err != nil {
+	if err = json.Unmarshal(response.Data, &policyBindings); err != nil {
 		return GroupPolicyBindings{}, err
 	}
 	return policyBindings, nil
@@ -249,7 +249,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 			Metadata:   desiredPolicy.Metadata,
 			Boundaries: desiredPolicy.Boundaries,
 		}
-		if _, err = client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), payload, rest2.RequestOptions{}, 204); err != nil {
+		if _, err = client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), payload, rest2.RequestOptions{}); err != nil {
 			return err
 		}
 	}
@@ -272,21 +272,20 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 			close(results)
 		}()
 
-		var err error
-		var response ListPolicyBindingsResponse
+		var policyBindings ListPolicyBindingsResponse
 		client := iam.NewIAMClient(ctx, me)
 
-		var responseBytes []byte
-		if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.AccountID()), rest2.RequestOptions{}, 200); err != nil {
+		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.AccountID()), rest2.RequestOptions{})
+		if err != nil {
 			return
 		}
-		if err = json.Unmarshal(responseBytes, &response); err != nil {
+		if err = json.Unmarshal(response.Data, &policyBindings); err != nil {
 			return
 		}
 
 		var stubs api.Stubs
 		groupIds := map[string]bool{}
-		for _, policy := range response.PolicyBindings {
+		for _, policy := range policyBindings.PolicyBindings {
 			for _, group := range policy.Groups {
 				if _, exists := groupIds[group]; !exists {
 					id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", me.AccountID())
@@ -308,27 +307,26 @@ func (me *BindingServiceClient) FetchEnvironmentBindings(ctx context.Context) ch
 		defer func() {
 			close(results)
 		}()
-		var err error
 		client := iam.NewIAMClient(ctx, me)
 
-		var environmentIDs []string
-		if environmentIDs, err = policies.GetEnvironmentIDs(ctx, me); err != nil {
+		environmentIDs, err := policies.GetEnvironmentIDs(ctx, me)
+		if err != nil {
 			return
 		}
 
 		var stubs api.Stubs
 		for _, environmentID := range environmentIDs {
-			var response ListPolicyBindingsResponse
-			var responseBytes []byte
-			if responseBytes, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/bindings", environmentID), rest2.RequestOptions{}, 200); err != nil {
+			var policyBindings ListPolicyBindingsResponse
+			response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/bindings", environmentID), rest2.RequestOptions{})
+			if err != nil {
 				return
 			}
-			if err = json.Unmarshal(responseBytes, &response); err != nil {
+			if err = json.Unmarshal(response.Data, &policyBindings); err != nil {
 				return
 			}
 
 			groupIds := map[string]bool{}
-			for _, policy := range response.PolicyBindings {
+			for _, policy := range policyBindings.PolicyBindings {
 				for _, group := range policy.Groups {
 					if _, exists := groupIds[group]; !exists {
 						id := fmt.Sprintf("%s#-#%s#-#%s", group, "environment", environmentID)
@@ -394,7 +392,7 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 	groupBindings := groupPolicyBindingsUpdate{
 		PolicyUuids: make([]string, 0),
 	}
-	_, err = iam.NewIAMClient(ctx, me).PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), groupBindings, rest2.RequestOptions{}, 204)
+	_, err = iam.NewIAMClient(ctx, me).PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), groupBindings, rest2.RequestOptions{})
 	return err
 }
 

--- a/dynatrace/testing/mockiamclient.go
+++ b/dynatrace/testing/mockiamclient.go
@@ -20,38 +20,31 @@ import (
 	"context"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
 type MockIAMClient struct {
-	POSTFunc   func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error)
-	PUTFunc    func(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error)
-	GETFunc    func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error)
-	DELETEFunc func(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error)
+	POSTFunc   func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
+	PUTFunc    func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
+	GETFunc    func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
+	DELETEFunc func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
 }
 
-func (me *MockIAMClient) POST(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-	return me.POSTFunc(ctx, url, payload, options, expectedResponseCode)
+func (me *MockIAMClient) POST(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+	return me.POSTFunc(ctx, url, payload, options)
 }
 
-func (me *MockIAMClient) PUT(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-	return me.PUTFunc(ctx, url, payload, options, expectedResponseCode)
+func (me *MockIAMClient) PUT(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
+	return me.PUTFunc(ctx, url, payload, options)
 }
 
-func (me *MockIAMClient) PUT_MULTI_RESPONSE(ctx context.Context, url string, payload any, options rest2.RequestOptions, expectedResponseCodes []int) ([]byte, error) {
-	panic("mock doesnt support PUT_MULTI_RESPONSE")
+func (me *MockIAMClient) GET(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+	return me.GETFunc(ctx, url, options)
 }
 
-func (me *MockIAMClient) GET(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-	return me.GETFunc(ctx, url, options, expectedResponseCode)
-}
-
-func (me *MockIAMClient) DELETE(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCode int) ([]byte, error) {
-	return me.DELETEFunc(ctx, url, options, expectedResponseCode)
-}
-
-func (me *MockIAMClient) DELETE_MULTI_RESPONSE(ctx context.Context, url string, options rest2.RequestOptions, expectedResponseCodes []int) ([]byte, error) {
-	panic("mock doesnt support DELETE_MULTI_RESPONSE")
+func (me *MockIAMClient) DELETE(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
+	return me.DELETEFunc(ctx, url, options)
 }
 
 type MockIAMClientGetter struct {


### PR DESCRIPTION
#### **Why** this PR?
- The IAM client had its own response-code validation and error handling, which duplicated the standard request-processing behavior used elsewhere.
- The code was brittle when callers had to inspect specific API errors.

#### **What** has changed and **how** does it do it?
- Refactored `IAMClient` so methods return `api.Response` instead of raw response bytes, and removed the custom `handleResponse` plus the exact-status-code method parameters.
- The client now relies on `api.NewResponseFromHTTPResponse(...)` for standard success and error handling.
- Updated IAM callers to unmarshal from `response.Data` and use the simplified request interface.
- Tightened IAM-specific error handling where callers need to branch on API errors: `dynatrace/api/iam/policies/policy_level.go` now uses `coreapi.IsNotFoundError(err)` instead of string-matching `404`, and `dynatrace/api/iam/bindings/service.go` now tolerates `400 Bad Request` when deleting bindings that no longer exist.
- Removed now-unnecessary multi-response helpers and related call-site handling

#### How is it **tested**?
- Existing tests
- Updated IAM client mocks in `dynatrace/testing/mockiamclient.go`.
- Unit tests updated in `dynatrace/api/iam/boundaries/service_unit_test.go`.
- Unit tests updated in `dynatrace/api/iam/serviceusers/service_test.go`.

#### How does it affect **users**?
Error messages contain more detail. Previously:
```
╷
│ Error: API error: response code 400 (expected: [201])
│
│   with dynatrace_iam_user.user1_test_com,
│   on main.tf line 11, in resource "dynatrace_iam_user" "user1_test_com":
│   11: resource "dynatrace_iam_user" "user1_test_com" {
│
╵
```

Now:
```
╷
│ Error: API error: API request HTTP POST https://api.dynatace.com/iam/v1/accounts/12345678-1234-1234-1234-123456789012/users failed with status code 400: {"error":true,"message":"Following users: user1@test.com have already been invited into the account: 12345678-1234-1234-1234-123456789012","payload":null}
│
│   with dynatrace_iam_user.user1_test_com,
│   on main.tf line 11, in resource "dynatrace_iam_user" "user1_test_com":
│   11: resource "dynatrace_iam_user" "user1_test_com" {
│
╵
```
**Issue:** PS-45554, PS-45615
