### PR TITLE
feat: update dynatrace_browser_monitor default value

### DIFF
--- a/dynatrace/api/v1/config/synthetic/monitors/browser/settings/script_config.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/settings/script_config.go
@@ -57,6 +57,7 @@ func (me *ScriptConfig) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "Capture performance metrics for pages loaded in frames",
 			Optional:    true,
+			Default:     true,
 		},
 		"user_agent": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
#### **Why** this PR?
The API for the browser monitor changed. For `script.configuration.monitor_frames` it now sets a default of `true` if not given, which leads to a non-empty plan in TF now.

#### **What** has changed?
Non-empty plan again

#### **How** does it do it?
Updates the default value of script.configuration.monitor_frames to `true` to align with the API

#### How is it **tested**?
Tests are working again

#### How does it affect **users**?
They will get an empty plan after the creation of a browser monitor

**Issue:** NOISSUE
