### PR TITLE
doc(document): Clarify that ready-made documents are excluded from export

### DIFF
--- a/templates/resources/document.md.tmpl
+++ b/templates/resources/document.md.tmpl
@@ -3,7 +3,7 @@ layout: ""
 page_title: "{{.Type}} - {{.ProviderName}}"
 subcategory: "Documents"
 description: |-
-  The resource `{{ .Name }}` covers configuration of Documents (dashboards and notebooks) in Dynatrace.
+  The resource `{{ .Name }}` covers configuration of Documents (dashboards, notebooks and launchpads) in Dynatrace.
 ---
 
 # {{ .Name }} ({{.Type}})
@@ -12,7 +12,7 @@ description: |-
 
 -> To utilize this resource, please define the environment variables `DT_CLIENT_ID`, `DT_CLIENT_SECRET`, `DT_ACCOUNT_ID` with an OAuth client including the following permissions: **Create and edit documents** (`document:documents:write`), **View documents** (`document:documents:read`), **Delete documents** (`document:documents:delete`), and  **Delete documents from trash** (`document:trash.documents:delete`).
 
--> This resource is excluded by default in the export utility, please explicitly specify the resource to retrieve existing configuration.
+-> This resource is excluded by default in the export utility, please explicitly specify the resource to retrieve existing documents. Ready-made documents, created and automatically distributed by Dynatrace as examples and templates, are excluded and cannot be managed by Terraform.
 
 ## Dynatrace Documentation
 


### PR DESCRIPTION
#### **Why** this PR?
The documentation should mention that ready-made documents are excluded from export and cannot be managed by Terraform.

#### **What** has changed and **How** does it do it?
Documentation update.

#### How is it **tested**?
NA

#### How does it affect **users**?
They will understand that ready-made documents are excluded from export.

**Issue:** PS-46499
