### PR TITLE
chore: removed deprecated "DA" and "NONE" consumers

### DIFF
--- a/docs/resources/aws_connection.md
+++ b/docs/resources/aws_connection.md
@@ -116,7 +116,7 @@ resource "dynatrace_aws_connection_role_arn" "test-aws-connection-arn" {
 
 Optional:
 
-- `consumers` (Set of String) Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
+- `consumers` (Set of String) Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
 
 
 <a id="nestedblock--web_identity"></a>

--- a/docs/resources/azure_connection.md
+++ b/docs/resources/azure_connection.md
@@ -85,7 +85,7 @@ resource "dynatrace_azure_connection" "example" {
     application_id = azuread_application_registration.example.client_id
     directory_id   = var.azure_tenant_id
     consumers = [
-      "DA"
+      "SVC:com.dynatrace.da"
     ]
   }
 }
@@ -186,7 +186,7 @@ Required:
 
 Optional:
 
-- `consumers` (List of String) Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.da`
+- `consumers` (List of String) Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.da`
 
 
 <a id="nestedblock--federated_identity_credential"></a>
@@ -194,7 +194,7 @@ Optional:
 
 Optional:
 
-- `consumers` (List of String) Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
+- `consumers` (List of String) Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
 
 
 <a id="nestedblock--timeouts"></a>

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/schema.json
@@ -20,10 +20,6 @@
 			"documentation": "",
 			"items": [
 				{
-					"displayName": "(Deprecated) Data Acquisition",
-					"value": "DA"
-				},
-				{
 					"displayName": "Data Acquisition",
 					"value": "SVC:com.dynatrace.da"
 				},
@@ -38,10 +34,6 @@
 				{
 					"displayName": "Grail",
 					"value": "SVC:com.dynatrace.grail"
-				},
-				{
-					"displayName": "None",
-					"value": "NONE"
 				}
 			],
 			"type": "enum"

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/aws_role_based_authentication_config.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/aws_role_based_authentication_config.go
@@ -23,7 +23,7 @@ import (
 )
 
 type AwsRoleBasedAuthenticationConfig struct {
-	Consumers []ConsumersOfAwsRoleBasedAuthentication `json:"consumers"` // Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
+	Consumers []ConsumersOfAwsRoleBasedAuthentication `json:"consumers"` // Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
 	RoleArn   string                                  `json:"roleArn"`   // The ARN of the AWS role that should be assumed
 }
 
@@ -37,7 +37,7 @@ func (me *AwsRoleBasedAuthenticationConfig) Schema() map[string]*schema.Schema {
 		// },
 		"consumers": {
 			Type:        schema.TypeSet,
-			Description: "Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`",
+			Description: "Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			MinItems:    1,

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/enums.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/enums.go
@@ -27,8 +27,6 @@ var ConsumersOfAwsRoleBasedAuthentications = struct {
 	SvcComDynatraceGrail        ConsumersOfAwsRoleBasedAuthentication
 	SvcComDynatraceOpenpipeline ConsumersOfAwsRoleBasedAuthentication
 }{
-	"DA",
-	"NONE",
 	"SVC:com.dynatrace.bo",
 	"SVC:com.dynatrace.da",
 	"SVC:com.dynatrace.grail",

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/authentication/service_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/authentication/service_test.go
@@ -58,7 +58,7 @@ func TestService_List(t *testing.T) {
 
 		mockConn1 := &azure.Settings{
 			Type:                        azure.Types.Federatedidentitycredential,
-			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"DA"}},
+			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"SVC:com.dynatrace.da"}},
 			Name:                        "Federated Identity Credential Connection 1",
 		}
 
@@ -70,7 +70,7 @@ func TestService_List(t *testing.T) {
 
 		mockConn3 := &azure.Settings{
 			Type:                        azure.Types.Federatedidentitycredential,
-			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"DA"}},
+			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"SVC:com.dynatrace.da"}},
 			Name:                        "Federated Identity Credential Connection 2",
 		}
 
@@ -149,7 +149,7 @@ func TestService_Get(t *testing.T) {
 
 		mockConn := &azure.Settings{
 			Type:                        azure.Types.Federatedidentitycredential,
-			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"DA"}},
+			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"SVC:com.dynatrace.da"}},
 			Name:                        "Federated Identity Credential Connection 2",
 		}
 
@@ -220,7 +220,7 @@ func TestService_Create(t *testing.T) {
 	t.Run("success configuring federated identity credentials", func(t *testing.T) {
 		mockConn := &azure.Settings{
 			Type:                        azure.Types.Federatedidentitycredential,
-			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"DA"}},
+			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"SVC:com.dynatrace.da"}},
 			Name:                        name,
 		}
 		mock := &mockCRUDService{
@@ -269,7 +269,7 @@ func TestService_Create(t *testing.T) {
 	t.Run("federated identity credentials already set", func(t *testing.T) {
 		mockConn := &azure.Settings{
 			Type:                        azure.Types.Federatedidentitycredential,
-			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"DA"}, ApplicationID: &applicationID, DirectoryID: &directoryID},
+			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"SVC:com.dynatrace.da"}, ApplicationID: &applicationID, DirectoryID: &directoryID},
 			Name:                        name,
 		}
 		mock := &mockCRUDService{
@@ -292,7 +292,7 @@ func TestService_Create(t *testing.T) {
 	t.Run("federated identity credentials already set but equal", func(t *testing.T) {
 		mockConn := &azure.Settings{
 			Type:                        azure.Types.Federatedidentitycredential,
-			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"DA"}, ApplicationID: &applicationID, DirectoryID: &directoryID},
+			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"SVC:com.dynatrace.da"}, ApplicationID: &applicationID, DirectoryID: &directoryID},
 			Name:                        name,
 		}
 		mock := &mockCRUDService{
@@ -328,7 +328,7 @@ func TestService_Create(t *testing.T) {
 	t.Run("connService.Update error", func(t *testing.T) {
 		mockConn := &azure.Settings{
 			Type:                        azure.Types.Federatedidentitycredential,
-			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"DA"}},
+			FederatedIdentityCredential: &azure.FederatedIdentityCredential{Consumers: []azure.ConsumersOfFederatedIdentityCredential{"SVC:com.dynatrace.da"}},
 			Name:                        name,
 		}
 		mock := &mockCRUDService{

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/schema.json
@@ -20,16 +20,8 @@
 			"documentation": "",
 			"items": [
 				{
-					"displayName": "(Deprecated) Data Acquisition",
-					"value": "DA"
-				},
-				{
 					"displayName": "Data Acquisition",
 					"value": "SVC:com.dynatrace.da"
-				},
-				{
-					"displayName": "None",
-					"value": "NONE"
 				}
 			],
 			"type": "enum"
@@ -39,10 +31,6 @@
 			"displayName": "Consumers",
 			"documentation": "",
 			"items": [
-				{
-					"displayName": "(Deprecated) Data Acquisition",
-					"value": "DA"
-				},
 				{
 					"displayName": "Data Acquisition",
 					"value": "SVC:com.dynatrace.da"
@@ -62,10 +50,6 @@
 				{
 					"displayName": "Business Observability",
 					"value": "SVC:com.dynatrace.bo"
-				},
-				{
-					"displayName": "None",
-					"value": "NONE"
 				}
 			],
 			"type": "enum"

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/client_secret_config.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/client_secret_config.go
@@ -25,7 +25,7 @@ import (
 type ClientSecretConfig struct {
 	ApplicationID string                    `json:"applicationId"`       // Application (client) ID of your app registered in Microsoft Azure App registrations
 	ClientSecret  string                    `json:"clientSecret"`        // Client secret of your app registered in Microsoft Azure App registrations
-	Consumers     []ConsumersOfClientSecret `json:"consumers,omitempty"` // Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.da`
+	Consumers     []ConsumersOfClientSecret `json:"consumers,omitempty"` // Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.da`
 	DirectoryID   string                    `json:"directoryId"`         // Directory (tenant) ID of Microsoft Entra ID
 }
 
@@ -45,7 +45,7 @@ func (me *ClientSecretConfig) Schema() map[string]*schema.Schema {
 		},
 		"consumers": {
 			Type:        schema.TypeList,
-			Description: "Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.da`",
+			Description: "Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.da`",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			ForceNew:    true,

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/enums.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/enums.go
@@ -24,8 +24,6 @@ var ConsumersOfClientSecrets = struct {
 	None              ConsumersOfClientSecret
 	SvcComDynatraceDa ConsumersOfClientSecret
 }{
-	"DA",
-	"NONE",
 	"SVC:com.dynatrace.da",
 }
 
@@ -41,8 +39,6 @@ var ConsumersOfFederatedIdentityCredentials = struct {
 	SvcComDynatraceOpenpipeline         ConsumersOfFederatedIdentityCredential
 }{
 	"APP:dynatrace.microsoft.azure.connector",
-	"DA",
-	"NONE",
 	"SVC:com.dynatrace.bo",
 	"SVC:com.dynatrace.da",
 	"SVC:com.dynatrace.grail",

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/federated_identity_credential.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/federated_identity_credential.go
@@ -24,7 +24,7 @@ import (
 
 type FederatedIdentityCredential struct {
 	ApplicationID *string                                  `json:"applicationId,omitempty"` // Application (client) ID of your app registered in Microsoft Azure App registrations
-	Consumers     []ConsumersOfFederatedIdentityCredential `json:"consumers,omitempty"`     // Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
+	Consumers     []ConsumersOfFederatedIdentityCredential `json:"consumers,omitempty"`     // Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
 	DirectoryID   *string                                  `json:"directoryId,omitempty"`   // Directory (tenant) ID of Microsoft Entra ID
 }
 
@@ -32,7 +32,7 @@ func (me *FederatedIdentityCredential) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"consumers": {
 			Type:        schema.TypeList,
-			Description: "Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`",
+			Description: "Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			ForceNew:    true,

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/terraform/azure_connector_client_secret.tf
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/terraform/azure_connector_client_secret.tf
@@ -36,7 +36,7 @@ resource "dynatrace_azure_connection" "example" {
     application_id = azuread_application_registration.example.client_id
     directory_id   = var.azure_tenant_id
     consumers = [
-      "DA"
+      "SVC:com.dynatrace.da"
     ]
   }
 }


### PR DESCRIPTION
#### **Why** this PR?

"DA" and "NONE" consumers have been removed from the original schema.

#### **What** has changed?

"DA" and "NONE" consumers have been removed.
