### PR TITLE
test: add Go tags for different use cases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,7 @@ jobs:
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
           TF_VAR_DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT: ${{ secrets.DT_GCP_TEST_UNIMPERSONABLE_SERVICE_ACCOUNT }}
           TF_VAR_DT_GCP_TEST_IMPERSONABLE_SERVICE_ACCOUNT: ${{ secrets.DT_GCP_TEST_IMPERSONABLE_SERVICE_ACCOUNT }}
-        run: go test -tags=integration -v -p 1 ${{ matrix.config.path }}
+        run: go test -tags="integration monitored connector" -v -p 1 ${{ matrix.config.path }}
 
   sequential-integration-tests:
     name: Sequential Integration Tests
@@ -205,7 +205,7 @@ jobs:
           DT_CLIENT_ID: ${{ secrets.DT_CLIENT_ID }}
           DT_CLIENT_SECRET: ${{ secrets.DT_CLIENT_SECRET }}
           DT_ACCOUNT_ID: ${{ secrets.DT_ACCOUNT_ID }}
-        run: go test -tags=sequential_integration -v -p 1 ./...
+        run: go test -tags="sequential_integration monitored" -v -p 1 ./...
 
   sonar_scan:
     name: SonarQube lint and test coverage

--- a/dynatrace/api/builtin/alerting/connectivityalerts/service_test.go
+++ b/dynatrace/api/builtin/alerting/connectivityalerts/service_test.go
@@ -1,4 +1,4 @@
-//go:build sequential_integration
+//go:build sequential_integration && monitored
 
 /**
 * @license

--- a/dynatrace/api/builtin/availability/processgroupalerting/service_test.go
+++ b/dynatrace/api/builtin/availability/processgroupalerting/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && monitored
 
 /**
 * @license

--- a/dynatrace/api/builtin/devobs/agentoptin/service_test.go
+++ b/dynatrace/api/builtin/devobs/agentoptin/service_test.go
@@ -1,4 +1,4 @@
-//go:build sequential_integration
+//go:build sequential_integration && monitored
 
 /**
 * @license

--- a/dynatrace/api/builtin/host/monitoring/mode/service_test.go
+++ b/dynatrace/api/builtin/host/monitoring/mode/service_test.go
@@ -1,4 +1,4 @@
-//go:build sequential_integration
+//go:build sequential_integration && monitored
 
 /**
 * @license

--- a/dynatrace/api/builtin/host/processgroups/monitoringstate/service_test.go
+++ b/dynatrace/api/builtin/host/processgroups/monitoringstate/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && monitored
 
 /**
 * @license

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/bizevents/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/davis/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/davis/problems/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/logs/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/metrics/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/security/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/spans/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/system/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/user/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/usersessions/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/processgroup/monitoring/state/service_test.go
+++ b/dynatrace/api/builtin/processgroup/monitoring/state/service_test.go
@@ -1,4 +1,4 @@
-//go:build sequential_integration
+//go:build sequential_integration && monitored
 
 /**
 * @license

--- a/dynatrace/api/builtin/rum/processgroup/service_test.go
+++ b/dynatrace/api/builtin/rum/processgroup/service_test.go
@@ -1,4 +1,4 @@
-//go:build sequential_integration
+//go:build sequential_integration && monitored
 
 /**
 * @license

--- a/dynatrace/api/extensions/monitoringconfigurations/service_test.go
+++ b/dynatrace/api/extensions/monitoringconfigurations/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && monitored
 
 /*
  * @license

--- a/dynatrace/api/v1/config/anomalies/processgroups/service_test.go
+++ b/dynatrace/api/v1/config/anomalies/processgroups/service_test.go
@@ -1,4 +1,4 @@
-//go:build sequential_integration
+//go:build sequential_integration && monitored
 
 /**
 * @license

--- a/dynatrace/api/v1/config/metrics/calculated/web/service_test.go
+++ b/dynatrace/api/v1/config/metrics/calculated/web/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && monitored
 
 /**
 * @license


### PR DESCRIPTION
#### **Why** this PR?
Some tests won't work in every environment. Without additional setup, a lot of tests will fail.

#### **What** has changed?
New tags introduced `monitored` and `connector`. With that, all tests that require an additional setup (e.g., OneAgent or GCP connection) can be excluded.

#### **How** does it do it?
Adds two test tags for related tests
- connector: If there is a connector in use like GCP, where we need an additional setup (e.g., on GCP side)
- monitored: If the environment needs to have hosts or process groups for a test to work (some resources require them)

Also `connector` and `monitored` are only executed if the `integration`/`sequential_integration` tag is set.

#### How is it **tested**?
Tests are still executed

#### How does it affect **users**?
N/A

**Issue:** PS-45596
