### PR TITLE
refactor: Align clients

### DIFF
--- a/dynatrace/api/iam/iam_client.go
+++ b/dynatrace/api/iam/iam_client.go
@@ -51,6 +51,8 @@ type iamClient struct {
 }
 
 func NewIAMClient(ctx context.Context, a Authenticator) IAMClient {
+	rest.PreRequest()
+
 	oauthConfig := clientcredentials.Config{
 		ClientID:     a.ClientID(),
 		ClientSecret: a.ClientSecret(),

--- a/dynatrace/api/iam/iam_client.go
+++ b/dynatrace/api/iam/iam_client.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
@@ -32,8 +31,8 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/auth"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 )
 
 // IAMClient performs HTTP requests against the IAM REST API. Each method returns an api.Response
@@ -57,23 +56,23 @@ func NewIAMClient(ctx context.Context, a Authenticator) IAMClient {
 		ClientSecret: a.ClientSecret(),
 		TokenURL:     a.TokenURL(),
 	}
-	httpClient := auth.NewOAuthClient(rest.NewContextWithOAuthRetryClient(ctx), &oauthConfig)
 
-	opts := []rest2.Option{
-		rest2.WithHTTPListener(logging.HTTPListener("iam")),
-		rest2.WithRateLimiter(),
-		rest2.WithRetryOptions(&rest2.RetryOptions{
+	client, _ := clients.Factory().
+		WithHTTPListener(logging.HTTPListener("iam")).
+		WithOAuthCredentials(oauthConfig).
+		WithUserAgent(version.UserAgent()).
+		WithRateLimiter(true).
+		WithRetryOptions(&rest2.RetryOptions{
 			DelayAfterRetry: time.Second * 60,
 			MaxRetries:      10,
 			ShouldRetryFunc: func(resp *http.Response) bool {
 				return rest2.RetryIfTooManyRequestsOrServiceUnavailable(resp) || resp.StatusCode == http.StatusBadGateway || resp.StatusCode == http.StatusGatewayTimeout
 			},
-		}),
-	}
-	eUrl, _ := url.Parse(a.EndpointURL())
-	client := rest2.NewClient(eUrl, httpClient, opts...)
-	client.SetHeader("User-Agent", version.UserAgent())
-	return &iamClient{a, client}
+		}).
+		WithAccountURL(a.EndpointURL()).
+		AccountRestClient(rest.NewContextWithOAuthRetryClient(ctx))
+
+	return &iamClient{auth: a, client: client}
 }
 
 func (me *iamClient) POST(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
@@ -86,7 +85,6 @@ func (me *iamClient) POST(ctx context.Context, url string, payload any, options 
 		return api.Response{}, err
 	}
 	return api.NewResponseFromHTTPResponse(httpResponse)
-
 }
 
 func (me *iamClient) PUT(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
@@ -115,7 +116,7 @@ var classicClientCache = map[string]*rest.Client{}
 
 var classicClientCacheMutex sync.Mutex
 
-func CreateClassicClient(classicURL string, apiToken string) (*rest.Client, error) {
+func createClassicClient(classicURL string, apiToken string) (*rest.Client, error) {
 	if classicURL == "" {
 		// sanity check - this should not be empty anymore at this point
 		return nil, NoClassicURLDefinedErr
@@ -153,9 +154,9 @@ func (me *classic_request) Finish(optionalTarget ...any) error {
 
 	PreRequest()
 
-	classicURL := request(*me).evalClassicURL()
+	classicURL := evalClassicURL(me.client.Credentials().URL)
 
-	client, err := CreateClassicClient(classicURL, me.client.Credentials().Token)
+	client, err := createClassicClient(classicURL, me.client.Credentials().Token)
 	if err != nil {
 		return err
 	}
@@ -169,4 +170,15 @@ func (me *classic_request) Finish(optionalTarget ...any) error {
 	}
 
 	return request(*me).HandleResponse(client, pathURL, target)
+}
+
+func evalClassicURL(envURL string) string {
+	envURL = strings.TrimSuffix(strings.TrimSpace(envURL), "/")
+	if len(envURL) == 0 {
+		return envURL
+	}
+	envURL = strings.ReplaceAll(envURL, ".dev.apps.dynatracelabs.", ".dev.dynatracelabs.")
+	envURL = strings.ReplaceAll(envURL, ".sprint.apps.dynatracelabs.", ".sprint.dynatracelabs.")
+	envURL = strings.ReplaceAll(envURL, ".apps.dynatrace.", ".live.dynatrace.")
+	return envURL
 }

--- a/dynatrace/rest/cluster_v1_client.go
+++ b/dynatrace/rest/cluster_v1_client.go
@@ -56,7 +56,7 @@ func (me *cluster_v1_client) Get(ctx context.Context, url string, expectedStatus
 }
 
 func (me *cluster_v1_client) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &cluster_v1_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: Headers.ContentType.ApplicationJSON}
+	req := &cluster_v1_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: headers.ContentType.ApplicationJSON}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -64,7 +64,7 @@ func (me *cluster_v1_client) Post(ctx context.Context, url string, payload any, 
 }
 
 func (me *cluster_v1_client) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &cluster_v1_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: Headers.ContentType.ApplicationJSON}
+	req := &cluster_v1_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: headers.ContentType.ApplicationJSON}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -85,7 +85,7 @@ var clusterV1ClientCache = map[string]*rest.Client{}
 
 var clusterV1ClientCacheMutex sync.Mutex
 
-func clusterV1Client(baseURL string, apiToken string) (*rest.Client, error) {
+func createClusterV1Client(baseURL string, apiToken string) (*rest.Client, error) {
 	clusterV1ClientCacheMutex.Lock()
 	defer clusterV1ClientCacheMutex.Unlock()
 
@@ -118,7 +118,7 @@ func (me *cluster_v1_request) Finish(optionalTarget ...any) error {
 
 	clusterURL := strings.TrimSuffix(me.client.Credentials().Cluster.URL, "/") + "/api/v1.0/onpremise"
 
-	client, err := clusterV1Client(clusterURL, me.client.Credentials().Cluster.Token)
+	client, err := createClusterV1Client(clusterURL, me.client.Credentials().Cluster.Token)
 	if err != nil {
 		return err
 	}

--- a/dynatrace/rest/cluster_v2_client.go
+++ b/dynatrace/rest/cluster_v2_client.go
@@ -56,7 +56,7 @@ func (me *cluster_v2_client) Get(ctx context.Context, url string, expectedStatus
 }
 
 func (me *cluster_v2_client) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &cluster_v2_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: Headers.ContentType.ApplicationJSON}
+	req := &cluster_v2_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: headers.ContentType.ApplicationJSON}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -64,7 +64,7 @@ func (me *cluster_v2_client) Post(ctx context.Context, url string, payload any, 
 }
 
 func (me *cluster_v2_client) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &cluster_v2_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: Headers.ContentType.ApplicationJSON}
+	req := &cluster_v2_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: headers.ContentType.ApplicationJSON}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -85,7 +85,7 @@ var clusterV2ClientCache = map[string]*rest.Client{}
 
 var clusterV2ClientCacheMutex sync.Mutex
 
-func clusterV2Client(baseURL string, apiToken string) (*rest.Client, error) {
+func createClusterV2Client(baseURL string, apiToken string) (*rest.Client, error) {
 	clusterV2ClientCacheMutex.Lock()
 	defer clusterV2ClientCacheMutex.Unlock()
 
@@ -118,7 +118,7 @@ func (me *cluster_v2_request) Finish(optionalTarget ...any) error {
 
 	clusterV2URL := strings.TrimSuffix(me.client.Credentials().Cluster.URL, "/") + "/api/cluster/v2"
 
-	client, err := clusterV2Client(clusterV2URL, me.client.Credentials().Cluster.Token)
+	client, err := createClusterV2Client(clusterV2URL, me.client.Credentials().Cluster.Token)
 	if err != nil {
 		return err
 	}

--- a/dynatrace/rest/hybrid_client.go
+++ b/dynatrace/rest/hybrid_client.go
@@ -48,7 +48,7 @@ func (me *hybrid_client) Get(ctx context.Context, url string, expectedStatusCode
 }
 
 func (me *hybrid_client) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &hybrid_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: Headers.ContentType.ApplicationJSON}
+	req := &hybrid_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: headers.ContentType.ApplicationJSON}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -56,7 +56,7 @@ func (me *hybrid_client) Post(ctx context.Context, url string, payload any, expe
 }
 
 func (me *hybrid_client) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &hybrid_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: Headers.ContentType.ApplicationJSON}
+	req := &hybrid_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: headers.ContentType.ApplicationJSON}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -20,9 +20,6 @@ package rest
 import (
 	"context"
 	"errors"
-	"fmt"
-	"maps"
-	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
@@ -31,8 +28,8 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"golang.org/x/oauth2/clientcredentials"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/auth"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 )
 
 var eligiblePlatformRequests = map[string]string{
@@ -44,64 +41,34 @@ type platform_request request
 
 var NoPlatformCredentialsErr = errors.New("neither oauth credentials nor platform token present")
 
-func configureCommonRestClient(restClient *rest.Client) (*rest.Client, error) {
-	restClient.SetHeader("User-Agent", version.UserAgent())
-	return restClient, nil
-}
-
-func createPlatformOAuthClient(ctx context.Context, u string, credentials *Credentials) (*rest.Client, error) {
-	parsedURL, err := url.Parse(u)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL %q: %w", u, err)
-	}
-	oauthConfig := clientcredentials.Config{
-		ClientID:     credentials.OAuth.ClientID,
-		ClientSecret: credentials.OAuth.ClientSecret,
-		TokenURL:     evalTokenURL(parsedURL.String()),
-	}
-	httpClient := auth.NewOAuthClient(ctx, &oauthConfig)
-
-	opts := []rest.Option{
-		rest.WithHTTPListener(logging.HTTPListener("platform")),
-		rest.WithRateLimiter(),
-		rest.WithRetryOptions(defaultRetryOptions),
-	}
-
-	return configureCommonRestClient(rest.NewClient(parsedURL, httpClient, opts...))
-}
-
-func createPlatformTokenClient(u string, credentials *Credentials) (*rest.Client, error) {
-	parsedURL, err := url.Parse(u)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL %q: %w", u, err)
-	}
-
-	opts := []rest.Option{
-		rest.WithHTTPListener(logging.HTTPListener("plat/tok")),
-		rest.WithRateLimiter(),
-		rest.WithRetryOptions(defaultRetryOptions),
-	}
-
-	return configureCommonRestClient(rest.NewClient(parsedURL, NewBearerTokenBasedClient(credentials.OAuth.PlatformToken), opts...))
-}
-
 func CreatePlatformClient(ctx context.Context, platformURL string, credentials *Credentials) (*rest.Client, error) {
 	PreRequest()
 
-	var client *rest.Client
-	var err error
+	factory := clients.Factory().
+		WithPlatformURL(platformURL).
+		WithRateLimiter(true).
+		WithRetryOptions(defaultRetryOptions).
+		WithUserAgent(version.UserAgent())
+
 	if credentials.ContainsPlatformToken() {
-		client, err = createPlatformTokenClient(platformURL, credentials)
-	} else if credentials.ContainsOAuth() {
-		client, err = createPlatformOAuthClient(NewContextWithOAuthRetryClient(ctx), platformURL, credentials)
-	} else {
-		return nil, NoPlatformCredentialsErr
-	}
-	if err != nil {
-		return nil, err
+		return factory.
+			WithHTTPListener(logging.HTTPListener("plat/tok")).
+			WithPlatformToken(credentials.OAuth.PlatformToken).
+			CreatePlatformClient(ctx)
 	}
 
-	return client, err
+	if credentials.ContainsOAuth() {
+		return factory.
+			WithHTTPListener(logging.HTTPListener("platform")).
+			WithOAuthCredentials(clientcredentials.Config{
+				ClientID:     credentials.OAuth.ClientID,
+				ClientSecret: credentials.OAuth.ClientSecret,
+				TokenURL:     evalTokenURL(platformURL),
+			}).
+			CreatePlatformClient(NewContextWithOAuthRetryClient(ctx))
+	}
+
+	return nil, NoPlatformCredentialsErr
 }
 
 func (me *platform_request) Finish(optionalTarget ...any) error {
@@ -164,48 +131,4 @@ func evalTokenURL(dtEnvURL string) string {
 		return DevTokenURL
 	}
 	return ""
-}
-
-// NewBearerTokenBasedClient creates a new HTTP client with token-based authentication.
-// It takes a token string as an argument and returns an instance of *http.Client.
-func NewBearerTokenBasedClient(token string) *http.Client {
-	// Create a new tokenAuthTransport and initialize it with the provided token.
-	return &http.Client{Transport: newBearerTokenAuthTransport(nil, token)}
-}
-
-// bearerTokenAuthTransport is a custom transport that adds token-based authentication headers to HTTP requests.
-type bearerTokenAuthTransport struct {
-	http.RoundTripper
-	header http.Header
-}
-
-// newBearerTokenAuthTransport creates a new instance of tokenAuthTransport.
-// It takes a baseTransport (an existing HTTP transport) and a token string as arguments,
-// and returns a pointer to the newly created tokenAuthTransport instance.
-func newBearerTokenAuthTransport(baseTransport http.RoundTripper, token string) *bearerTokenAuthTransport {
-	// If no baseTransport is provided, use the default HTTP transport.
-	if baseTransport == nil {
-		baseTransport = http.DefaultTransport
-	}
-
-	// Create a new tokenAuthTransport instance and initialize it.
-	t := &bearerTokenAuthTransport{
-		RoundTripper: baseTransport,
-		header:       http.Header{},
-	}
-
-	// Set the "Authorization" header with the provided token.
-	t.header.Set("Authorization", "Bearer "+token)
-	return t
-}
-
-// RoundTrip implements the http.RoundTripper interface's RoundTrip method.
-// It adds the authentication headers from the tokenAuthTransport instance to the request's headers
-// and delegates the actual round trip to the underlying transport.
-func (t *bearerTokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Copy authentication headers from tokenAuthTransport to the request.
-	maps.Copy(req.Header, t.header)
-
-	// Perform the actual HTTP request using the underlying transport.
-	return t.RoundTripper.RoundTrip(req)
 }

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -49,7 +49,7 @@ func configureCommonRestClient(restClient *rest.Client) (*rest.Client, error) {
 	return restClient, nil
 }
 
-func CreatePlatformOAuthClient(ctx context.Context, u string, credentials *Credentials) (*rest.Client, error) {
+func createPlatformOAuthClient(ctx context.Context, u string, credentials *Credentials) (*rest.Client, error) {
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL %q: %w", u, err)
@@ -70,7 +70,7 @@ func CreatePlatformOAuthClient(ctx context.Context, u string, credentials *Crede
 	return configureCommonRestClient(rest.NewClient(parsedURL, httpClient, opts...))
 }
 
-func CreatePlatformTokenClient(u string, credentials *Credentials) (*rest.Client, error) {
+func createPlatformTokenClient(u string, credentials *Credentials) (*rest.Client, error) {
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL %q: %w", u, err)
@@ -91,9 +91,9 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 	var client *rest.Client
 	var err error
 	if credentials.ContainsPlatformToken() {
-		client, err = CreatePlatformTokenClient(platformURL, credentials)
+		client, err = createPlatformTokenClient(platformURL, credentials)
 	} else if credentials.ContainsOAuth() {
-		client, err = CreatePlatformOAuthClient(NewContextWithOAuthRetryClient(ctx), platformURL, credentials)
+		client, err = createPlatformOAuthClient(NewContextWithOAuthRetryClient(ctx), platformURL, credentials)
 	} else {
 		return nil, NoPlatformCredentialsErr
 	}
@@ -112,7 +112,7 @@ func (me *platform_request) Finish(optionalTarget ...any) error {
 
 	PreRequest()
 
-	platformURL := me.evalPlatformURL()
+	platformURL := me.evalPlatformURL(me.client.Credentials().URL)
 
 	client, err := CreatePlatformClient(me.ctx, platformURL, me.client.Credentials())
 	if err != nil {
@@ -137,8 +137,8 @@ func (me *platform_request) Finish(optionalTarget ...any) error {
 	return request(*me).HandleResponse(client, fullURL, target)
 }
 
-func (me *platform_request) evalPlatformURL() string {
-	envURL := strings.TrimSuffix(strings.TrimSpace(me.client.Credentials().URL), "/")
+func (me *platform_request) evalPlatformURL(envURL string) string {
+	envURL = strings.TrimSuffix(strings.TrimSpace(envURL), "/")
 	if len(envURL) == 0 {
 		return envURL
 	}

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
@@ -59,17 +58,6 @@ type request struct {
 	onResponse func(resp *http.Response)
 }
 
-func (me request) evalClassicURL() string {
-	envURL := strings.TrimSuffix(strings.TrimSpace(me.client.Credentials().URL), "/")
-	if len(envURL) == 0 {
-		return envURL
-	}
-	envURL = strings.ReplaceAll(envURL, ".dev.apps.dynatracelabs.", ".dev.dynatracelabs.")
-	envURL = strings.ReplaceAll(envURL, ".sprint.apps.dynatracelabs.", ".sprint.dynatracelabs.")
-	envURL = strings.ReplaceAll(envURL, ".apps.dynatrace.", ".live.dynatrace.")
-	return envURL
-}
-
 func PreRequest() {
 	preRequestMutex.Lock()
 	defer preRequestMutex.Unlock()
@@ -92,7 +80,7 @@ func readerFromPayload(payload any) (io.Reader, error) {
 	return bytes.NewBuffer(data), nil
 }
 
-func UnmarshalError(method string, url string, data []byte, response *http.Response) (err error) {
+func unmarshalError(method string, url string, data []byte, response *http.Response) (err error) {
 	if response == nil {
 		return nil
 	}
@@ -162,7 +150,7 @@ func (me request) HandleResponse(client *rest.Client, u *url.URL, target any) (e
 		}
 	}
 
-	if err = UnmarshalError(me.method, u.String(), data, response); err != nil {
+	if err = unmarshalError(me.method, u.String(), data, response); err != nil {
 		return err
 	}
 
@@ -175,7 +163,7 @@ func (me request) HandleResponse(client *rest.Client, u *url.URL, target any) (e
 	return nil
 }
 
-var Headers = struct {
+var headers = struct {
 	ContentType struct{ ApplicationJSON map[string]string }
 }{
 	ContentType: struct{ ApplicationJSON map[string]string }{ApplicationJSON: map[string]string{"Content-Type": "application/json"}},

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260707095607-540d9090df78
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3
@@ -18,7 +18,6 @@ require (
 	github.com/zclconf/go-cty v1.18.1
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	golang.org/x/oauth2 v0.36.0
-	golang.org/x/sync v0.21.0
 )
 
 require (
@@ -78,6 +77,7 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203 h1:kzNnEcxFIvdGGIAP4uyxCsRnKqFu9Th5/9VG0Ibnr+U=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260707095607-540d9090df78 h1:Blet3gMWA58QgUKFx9gSh//wUBgMX4oO3lCpvf7X91I=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260707095607-540d9090df78/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
#### **Why** this PR?
Platform and IAM clients were maintaining their own client construction logic, which duplicated setup already available in the shared core client factory. The IAM OAuth path also did not consistently carry `InsecureSkipVerify` into the underlying `tls.Config`.

#### **What** has changed and **how** does it do it?
- `dynatrace/rest/platform_request.go` now creates platform clients through `dynatrace-configuration-as-code-core/clients.Factory()`, centralizing OAuth and platform-token authentication, retry handling, rate limiting, HTTP listeners, and the `User-Agent` setup.
- `dynatrace/api/iam/iam_client.go` switches IAM client creation to the same shared client factory and uses `rest.NewContextWithOAuthRetryClient(ctx)` when creating the account REST client so the existing TLS configuration, including `InsecureSkipVerify`, is preserved.

#### How is it **tested**?
N/A

#### How does it affect **users**?
Users configuring IAM access against environments that require `insecure_skip_verify` now get consistent TLS handling there as well. Other changes are internal refactoring with no intended user-facing behavior change.

**Issue:** PS-45605