### PR TITLE
chore: update extension examples

### DIFF
--- a/datasources/extensions/active_version/data_source_test.go
+++ b/datasources/extensions/active_version/data_source_test.go
@@ -39,7 +39,7 @@ func TestAccExtensionsActiveVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: datasourceConfig,
-				Check:  resource.TestCheckOutput("active_version", "2.1.1"),
+				Check:  resource.TestCheckOutput("active_version", "2.0.1"),
 			},
 		},
 	})

--- a/datasources/extensions/active_version/testdata/example.tf
+++ b/datasources/extensions/active_version/testdata/example.tf
@@ -1,5 +1,5 @@
 data "dynatrace_hub_extension_v2_active_version" "active_version" {
-  name = "com.dynatrace.extension.jmx-weblogic-cp"
+  name = "com.dynatrace.extension.wmi.iis"
 }
 
 output "active_version" {

--- a/datasources/extensions/latest_version/data_source_test.go
+++ b/datasources/extensions/latest_version/data_source_test.go
@@ -39,7 +39,7 @@ func TestAccExtensionsLatestVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: datasourceConfig,
-				Check:  resource.TestCheckOutput("latest_version", "2.1.1"),
+				Check:  resource.TestCheckOutput("latest_version", "2.0.1"),
 			},
 		},
 	})

--- a/datasources/extensions/latest_version/testdata/example.tf
+++ b/datasources/extensions/latest_version/testdata/example.tf
@@ -1,5 +1,5 @@
 data "dynatrace_hub_extension_v2_latest_version" "latest_version" {
-  name = "com.dynatrace.extension.jmx-weblogic-cp"
+  name = "com.dynatrace.extension.wmi.iis"
 }
 
 output "latest_version" {

--- a/dynatrace/api/extensions/monitoringconfigurations/testcases/recreate-scope-change/create.tf
+++ b/dynatrace/api/extensions/monitoringconfigurations/testcases/recreate-scope-change/create.tf
@@ -1,18 +1,17 @@
 resource "dynatrace_hub_extension_v2_config" "config" {
-  name  = "com.dynatrace.extension.jmx-weblogic-cp"
+  name  = "com.dynatrace.extension.wmi.iis"
   scope = "environment"
   value = jsonencode(
     {
-      "activationContext" : "LOCAL",
-      "activationTags" : [],
       "enabled" : true,
-      "description" : "jj",
-      "version" : "2.1.1",
+      "description" : "my description",
+      "version" : "1.1.1",
       "featureSets" : [
-        "cache",
-        "connections",
-        "capacity"
-      ]
+        "IIS Extended Request Metrics"
+      ],
+      "vars" : {},
+      "activationContext" : "LOCAL",
+      "activationTags" : []
     }
   )
 }

--- a/dynatrace/api/extensions/monitoringconfigurations/testcases/recreate-scope-change/update.tf
+++ b/dynatrace/api/extensions/monitoringconfigurations/testcases/recreate-scope-change/update.tf
@@ -3,20 +3,19 @@ data "dynatrace_entities" "hosts" {
 }
 
 resource "dynatrace_hub_extension_v2_config" "config" {
-  name  = "com.dynatrace.extension.jmx-weblogic-cp"
+  name  = "com.dynatrace.extension.wmi.iis"
   scope = data.dynatrace_entities.hosts.entities[0].entity_id // update with HOST-... instead of "environment"
   value = jsonencode(
     {
-      "activationContext" : "LOCAL",
-      "activationTags" : [],
       "enabled" : true,
-      "description" : "jj",
-      "version" : "2.1.1",
+      "description" : "my description",
+      "version" : "1.1.1",
       "featureSets" : [
-        "cache",
-        "connections",
-        "capacity"
-      ]
+        "IIS Extended Request Metrics"
+      ],
+      "vars" : {},
+      "activationContext" : "LOCAL",
+      "activationTags" : []
     }
   )
 }

--- a/dynatrace/api/extensions/monitoringconfigurations/testcases/update-no-recreate/create.tf
+++ b/dynatrace/api/extensions/monitoringconfigurations/testcases/update-no-recreate/create.tf
@@ -1,18 +1,17 @@
 resource "dynatrace_hub_extension_v2_config" "config" {
-  name  = "com.dynatrace.extension.jmx-weblogic-cp"
+  name  = "com.dynatrace.extension.wmi.iis"
   scope = "environment"
   value = jsonencode(
     {
-      "activationContext" : "LOCAL",
-      "activationTags" : [],
       "enabled" : true,
-      "description" : "jj",
-      "version" : "2.0.4",
+      "description" : "my description",
+      "version" : "1.1.1",
       "featureSets" : [
-        "cache",
-        "connections",
-        "capacity"
-      ]
+        "IIS Extended Request Metrics"
+      ],
+      "vars" : {},
+      "activationContext" : "LOCAL",
+      "activationTags" : []
     }
   )
 }

--- a/dynatrace/api/extensions/monitoringconfigurations/testcases/update-no-recreate/update.tf
+++ b/dynatrace/api/extensions/monitoringconfigurations/testcases/update-no-recreate/update.tf
@@ -1,18 +1,20 @@
 resource "dynatrace_hub_extension_v2_config" "config" {
-  name  = "com.dynatrace.extension.jmx-weblogic-cp"
+  name  = "com.dynatrace.extension.wmi.iis"
   scope = "environment"
   value = jsonencode(
     {
-      "activationContext" : "LOCAL",
-      "activationTags" : [],
       "enabled" : true,
       "description" : "update",
-      "version" : "2.1.1", // version and description update
+      "version" : "2.0.1", // version and description update
       "featureSets" : [
-        "cache",
-        "connections",
-        "capacity"
-      ]
+        "IIS Extended Request Metrics"
+      ],
+      "vars" : {
+        iis_app_pool = "Name != '_Total'"
+        iis_site     = "Name != '_Total'"
+      },
+      "activationContext" : "LOCAL",
+      "activationTags" : []
     }
   )
 }

--- a/dynatrace/api/extensions/monitoringconfigurations/testdata/terraform/withscope.tf
+++ b/dynatrace/api/extensions/monitoringconfigurations/testdata/terraform/withscope.tf
@@ -2,21 +2,20 @@ data "dynatrace_entities" "hosts" {
   type = "HOST"
 }
 
-resource "dynatrace_hub_extension_v2_config" "com_dynatrace_extension_jmx-weblogic-cp" {
-  name  = "com.dynatrace.extension.jmx-weblogic-cp"
+resource "dynatrace_hub_extension_v2_config" "com_dynatrace_extension_wmi_iis" {
+  name = "com.dynatrace.extension.wmi.iis"
   scope = data.dynatrace_entities.hosts.entities[0].entity_id // or "environment"
   value = jsonencode(
     {
-      "activationContext" : "LOCAL",
-      "activationTags" : [],
-      "enabled" : true,
-      "description" : "my description",
-      "version" : "2.1.1",
-      "featureSets" : [
-        "cache",
-        "connections",
-        "capacity"
-      ]
+      "enabled": true,
+      "description": "my description",
+      "version": "1.1.1",
+      "featureSets": [
+        "IIS Extended Request Metrics"
+      ],
+      "vars": {},
+      "activationContext": "LOCAL",
+      "activationTags": []
     }
   )
 }

--- a/dynatrace/api/v2/hub/extension/active_version/testdata/terraform/example-a.tf
+++ b/dynatrace/api/v2/hub/extension/active_version/testdata/terraform/example-a.tf
@@ -1,4 +1,4 @@
-resource "dynatrace_hub_extension_active_version" "jmx-weblogic-cp" {
-  name    = "com.dynatrace.extension.jmx-weblogic-cp"
-  version = "2.1.1"
+resource "dynatrace_hub_extension_active_version" "com_dynatrace_extension_wmi_iis" {
+  name    = "com.dynatrace.extension.wmi.iis"
+  version = "2.0.1"
 }

--- a/dynatrace/api/v2/hub/extension/config/testdata/terraform/noscope.tf
+++ b/dynatrace/api/v2/hub/extension/config/testdata/terraform/noscope.tf
@@ -1,17 +1,16 @@
-resource "dynatrace_hub_extension_config" "com_dynatrace_extension_jmx-weblogic-cp" {
-  name = "com.dynatrace.extension.jmx-weblogic-cp"
+resource "dynatrace_hub_extension_config" "com_dynatrace_extension_wmi_iis" {
+  name = "com.dynatrace.extension.wmi.iis"
   value = jsonencode(
     {
-      "activationContext": "LOCAL",
-      "activationTags": [],
       "enabled" : true,
-      "description" : "jj",
-      "version" : "2.0.4",
+      "description" : "my description",
+      "version" : "1.1.1",
       "featureSets" : [
-        "cache",
-        "connections",
-        "capacity"
-      ]
+        "IIS Extended Request Metrics"
+      ],
+      "vars" : {},
+      "activationContext" : "LOCAL",
+      "activationTags" : []
     }
   )
 }

--- a/dynatrace/api/v2/hub/extension/config/testdata/terraform/withscope.tf
+++ b/dynatrace/api/v2/hub/extension/config/testdata/terraform/withscope.tf
@@ -1,18 +1,17 @@
-resource "dynatrace_hub_extension_config" "com_dynatrace_extension_jmx-weblogic-cp" {
-  name = "com.dynatrace.extension.jmx-weblogic-cp"
+resource "dynatrace_hub_extension_config" "com_dynatrace_extension_wmi_iis" {
+  name  = "com.dynatrace.extension.wmi.iis"
   scope = "environment"
-    value = jsonencode(
+  value = jsonencode(
     {
-      "activationContext": "LOCAL",
-      "activationTags": [],
       "enabled" : true,
-      "description" : "jj",
-      "version" : "2.0.4",
+      "description" : "my description",
+      "version" : "1.1.1",
       "featureSets" : [
-        "cache",
-        "connections",
-        "capacity"
-      ]
+        "IIS Extended Request Metrics"
+      ],
+      "vars" : {},
+      "activationContext" : "LOCAL",
+      "activationTags" : []
     }
   )
 }


### PR DESCRIPTION
#### **Why** this PR?
Changing the extension examples to a different generic one.

#### **What** has changed?
Instead of using `com.dynatrace.extension.jmx-weblogic-cp` they now use `com.dynatrace.extension.wmi.iis`

#### **How** does it do it?
By using `com.dynatrace.extension.wmi.iis` and its correct payload.

#### How is it **tested**?
Tests are updated to `com.dynatrace.extension.wmi.iis`

#### How does it affect **users**?
N/A

**Issue:** PS-45596