### PR TITLE
fix(document): Export should not include unsupported document types or ready-made documents

### DIFF
--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -20,6 +20,7 @@ package documents
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
@@ -32,10 +33,15 @@ import (
 	documents "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/document/settings"
 )
 
+var supportedDocumentTypes = []docclient.DocumentType{
+	docclient.Dashboard,
+	docclient.Notebook,
+	docclient.Launchpad,
+}
+
 func Service(credentials *rest.Credentials) settings.CRUDService[*documents.Document] {
 	return &service{credentials}
 }
-
 
 type service struct {
 	credentials *rest.Credentials
@@ -106,7 +112,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	if cl == nil {
 		return api.Stubs{}, nil
 	}
-	listResponse, err := cl.List(ctx, "")
+	listResponse, err := cl.List(ctx, getSupportedDocumentsFilter())
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +122,26 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 
 	return stubs, nil
+}
+
+// getSupportedDocumentsFilter returns a filter string for supported documents, those of known types and not created by apps or extensions.
+func getSupportedDocumentsFilter() string {
+	filterBuilder := strings.Builder{}
+
+	// exclude readmade documents created by apps or extensions
+	filterBuilder.WriteString("not (originAppId exists) and not (originExtensionId exists) and ")
+
+	// add filter for the supported document types
+	filterBuilder.WriteString("type in (")
+	for i, documentType := range supportedDocumentTypes {
+		if i > 0 {
+			filterBuilder.WriteString(", ")
+		}
+		filterBuilder.WriteString(fmt.Sprintf("'%s'", documentType))
+	}
+	filterBuilder.WriteString(")")
+
+	return filterBuilder.String()
 }
 
 func (me *service) Validate(_ *documents.Document) error {

--- a/dynatrace/api/documents/document/service_unit_test.go
+++ b/dynatrace/api/documents/document/service_unit_test.go
@@ -1,0 +1,32 @@
+//go:build unit
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package documents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetSupportedDocumentsFilter tests that the getSupportedDocumentsFilter function returns a filter less than or equal to 1024 characters in length.
+func TestGetSupportedDocumentsFilter(t *testing.T) {
+	filter := getSupportedDocumentsFilter()
+	assert.LessOrEqual(t, len(filter), 1024, "supported documents filter string is longer than 1024 characters")
+}


### PR DESCRIPTION
#### **Why** this PR?
Document export currently includes unsupported document types and ready-made documents created by apps or extensions, which can produce exports that the provider cannot manage correctly.

#### **What** has changed and **how** does it do it?
In `dynatrace/api/documents/document/service.go`, `List` now requests only supported document types by passing a filter from `getSupportedDocumentsFilter()` to the document client. The filter restricts results to `dashboard`, `notebook`, and `launchpad` document types and skips documents created by apps or extensions.

#### How is it **tested**?
- Manual test of export functionality for documents; E2E tests don't cover export.
- A unit test is added for `getSupportedDocumentsFilter()` to ensure it doesn't exceed the maximum filter length.

#### How does it affect **users**?
Users exporting documents will no longer get unsupported or ready-made documents in the exported configurations.

**Issue:** PS-46499
