### PR TITLE
refactor: Clean up provider configuration

### DIFF
--- a/datasources/documents/document/data_source.go
+++ b/datasources/documents/document/data_source.go
@@ -78,7 +78,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		docType = v.(string)
 	}
 
-	creds, err := config.Credentials(m, config.CredValAutomation)
+	creds, err := config.Credentials(m, config.CredValPlatform)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/datasources/dql/data_source.go
+++ b/datasources/dql/data_source.go
@@ -109,7 +109,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	restClient, err := rest.CreatePlatformClient(ctx, creds.OAuth.EnvironmentURL, creds)
+	restClient, err := rest.CreatePlatformClient(ctx, creds.Platform.EnvironmentURL, creds)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/datasources/extensions/active_version/data_source.go
+++ b/datasources/extensions/active_version/data_source.go
@@ -55,7 +55,7 @@ type ExtensionClient interface {
 }
 
 func createCoreClient(ctx context.Context, credentials *rest.Credentials) (ExtensionClient, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, credentials.OAuth.EnvironmentURL, credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, credentials.Platform.EnvironmentURL, credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/datasources/extensions/latest_version/data_source.go
+++ b/datasources/extensions/latest_version/data_source.go
@@ -56,7 +56,7 @@ type ExtensionClient interface {
 }
 
 func createCoreClient(ctx context.Context, credentials *rest.Credentials) (ExtensionClient, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, credentials.OAuth.EnvironmentURL, credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, credentials.Platform.EnvironmentURL, credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/datasources/slo/objectivetemplates/data_source.go
+++ b/datasources/slo/objectivetemplates/data_source.go
@@ -54,7 +54,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	restClient, _ := rest.CreatePlatformClient(ctx, creds.OAuth.EnvironmentURL, creds)
+	restClient, _ := rest.CreatePlatformClient(ctx, creds.Platform.EnvironmentURL, creds)
 
 	client := NewClient(restClient)
 

--- a/datasources/slo/objectivetemplates/data_source_multi.go
+++ b/datasources/slo/objectivetemplates/data_source_multi.go
@@ -65,7 +65,7 @@ func DataSourceMultiRead(ctx context.Context, d *schema.ResourceData, m any) dia
 		return diag.FromErr(err)
 	}
 
-	restClient, _ := rest.CreatePlatformClient(ctx, creds.OAuth.EnvironmentURL, creds)
+	restClient, _ := rest.CreatePlatformClient(ctx, creds.Platform.EnvironmentURL, creds)
 
 	client := NewClient(restClient)
 

--- a/dynatrace/api/automation/business_calendars/service.go
+++ b/dynatrace/api/automation/business_calendars/service.go
@@ -39,7 +39,7 @@ type service struct {
 }
 
 func (me *service) client(ctx context.Context) (*automation.Client, error) {
-	platformClient, err := tfrest.CreatePlatformClient(ctx, me.credentials.OAuth.EnvironmentURL, me.credentials)
+	platformClient, err := tfrest.CreatePlatformClient(ctx, me.credentials.Platform.EnvironmentURL, me.credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/automation/scheduling_rules/service.go
+++ b/dynatrace/api/automation/scheduling_rules/service.go
@@ -39,7 +39,7 @@ type service struct {
 }
 
 func (me *service) client(ctx context.Context) (*automation.Client, error) {
-	platformClient, err := tfrest.CreatePlatformClient(ctx, me.credentials.OAuth.EnvironmentURL, me.credentials)
+	platformClient, err := tfrest.CreatePlatformClient(ctx, me.credentials.Platform.EnvironmentURL, me.credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/automation/workflows/service.go
+++ b/dynatrace/api/automation/workflows/service.go
@@ -54,7 +54,7 @@ func ServiceWithClientGetter(clientGetter func(ctx context.Context, credentials 
 }
 
 func createCoreClient(ctx context.Context, credentials *tfrest.Credentials) (AutomationClient, error) {
-	platformClient, err := tfrest.CreatePlatformClient(ctx, credentials.OAuth.EnvironmentURL, credentials)
+	platformClient, err := tfrest.CreatePlatformClient(ctx, credentials.Platform.EnvironmentURL, credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/documents/directshares/service.go
+++ b/dynatrace/api/documents/directshares/service.go
@@ -81,7 +81,7 @@ type removeDirectShareRecipientsDTO struct {
 }
 
 func createCoreClient(ctx context.Context, credentials *rest.Credentials) (directSharesClient, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, credentials.OAuth.EnvironmentURL, credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, credentials.Platform.EnvironmentURL, credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -48,7 +48,7 @@ type service struct {
 }
 
 func (me *service) client(ctx context.Context) (*docclient.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, me.credentials.OAuth.EnvironmentURL, me.credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, me.credentials.Platform.EnvironmentURL, me.credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/extensions/monitoringconfigurations/service.go
+++ b/dynatrace/api/extensions/monitoringconfigurations/service.go
@@ -70,7 +70,7 @@ func ServiceWithClientGetter(clientGetter func(ctx context.Context, credentials 
 }
 
 func createCoreClient(ctx context.Context, credentials *rest.Credentials) (ExtensionClient, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, credentials.OAuth.EnvironmentURL, credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, credentials.Platform.EnvironmentURL, credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/grail/segments/service.go
+++ b/dynatrace/api/grail/segments/service.go
@@ -39,7 +39,7 @@ type service struct {
 }
 
 func (me *service) client(ctx context.Context) (*segmentsclient.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, me.credentials.OAuth.EnvironmentURL, me.credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, me.credentials.Platform.EnvironmentURL, me.credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/grail/segments/service_unit_test.go
+++ b/dynatrace/api/grail/segments/service_unit_test.go
@@ -52,7 +52,7 @@ func TestList(t *testing.T) {
 		defer server.Close()
 
 		result, err := segments.Service(&rest.Credentials{
-			OAuth: rest.OAuthCredentials{
+			Platform: rest.PlatformCredentials{
 				EnvironmentURL: server.URL,
 				PlatformToken:  "token",
 			},

--- a/dynatrace/api/openpipeline/service.go
+++ b/dynatrace/api/openpipeline/service.go
@@ -86,7 +86,7 @@ type service struct {
 }
 
 func (s *service) createClient(ctx context.Context) (*caclib.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, s.credentials.OAuth.EnvironmentURL, s.credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, s.credentials.Platform.EnvironmentURL, s.credentials)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (s *service) Get(ctx context.Context, id string, v *openpipeline.Configurat
 	if err != nil {
 		apiErr := cacapi.APIError{}
 		if errors.As(err, &apiErr) {
-			return rest.Envelope(apiErr.Body, s.credentials.OAuth.EnvironmentURL, "GET")
+			return rest.Envelope(apiErr.Body, s.credentials.Platform.EnvironmentURL, "GET")
 		}
 		return err
 	}

--- a/dynatrace/api/openpipeline/service_unit_test.go
+++ b/dynatrace/api/openpipeline/service_unit_test.go
@@ -45,7 +45,7 @@ func TestList(t *testing.T) {
 		}))
 		defer server.Close()
 		_, err := openpipeline.EventsService(&rest.Credentials{
-			OAuth: rest.OAuthCredentials{
+			Platform: rest.PlatformCredentials{
 				EnvironmentURL: server.URL,
 				PlatformToken:  "token",
 			},
@@ -60,7 +60,7 @@ func TestList(t *testing.T) {
 		defer server.Close()
 
 		configs, err := openpipeline.EventsService(&rest.Credentials{
-			OAuth: rest.OAuthCredentials{
+			Platform: rest.PlatformCredentials{
 				EnvironmentURL: server.URL,
 				PlatformToken:  "token",
 			},

--- a/dynatrace/api/platform/buckets/service.go
+++ b/dynatrace/api/platform/buckets/service.go
@@ -44,7 +44,7 @@ type service struct {
 }
 
 func (me *service) client(ctx context.Context) (*bucket.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, me.credentials.OAuth.EnvironmentURL, me.credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, me.credentials.Platform.EnvironmentURL, me.credentials)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (me *service) get(ctx context.Context, id string, v *buckets.Bucket) (err e
 	if result, err = client.Get(ctx, id); err != nil {
 		apiErr := coreapi.APIError{}
 		if errors.As(err, &apiErr) {
-			return rest.Envelope(apiErr.Body, me.credentials.OAuth.EnvironmentURL, "GET")
+			return rest.Envelope(apiErr.Body, me.credentials.Platform.EnvironmentURL, "GET")
 		}
 		return err
 	}
@@ -128,7 +128,7 @@ func (me *service) Create(ctx context.Context, v *buckets.Bucket) (stub *api.Stu
 	if _, err = client.Create(ctx, v.Name, data); err != nil {
 		apiErr := coreapi.APIError{}
 		if errors.As(err, &apiErr) {
-			return nil, rest.Envelope(apiErr.Body, me.credentials.OAuth.EnvironmentURL, "POST")
+			return nil, rest.Envelope(apiErr.Body, me.credentials.Platform.EnvironmentURL, "POST")
 		}
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (me *service) Update(ctx context.Context, id string, v *buckets.Bucket) (er
 	if err != nil {
 		apiErr := coreapi.APIError{}
 		if errors.As(err, &apiErr) {
-			return rest.Envelope(apiErr.Body, me.credentials.OAuth.EnvironmentURL, "PUT")
+			return rest.Envelope(apiErr.Body, me.credentials.Platform.EnvironmentURL, "PUT")
 		}
 		return err
 	}

--- a/dynatrace/api/slo/service.go
+++ b/dynatrace/api/slo/service.go
@@ -38,7 +38,7 @@ type service struct {
 }
 
 func (me *service) client(ctx context.Context) (*sloclient.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, me.credentials.OAuth.EnvironmentURL, me.credentials)
+	platformClient, err := rest.CreatePlatformClient(ctx, me.credentials.Platform.EnvironmentURL, me.credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/v2/settings/objects/permissions/service.go
+++ b/dynatrace/api/v2/settings/objects/permissions/service.go
@@ -46,7 +46,7 @@ func (me *ServiceImpl) getClient(ctx context.Context) (permissions.PermissionCli
 	if me.Client != nil {
 		return me.Client, nil
 	}
-	restClient, err := rest.CreatePlatformClient(ctx, me.Credentials.OAuth.EnvironmentURL, me.Credentials)
+	restClient, err := rest.CreatePlatformClient(ctx, me.Credentials.Platform.EnvironmentURL, me.Credentials)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (me *ServiceImpl) getSettingsClient(ctx context.Context) (PlatformSettingsC
 	if me.SettingsClient != nil {
 		return me.SettingsClient, nil
 	}
-	restClient, err := rest.CreatePlatformClient(ctx, me.Credentials.OAuth.EnvironmentURL, me.Credentials)
+	restClient, err := rest.CreatePlatformClient(ctx, me.Credentials.Platform.EnvironmentURL, me.Credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/rest/credentials.go
+++ b/dynatrace/rest/credentials.go
@@ -29,7 +29,7 @@ const (
 
 const TestCaseEnvURL = "go-test"
 
-type OAuthCredentials struct {
+type PlatformCredentials struct {
 	ClientID       string
 	ClientSecret   string
 	TokenURL       string
@@ -47,19 +47,19 @@ type Credentials struct {
 		TokenURL     string
 		EndpointURL  string
 	}
-	OAuth   OAuthCredentials
-	Cluster struct {
+	Platform PlatformCredentials
+	Cluster  struct {
 		URL   string
 		Token string
 	}
 }
 
 func (c *Credentials) ContainsOAuth() bool {
-	return len(c.OAuth.ClientID) > 0 && len(c.OAuth.ClientSecret) > 0
+	return len(c.Platform.ClientID) > 0 && len(c.Platform.ClientSecret) > 0
 }
 
 func (c *Credentials) ContainsPlatformToken() bool {
-	return len(c.OAuth.PlatformToken) > 0
+	return len(c.Platform.PlatformToken) > 0
 }
 
 func (c *Credentials) ContainsAPIToken() bool {

--- a/dynatrace/rest/credentials.go
+++ b/dynatrace/rest/credentials.go
@@ -17,16 +17,6 @@
 
 package rest
 
-const (
-	ProdTokenURL   = "https://sso.dynatrace.com/sso/oauth2/token"
-	SprintTokenURL = "https://sso-sprint.dynatracelabs.com/sso/oauth2/token"
-	DevTokenURL    = "https://sso-dev.dynatracelabs.com/sso/oauth2/token"
-
-	ProdIAMEndpointURL   = "https://api.dynatrace.com"
-	SprintIAMEndpointURL = "https://api-hardening.internal.dynatracelabs.com"
-	DevIAMEndpointURL    = "https://api-dev.internal.dynatracelabs.com"
-)
-
 const TestCaseEnvURL = "go-test"
 
 type PlatformCredentials struct {

--- a/dynatrace/rest/hybrid_client_test.go
+++ b/dynatrace/rest/hybrid_client_test.go
@@ -38,12 +38,12 @@ const mockToken = "########"
 var credential_repo = map[string]Credentials{
 	"unconfigured":                           {URL: TestCaseEnvURL},
 	"api-token":                              {URL: TestCaseEnvURL, Token: mockToken},
-	"oauth":                                  {URL: TestCaseEnvURL, OAuth: OAuthCredentials{ClientID: mockToken, ClientSecret: mockToken}},
-	"platform-token":                         {URL: TestCaseEnvURL, OAuth: OAuthCredentials{PlatformToken: mockToken}},
-	"api-token-and-oauth":                    {URL: TestCaseEnvURL, Token: mockToken, OAuth: OAuthCredentials{ClientID: mockToken, ClientSecret: mockToken}},
-	"api-token-and-platform-token":           {URL: TestCaseEnvURL, Token: mockToken, OAuth: OAuthCredentials{PlatformToken: mockToken}},
-	"oauth-and-platform-token":               {URL: TestCaseEnvURL, OAuth: OAuthCredentials{ClientID: mockToken, ClientSecret: mockToken, PlatformToken: mockToken}},
-	"api-token-and-oauth-and-platform-token": {URL: TestCaseEnvURL, Token: mockToken, OAuth: OAuthCredentials{PlatformToken: mockToken, ClientID: mockToken, ClientSecret: mockToken}},
+	"oauth":                                  {URL: TestCaseEnvURL, Platform: PlatformCredentials{ClientID: mockToken, ClientSecret: mockToken}},
+	"platform-token":                         {URL: TestCaseEnvURL, Platform: PlatformCredentials{PlatformToken: mockToken}},
+	"api-token-and-oauth":                    {URL: TestCaseEnvURL, Token: mockToken, Platform: PlatformCredentials{ClientID: mockToken, ClientSecret: mockToken}},
+	"api-token-and-platform-token":           {URL: TestCaseEnvURL, Token: mockToken, Platform: PlatformCredentials{PlatformToken: mockToken}},
+	"oauth-and-platform-token":               {URL: TestCaseEnvURL, Platform: PlatformCredentials{ClientID: mockToken, ClientSecret: mockToken, PlatformToken: mockToken}},
+	"api-token-and-oauth-and-platform-token": {URL: TestCaseEnvURL, Token: mockToken, Platform: PlatformCredentials{PlatformToken: mockToken, ClientID: mockToken, ClientSecret: mockToken}},
 }
 
 type testcase struct {

--- a/dynatrace/rest/logging/logger_test.go
+++ b/dynatrace/rest/logging/logger_test.go
@@ -64,7 +64,7 @@ func TestProviderLogging(t *testing.T) {
 			credentials: func(url string) *rest.Credentials {
 				return &rest.Credentials{
 					URL: url,
-					OAuth: rest.OAuthCredentials{
+					Platform: rest.PlatformCredentials{
 						PlatformToken: "my-token",
 					},
 				}

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
@@ -63,7 +62,7 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 			WithOAuthCredentials(clientcredentials.Config{
 				ClientID:     credentials.Platform.ClientID,
 				ClientSecret: credentials.Platform.ClientSecret,
-				TokenURL:     evalTokenURL(platformURL),
+				TokenURL:     credentials.Platform.TokenURL,
 			}).
 			CreatePlatformClient(NewContextWithOAuthRetryClient(ctx))
 	}
@@ -114,21 +113,4 @@ func (me *platform_request) evalPlatformURL(envURL string) string {
 	envURL = strings.ReplaceAll(envURL, ".sprint.dynatracelabs.", ".sprint.apps.dynatracelabs.")
 	return envURL
 
-}
-
-var regexpSaasTenant = regexp.MustCompile(`https:\/\/(.*).(live|apps).dynatrace.com`)
-var regexpSprintTenant = regexp.MustCompile(`https:\/\/(.*).sprint(?:\.apps)?.dynatracelabs.com`)
-var regexpDevTenant = regexp.MustCompile(`https:\/\/(.*).dev(?:\.apps)?.dynatracelabs.com`)
-
-func evalTokenURL(dtEnvURL string) string {
-	if match := regexpSaasTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-		return ProdTokenURL
-	}
-	if match := regexpSprintTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-		return SprintTokenURL
-	}
-	if match := regexpDevTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-		return DevTokenURL
-	}
-	return ""
 }

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -53,7 +53,7 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 	if credentials.ContainsPlatformToken() {
 		return factory.
 			WithHTTPListener(logging.HTTPListener("plat/tok")).
-			WithPlatformToken(credentials.OAuth.PlatformToken).
+			WithPlatformToken(credentials.Platform.PlatformToken).
 			CreatePlatformClient(ctx)
 	}
 
@@ -61,8 +61,8 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 		return factory.
 			WithHTTPListener(logging.HTTPListener("platform")).
 			WithOAuthCredentials(clientcredentials.Config{
-				ClientID:     credentials.OAuth.ClientID,
-				ClientSecret: credentials.OAuth.ClientSecret,
+				ClientID:     credentials.Platform.ClientID,
+				ClientSecret: credentials.Platform.ClientSecret,
 				TokenURL:     evalTokenURL(platformURL),
 			}).
 			CreatePlatformClient(NewContextWithOAuthRetryClient(ctx))

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -18,17 +18,17 @@
 package config
 
 import (
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"context"
 	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
 
 type IAM struct {
 	ClientID     string
@@ -134,15 +134,12 @@ func Credentials(m any, CredentialValidation int) (*rest.Credentials, error) {
 
 // ProviderConfiguration contains the initialized API clients to communicate with the Dynatrace API
 type ProviderConfiguration struct {
-	EnvironmentURL    string
-	DTenvURL          string
-	DTNonConfigEnvURL string
-	DTApiV2URL        string
-	ClusterAPIV2URL   string
-	ClusterAPIToken   string
-	APIToken          string
-	IAM               IAM
-	Automation        rest.OAuthCredentials
+	EnvironmentURL  string
+	ClusterAPIV2URL string
+	ClusterAPIToken string
+	APIToken        string
+	IAM             IAM
+	Automation      rest.OAuthCredentials
 }
 
 type Getter interface {
@@ -177,10 +174,6 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnost
 	}
 
 	clusterURL = strings.TrimSuffix(strings.TrimSuffix(clusterURL, " "), "/")
-
-	fullURL := dtEnvURL + "/api/config/v1"
-	fullNonConfigURL := dtEnvURL + "/api/v1"
-	fullApiV2URL := dtEnvURL + "/api/v2"
 
 	automation_environment_url := getString(d, "automation_env_url")
 	automation_token_url := getString(d, "automation_token_url")
@@ -244,13 +237,10 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnost
 	var diags diag.Diagnostics
 
 	pc := &ProviderConfiguration{
-		EnvironmentURL:    dtEnvURL,
-		DTenvURL:          fullURL,
-		DTApiV2URL:        fullApiV2URL,
-		DTNonConfigEnvURL: fullNonConfigURL,
-		APIToken:          apiToken,
-		ClusterAPIToken:   clusterAPIToken,
-		ClusterAPIV2URL:   clusterURL,
+		EnvironmentURL:  dtEnvURL,
+		APIToken:        apiToken,
+		ClusterAPIToken: clusterAPIToken,
+		ClusterAPIV2URL: clusterURL,
 		IAM: IAM{
 			ClientID:     iam_client_id,
 			AccountID:    iam_account_id,

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -38,6 +38,24 @@ type IAM struct {
 	EndpointURL  string
 }
 
+// ProviderConfiguration contains credentials to communicate with the Dynatrace API
+type ProviderConfiguration struct {
+	EnvironmentURL  string
+	ClusterAPIV2URL string
+	ClusterAPIToken string
+	APIToken        string
+	IAM             IAM
+	Platform        rest.PlatformCredentials
+}
+
+type Getter interface {
+	Get(key string) any
+}
+
+type ConfigGetter struct {
+	Provider *schema.Provider
+}
+
 const (
 	CredValDefault = iota
 	CredValIAM
@@ -47,6 +65,50 @@ const (
 	CredValExport
 	CredValExportIAM
 )
+
+const (
+	ProdTokenURL   = "https://sso.dynatrace.com/sso/oauth2/token"
+	SprintTokenURL = "https://sso-sprint.dynatracelabs.com/sso/oauth2/token"
+	DevTokenURL    = "https://sso-dev.dynatracelabs.com/sso/oauth2/token"
+
+	ProdIAMEndpointURL   = "https://api.dynatrace.com"
+	SprintIAMEndpointURL = "https://api-hardening.internal.dynatracelabs.com"
+	DevIAMEndpointURL    = "https://api-dev.internal.dynatracelabs.com"
+)
+
+var regexpProdTenant = regexp.MustCompile(`https:\/\/(.*).(live|apps).dynatrace.com`)
+
+var regexpSprintTenant = regexp.MustCompile(`https:\/\/(.*).sprint(?:\.apps)?.dynatracelabs.com`)
+
+var regexpDevTenant = regexp.MustCompile(`https:\/\/(.*).dev(?:\.apps)?.dynatracelabs.com`)
+
+func ProviderConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.Diagnostics) {
+	return ProviderConfigureGeneric(ctx, d)
+}
+
+func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnostics) {
+	pc := &ProviderConfiguration{
+		EnvironmentURL:  getClassicEnvironmentURL(d),
+		APIToken:        getString(d, "dt_api_token"),
+		ClusterAPIToken: getString(d, "dt_cluster_api_token"),
+		ClusterAPIV2URL: getURLString(d, "dt_cluster_url"),
+		IAM: IAM{
+			ClientID:     getIAMClientID(d),
+			AccountID:    getAccountID(d),
+			ClientSecret: getIAMClientSecret(d),
+			TokenURL:     getIAMTokenURL(d),
+			EndpointURL:  getIAMEndpointURL(d),
+		},
+		Platform: rest.PlatformCredentials{
+			PlatformToken:  getString(d, "platform_token"),
+			ClientID:       getPlatformClientID(d),
+			ClientSecret:   getPlatformClientSecret(d),
+			TokenURL:       getPlatformTokenURL(d),
+			EnvironmentURL: getPlatformEnvironmentURL(d),
+		},
+	}
+	return pc, diag.Diagnostics{}
+}
 
 func validateCredentials(conf *ProviderConfiguration, CredentialValidation int) error {
 	switch CredentialValidation {
@@ -132,144 +194,228 @@ func Credentials(m any, CredentialValidation int) (*rest.Credentials, error) {
 	}, nil
 }
 
-// ProviderConfiguration contains the initialized API clients to communicate with the Dynatrace API
-type ProviderConfiguration struct {
-	EnvironmentURL  string
-	ClusterAPIV2URL string
-	ClusterAPIToken string
-	APIToken        string
-	IAM             IAM
-	Platform        rest.PlatformCredentials
+// getClassicEnvironmentURL retrieves the classic environment URL from the "dt_env_url" key in the provided configuration.
+// It ensures that the URL is in the correct format for classic usage.
+func getClassicEnvironmentURL(d Getter) string {
+	return ensureClassicEnvironmentURL(getURLString(d, "dt_env_url"))
 }
 
-type Getter interface {
-	Get(key string) any
+// getPlatformEnvironmentURL retrieves the platform environment URL from the provided configuration.
+// It first checks for the "automation_env_url" key, and if not found, it derives it based on the classic environment URL.
+func getPlatformEnvironmentURL(d Getter) string {
+	if platformEnvironmentURL := getURLString(d, "automation_env_url"); platformEnvironmentURL != "" {
+		return platformEnvironmentURL
+	}
+	return ensurePlatformEnvironmentURL(getClassicEnvironmentURL(d))
 }
 
-func ProviderConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.Diagnostics) {
-	return ProviderConfigureGeneric(ctx, d)
+// getIAMEndpointURL retrieves the IAM API endpoint URL from the provided configuration.
+// It first checks for the "iam_endpoint_url" key, and if not found, it derives it based on the environment URL.
+func getIAMEndpointURL(d Getter) string {
+	if iamEndpointURL := getURLString(d, "iam_endpoint_url"); iamEndpointURL != "" {
+		return iamEndpointURL
+	}
+	return getIAMEndpointURLForEnvironment(getClassicEnvironmentURL(d))
 }
 
-var regexpSaasTenant = regexp.MustCompile(`https:\/\/(.*).(live|apps).dynatrace.com`)
-var regexpSprintTenant = regexp.MustCompile(`https:\/\/(.*).sprint(?:\.apps)?.dynatracelabs.com`)
-var regexpDevTenant = regexp.MustCompile(`https:\/\/(.*).dev(?:\.apps)?.dynatracelabs.com`)
-
-func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnostics) {
-
-	dtEnvURL := d.Get("dt_env_url").(string)
-	apiToken := d.Get("dt_api_token").(string)
-	clusterAPIToken := getString(d, "dt_cluster_api_token")
-	clusterURL := getString(d, "dt_cluster_url")
-
-	dtEnvURL = strings.TrimSuffix(strings.TrimSuffix(dtEnvURL, " "), "/")
-	if len(dtEnvURL) != 0 {
-		if match := regexpSaasTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			dtEnvURL = fmt.Sprintf("https://%s.live.dynatrace.com", match[1])
-		}
-		if match := regexpSprintTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			dtEnvURL = fmt.Sprintf("https://%s.sprint.dynatracelabs.com", match[1])
-		}
-		if match := regexpDevTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			dtEnvURL = fmt.Sprintf("https://%s.dev.dynatracelabs.com", match[1])
-		}
+// getIAMTokenURL retrieves the SSO token URL for IAM from the provided configuration.
+// It first checks for the "iam_token_url" key, and if not found, it checks for the "token_url" key and then "automation_token_url" key.
+// If neither is found, it derives the token URL based on the environment URL.
+func getIAMTokenURL(d Getter) string {
+	if iamTokenURL := getURLString(d, "iam_token_url"); iamTokenURL != "" {
+		return iamTokenURL
 	}
 
-	clusterURL = strings.TrimSuffix(strings.TrimSuffix(clusterURL, " "), "/")
-
-	platformEnvironmentURL := getString(d, "automation_env_url")
-	platformTokenURL := getString(d, "automation_token_url")
-	if len(platformEnvironmentURL) == 0 {
-		if match := regexpSaasTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			platformEnvironmentURL = fmt.Sprintf("https://%s.apps.dynatrace.com", match[1])
-			platformTokenURL = rest.ProdTokenURL
-		}
-		if match := regexpSprintTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			platformEnvironmentURL = fmt.Sprintf("https://%s.sprint.apps.dynatracelabs.com", match[1])
-			platformTokenURL = rest.SprintTokenURL
-		}
-		if match := regexpDevTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			platformEnvironmentURL = fmt.Sprintf("https://%s.dev.apps.dynatracelabs.com", match[1])
-			platformTokenURL = rest.DevTokenURL
-		}
+	if tokenURL := getURLString(d, "token_url"); tokenURL != "" {
+		return tokenURL
 	}
 
-	client_id := getString(d, "client_id")
-	client_secret := getString(d, "client_secret")
-	account_id := getString(d, "account_id")
-	token_url := getString(d, "token_url")
-	platform_token := getString(d, "platform_token")
-
-	oauth_endpoint_url := "https://api.dynatrace.com"
-	if strings.Contains(dtEnvURL, ".live.dynatrace.com") || strings.Contains(dtEnvURL, ".apps.dynatrace.com") {
-		oauth_endpoint_url = rest.ProdIAMEndpointURL
-	} else if strings.Contains(dtEnvURL, ".sprint.dynatracelabs.com") || strings.Contains(dtEnvURL, ".sprint.apps.dynatracelabs.com") {
-		oauth_endpoint_url = rest.SprintIAMEndpointURL
-	} else if strings.Contains(dtEnvURL, ".dev.dynatracelabs.com") || strings.Contains(dtEnvURL, ".dev.apps.dynatracelabs.com") {
-		oauth_endpoint_url = rest.DevIAMEndpointURL
+	if platformTokenURL := getURLString(d, "automation_token_url"); platformTokenURL != "" {
+		return platformTokenURL
 	}
-
-	iam_client_id := getString(d, "iam_client_id")
-	iam_account_id := getString(d, "iam_account_id")
-	iam_client_secret := getString(d, "iam_client_secret")
-	iam_token_url := strings.TrimSuffix(strings.TrimSpace(getString(d, "iam_token_url")), "/")
-	iam_endpoint_url := strings.TrimSuffix(strings.TrimSpace(getString(d, "iam_endpoint_url")), "/")
-
-	platformClientID := getString(d, "automation_client_id")
-	if len(platformClientID) == 0 {
-		platformClientID = client_id
-	}
-	platformClientSecret := getString(d, "automation_client_secret")
-	if len(platformClientSecret) == 0 {
-		platformClientSecret = client_secret
-	}
-
-	platformClientID = streamlineOAuthCreds(platformClientID, client_id, iam_client_id)
-	platformClientSecret = streamlineOAuthCreds(platformClientSecret, client_secret, iam_client_secret)
-	platformTokenURL = streamlineOAuthCreds(platformTokenURL, token_url, iam_token_url, rest.ProdTokenURL)
-
-	iam_client_id = streamlineOAuthCreds(iam_client_id, client_id, platformClientID)
-	iam_client_secret = streamlineOAuthCreds(iam_client_secret, client_secret, platformClientSecret)
-	iam_token_url = streamlineOAuthCreds(iam_token_url, token_url, platformTokenURL, rest.ProdTokenURL)
-	iam_account_id = streamlineOAuthCreds(iam_account_id, account_id)
-	iam_endpoint_url = streamlineOAuthCreds(iam_endpoint_url, oauth_endpoint_url, rest.ProdIAMEndpointURL)
-
-	iam_account_id = strings.TrimPrefix(iam_account_id, "urn:dtaccount:")
-
-	var diags diag.Diagnostics
-
-	pc := &ProviderConfiguration{
-		EnvironmentURL:  dtEnvURL,
-		APIToken:        apiToken,
-		ClusterAPIToken: clusterAPIToken,
-		ClusterAPIV2URL: clusterURL,
-		IAM: IAM{
-			ClientID:     iam_client_id,
-			AccountID:    iam_account_id,
-			ClientSecret: iam_client_secret,
-			TokenURL:     iam_token_url,
-			EndpointURL:  iam_endpoint_url,
-		},
-		Platform: rest.PlatformCredentials{
-			PlatformToken:  platform_token,
-			ClientID:       platformClientID,
-			ClientSecret:   platformClientSecret,
-			TokenURL:       platformTokenURL,
-			EnvironmentURL: platformEnvironmentURL,
-		},
-	}
-	return pc, diags
+	return getTokenURLForEnvironment(getClassicEnvironmentURL(d))
 }
 
-func streamlineOAuthCreds(values ...string) string {
-	if len(values) == 0 {
-		return ""
+// getIAMClientID retrieves the OAuth client ID for IAM from the provided configuration.
+// It first checks for the "iam_client_id" key, and if not found, it checks for the "client_id" and "automation_client_id" keys.
+func getIAMClientID(d Getter) string {
+	if iamClientID := getString(d, "iam_client_id"); iamClientID != "" {
+		return iamClientID
 	}
-	for _, value := range values {
-		if len(value) != 0 {
-			return value
-		}
+	if clientID := getString(d, "client_id"); clientID != "" {
+		return clientID
+	}
+	return getString(d, "automation_client_id")
+}
+
+// getIAMClientSecret retrieves the OAuth client secret for IAM from the provided configuration.
+// It first checks for the "iam_client_secret" key, and if not found, it checks for the "client_secret" and "automation_client_secret" keys.
+func getIAMClientSecret(d Getter) string {
+	if iamClientSecret := getString(d, "iam_client_secret"); iamClientSecret != "" {
+		return iamClientSecret
+	}
+	if clientSecret := getString(d, "client_secret"); clientSecret != "" {
+		return clientSecret
+	}
+	return getString(d, "automation_client_secret")
+}
+
+// getAccountID retrieves the account ID from the provided configuration.
+// It first checks for the "iam_account_id" key, and if not found, it checks for the "account_id" key.
+// The function returns the account ID with the "urn:dtaccount:" prefix removed, if present.
+func getAccountID(d Getter) string {
+	if iamAccountID := getString(d, "iam_account_id"); iamAccountID != "" {
+		return strings.TrimPrefix(iamAccountID, "urn:dtaccount:")
+	}
+	if accountID := getString(d, "account_id"); accountID != "" {
+		return strings.TrimPrefix(accountID, "urn:dtaccount:")
 	}
 	return ""
+}
+
+// getPlatformClientID retrieves the OAuth client ID for platform from the provided configuration.
+// It first checks for the "automation_client_id" key, then "client_id", and finally "iam_client_id".
+func getPlatformClientID(d Getter) string {
+	if automationClientID := getString(d, "automation_client_id"); automationClientID != "" {
+		return automationClientID
+	}
+	if clientID := getString(d, "client_id"); clientID != "" {
+		return clientID
+	}
+	return getString(d, "iam_client_id")
+}
+
+// getPlatformClientSecret retrieves the OAuth client secret for platform from the provided configuration.
+// It first checks for the "automation_client_secret" key, then "client_secret", and finally "iam_client
+func getPlatformClientSecret(d Getter) string {
+	if automation_client_secret := getString(d, "automation_client_secret"); automation_client_secret != "" {
+		return automation_client_secret
+	}
+	if clientSecret := getString(d, "client_secret"); clientSecret != "" {
+		return clientSecret
+	}
+	return getString(d, "iam_client_secret")
+}
+
+// getPlatformTokenURL returns the SSO token URL for platform based on the provided configuration.
+// It first checks if a custom token URL is specified in the configuration using the "automation_token_url" key.
+// If not, it checks the "token_url" and "iam_token_url" keys.
+// If none are found, it derives the token URL based on the environment URL.
+func getPlatformTokenURL(d Getter) string {
+	if platformTokenURL := getURLString(d, "automation_token_url"); platformTokenURL != "" {
+		return platformTokenURL
+	}
+
+	if tokenURL := getURLString(d, "token_url"); tokenURL != "" {
+		return tokenURL
+	}
+
+	if iamTokenURL := getURLString(d, "iam_token_url"); iamTokenURL != "" {
+		return iamTokenURL
+	}
+
+	return getTokenURLForEnvironment(getClassicEnvironmentURL(d))
+}
+
+// ensureClassicEnvironmentURL ensures that the provided Dynatrace environment URL is in the correct format for classic usage.
+// It checks if the environment URL corresponds to a SaaS, Sprint, or Dev environment and returns the appropriate classic environment URL.
+// If the environment URL does not match any of these, it returns the original environment URL.
+func ensureClassicEnvironmentURL(dtEnvURL string) string {
+	if envID, ok := extractProdEnvironmentID(dtEnvURL); ok {
+		return fmt.Sprintf("https://%s.live.dynatrace.com", envID)
+	}
+
+	if envID, ok := extractSprintEnvironmentID(dtEnvURL); ok {
+		return fmt.Sprintf("https://%s.sprint.dynatracelabs.com", envID)
+	}
+
+	if envID, ok := extractDevEnvironmentID(dtEnvURL); ok {
+		return fmt.Sprintf("https://%s.dev.dynatracelabs.com", envID)
+	}
+
+	return dtEnvURL
+}
+
+// ensurePlatformEnvironmentURL ensures that the provided Dynatrace environment URL is in the correct format for platform usage.
+// It checks if the environment URL corresponds to a SaaS, Sprint, or Dev environment and returns the appropriate platform environment URL.
+// If the environment URL does not match any of these, it returns the original environment URL.
+func ensurePlatformEnvironmentURL(dtEnvURL string) string {
+	if envID, ok := extractProdEnvironmentID(dtEnvURL); ok {
+		return fmt.Sprintf("https://%s.apps.dynatrace.com", envID)
+	}
+	if envID, ok := extractSprintEnvironmentID(dtEnvURL); ok {
+		return fmt.Sprintf("https://%s.sprint.apps.dynatracelabs.com", envID)
+	}
+	if envID, ok := extractDevEnvironmentID(dtEnvURL); ok {
+		return fmt.Sprintf("https://%s.dev.apps.dynatracelabs.com", envID)
+	}
+
+	return dtEnvURL
+}
+
+// getTokenURLForEnvironment returns the token URL based on the provided Dynatrace environment URL.
+// It checks if the environment URL corresponds to a SaaS, Sprint, or Dev environment and returns the appropriate token URL.
+// If the environment URL does not match any of these, it defaults to the production token URL.
+func getTokenURLForEnvironment(dtEnvURL string) string {
+	if _, ok := extractProdEnvironmentID(dtEnvURL); ok {
+		return ProdTokenURL
+	}
+	if _, ok := extractSprintEnvironmentID(dtEnvURL); ok {
+		return SprintTokenURL
+	}
+	if _, ok := extractDevEnvironmentID(dtEnvURL); ok {
+		return DevTokenURL
+	}
+	return ProdTokenURL
+}
+
+// getIAMEndpointURLForEnvironment returns the IAM endpoint URL based on the provided Dynatrace environment URL.
+// It checks if the environment URL corresponds to a SaaS, Sprint, or Dev environment and returns the appropriate IAM endpoint URL.
+// If the environment URL does not match any of these, it defaults to the production IAM endpoint URL.
+func getIAMEndpointURLForEnvironment(dtEnvURL string) string {
+	if _, ok := extractProdEnvironmentID(dtEnvURL); ok {
+		return ProdIAMEndpointURL
+	}
+	if _, ok := extractSprintEnvironmentID(dtEnvURL); ok {
+		return SprintIAMEndpointURL
+	}
+	if _, ok := extractDevEnvironmentID(dtEnvURL); ok {
+		return DevIAMEndpointURL
+	}
+	return ProdIAMEndpointURL
+}
+
+// extractProdEnvironmentID extracts the environment ID from a Dynatrace SaaS environment URL.
+// It returns the environment ID and a boolean indicating whether the extraction was successful.
+func extractProdEnvironmentID(envURL string) (string, bool) {
+	if match := regexpProdTenant.FindStringSubmatch(envURL); len(match) > 0 {
+		return match[1], true
+	}
+	return "", false
+}
+
+// extractSprintEnvironmentID extracts the environment ID from a Dynatrace Sprint environment URL.
+// It returns the environment ID and a boolean indicating whether the extraction was successful.
+func extractSprintEnvironmentID(envURL string) (string, bool) {
+	if match := regexpSprintTenant.FindStringSubmatch(envURL); len(match) > 0 {
+		return match[1], true
+	}
+	return "", false
+}
+
+// extractDevEnvironmentID extracts the environment ID from a Dynatrace Dev environment URL.
+// It returns the environment ID and a boolean indicating whether the extraction was successful.
+func extractDevEnvironmentID(envURL string) (string, bool) {
+	if match := regexpDevTenant.FindStringSubmatch(envURL); len(match) > 0 {
+		return match[1], true
+	}
+	return "", false
+}
+
+// getURLString retrieves the URL string for the given key from the configuration,
+// It removes trailing slashes and whitespace.
+func getURLString(d Getter, key string) string {
+	return strings.TrimSuffix(strings.TrimSpace(getString(d, key)), "/")
 }
 
 func getString(d Getter, key string) string {
@@ -277,10 +423,6 @@ func getString(d Getter, key string) string {
 		return value.(string)
 	}
 	return ""
-}
-
-type ConfigGetter struct {
-	Provider *schema.Provider
 }
 
 func (me ConfigGetter) Get(key string) any {

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -42,7 +42,7 @@ const (
 	CredValDefault = iota
 	CredValIAM
 	CredValCluster
-	CredValAutomation
+	CredValPlatform
 	CredValNone
 	CredValExport
 	CredValExportIAM
@@ -82,24 +82,24 @@ func validateCredentials(conf *ProviderConfiguration, CredentialValidation int) 
 		if len(conf.ClusterAPIV2URL) == 0 {
 			return fmt.Errorf(" No Cluster URL has been specified. Use either the environment variable `DT_CLUSTER_URL` or the configuration attribute `dt_cluster_url` of the provider for that")
 		}
-	case CredValAutomation:
-		if len(conf.Automation.ClientID) == 0 {
+	case CredValPlatform:
+		if len(conf.Platform.ClientID) == 0 {
 			return fmt.Errorf(" No OAuth Client ID for the Automation API has been specified. Use either the environment variable `DT_AUTOMATION_CLIENT_ID` or the configuration attribute `automation_client_id` of the provider for that")
 		}
-		if len(conf.Automation.ClientSecret) == 0 {
+		if len(conf.Platform.ClientSecret) == 0 {
 			return fmt.Errorf(" No OAuth Client Secret for the Automation API has been specified. Use either the environment variable `DT_AUTOMATION_CLIENT_SECRET` or the configuration attribute `automation_client_secret` of the provider for that")
 		}
-		if len(conf.Automation.TokenURL) == 0 {
+		if len(conf.Platform.TokenURL) == 0 {
 			return fmt.Errorf(" No Token URL for the Automation API has been specified. Use either the environment variable `DT_AUTOMATION_TOKEN_URL` or the configuration attribute `automation_token_url` of the provider for that")
 		}
-		if len(conf.Automation.EnvironmentURL) == 0 {
+		if len(conf.Platform.EnvironmentURL) == 0 {
 			return fmt.Errorf(" No Environment URL for the Automation API has been specified. Use either the environment variable `DT_AUTOMATION_ENVIRONMENT_URL` or the configuration attribute `automation_env_url` of the provider for that")
 		}
 	case CredValExport:
 		if len(conf.EnvironmentURL) == 0 {
 			return fmt.Errorf(" No Environment URL has been specified. Use either the environment variable `DYNATRACE_ENV_URL` or the configuration attribute `dt_env_url` of the provider for that")
 		}
-		if len(conf.APIToken) == 0 && len(conf.Automation.PlatformToken) == 0 && validateCredentials(conf, CredValAutomation) != nil {
+		if len(conf.APIToken) == 0 && len(conf.Platform.PlatformToken) == 0 && validateCredentials(conf, CredValPlatform) != nil {
 			return fmt.Errorf(" No API Token, Platform Token, or OAuth has been specified for export. More detailed information can be found in the documentation at https://registry.terraform.io/providers/dynatrace-oss/dynatrace/latest/docs#configure-the-dynatrace-provider")
 		}
 	case CredValExportIAM:
@@ -118,10 +118,10 @@ func Credentials(m any, CredentialValidation int) (*rest.Credentials, error) {
 		return nil, err
 	}
 	return &rest.Credentials{
-		Token: conf.APIToken,
-		URL:   conf.EnvironmentURL,
-		IAM:   conf.IAM,
-		OAuth: conf.Automation,
+		Token:    conf.APIToken,
+		URL:      conf.EnvironmentURL,
+		IAM:      conf.IAM,
+		Platform: conf.Platform,
 		Cluster: struct {
 			URL   string
 			Token string
@@ -139,7 +139,7 @@ type ProviderConfiguration struct {
 	ClusterAPIToken string
 	APIToken        string
 	IAM             IAM
-	Automation      rest.OAuthCredentials
+	Platform        rest.PlatformCredentials
 }
 
 type Getter interface {
@@ -155,6 +155,7 @@ var regexpSprintTenant = regexp.MustCompile(`https:\/\/(.*).sprint(?:\.apps)?.dy
 var regexpDevTenant = regexp.MustCompile(`https:\/\/(.*).dev(?:\.apps)?.dynatracelabs.com`)
 
 func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnostics) {
+
 	dtEnvURL := d.Get("dt_env_url").(string)
 	apiToken := d.Get("dt_api_token").(string)
 	clusterAPIToken := getString(d, "dt_cluster_api_token")
@@ -175,20 +176,20 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnost
 
 	clusterURL = strings.TrimSuffix(strings.TrimSuffix(clusterURL, " "), "/")
 
-	automation_environment_url := getString(d, "automation_env_url")
-	automation_token_url := getString(d, "automation_token_url")
-	if len(automation_environment_url) == 0 {
+	platformEnvironmentURL := getString(d, "automation_env_url")
+	platformTokenURL := getString(d, "automation_token_url")
+	if len(platformEnvironmentURL) == 0 {
 		if match := regexpSaasTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			automation_environment_url = fmt.Sprintf("https://%s.apps.dynatrace.com", match[1])
-			automation_token_url = rest.ProdTokenURL
+			platformEnvironmentURL = fmt.Sprintf("https://%s.apps.dynatrace.com", match[1])
+			platformTokenURL = rest.ProdTokenURL
 		}
 		if match := regexpSprintTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			automation_environment_url = fmt.Sprintf("https://%s.sprint.apps.dynatracelabs.com", match[1])
-			automation_token_url = rest.SprintTokenURL
+			platformEnvironmentURL = fmt.Sprintf("https://%s.sprint.apps.dynatracelabs.com", match[1])
+			platformTokenURL = rest.SprintTokenURL
 		}
 		if match := regexpDevTenant.FindStringSubmatch(dtEnvURL); len(match) > 0 {
-			automation_environment_url = fmt.Sprintf("https://%s.dev.apps.dynatracelabs.com", match[1])
-			automation_token_url = rest.DevTokenURL
+			platformEnvironmentURL = fmt.Sprintf("https://%s.dev.apps.dynatracelabs.com", match[1])
+			platformTokenURL = rest.DevTokenURL
 		}
 	}
 
@@ -213,22 +214,22 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnost
 	iam_token_url := strings.TrimSuffix(strings.TrimSpace(getString(d, "iam_token_url")), "/")
 	iam_endpoint_url := strings.TrimSuffix(strings.TrimSpace(getString(d, "iam_endpoint_url")), "/")
 
-	automation_client_id := getString(d, "automation_client_id")
-	if len(automation_client_id) == 0 {
-		automation_client_id = client_id
+	platformClientID := getString(d, "automation_client_id")
+	if len(platformClientID) == 0 {
+		platformClientID = client_id
 	}
-	automation_client_secret := getString(d, "automation_client_secret")
-	if len(automation_client_secret) == 0 {
-		automation_client_secret = client_secret
+	platformClientSecret := getString(d, "automation_client_secret")
+	if len(platformClientSecret) == 0 {
+		platformClientSecret = client_secret
 	}
 
-	automation_client_id = streamlineOAuthCreds(automation_client_id, client_id, iam_client_id)
-	automation_client_secret = streamlineOAuthCreds(automation_client_secret, client_secret, iam_client_secret)
-	automation_token_url = streamlineOAuthCreds(automation_token_url, token_url, iam_token_url, rest.ProdTokenURL)
+	platformClientID = streamlineOAuthCreds(platformClientID, client_id, iam_client_id)
+	platformClientSecret = streamlineOAuthCreds(platformClientSecret, client_secret, iam_client_secret)
+	platformTokenURL = streamlineOAuthCreds(platformTokenURL, token_url, iam_token_url, rest.ProdTokenURL)
 
-	iam_client_id = streamlineOAuthCreds(iam_client_id, client_id, automation_client_id)
-	iam_client_secret = streamlineOAuthCreds(iam_client_secret, client_secret, automation_client_secret)
-	iam_token_url = streamlineOAuthCreds(iam_token_url, token_url, automation_token_url, rest.ProdTokenURL)
+	iam_client_id = streamlineOAuthCreds(iam_client_id, client_id, platformClientID)
+	iam_client_secret = streamlineOAuthCreds(iam_client_secret, client_secret, platformClientSecret)
+	iam_token_url = streamlineOAuthCreds(iam_token_url, token_url, platformTokenURL, rest.ProdTokenURL)
 	iam_account_id = streamlineOAuthCreds(iam_account_id, account_id)
 	iam_endpoint_url = streamlineOAuthCreds(iam_endpoint_url, oauth_endpoint_url, rest.ProdIAMEndpointURL)
 
@@ -248,12 +249,12 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) (any, diag.Diagnost
 			TokenURL:     iam_token_url,
 			EndpointURL:  iam_endpoint_url,
 		},
-		Automation: rest.OAuthCredentials{
+		Platform: rest.PlatformCredentials{
 			PlatformToken:  platform_token,
-			ClientID:       automation_client_id,
-			ClientSecret:   automation_client_secret,
-			TokenURL:       automation_token_url,
-			EnvironmentURL: automation_environment_url,
+			ClientID:       platformClientID,
+			ClientSecret:   platformClientSecret,
+			TokenURL:       platformTokenURL,
+			EnvironmentURL: platformEnvironmentURL,
 		},
 	}
 	return pc, diags

--- a/provider/config/config_test.go
+++ b/provider/config/config_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockResourceData map[string]any
@@ -32,14 +33,359 @@ func (mrd mockResourceData) Get(k string) any {
 	return mrd[k]
 }
 
-func TestProviderConfigure(t *testing.T) {
-	d := mockResourceData{
-		"dt_env_url":   "https://something.live.dynatrace.com",
-		"dt_api_token": "faketoken",
-	}
+func configure(t *testing.T, d mockResourceData) *config.ProviderConfiguration {
+	t.Helper()
+	result, diags := config.ProviderConfigureGeneric(t.Context(), d)
+	assert.Empty(t, diags)
+	configuration, ok := result.(*config.ProviderConfiguration)
+	require.True(t, ok)
+	return configuration
+}
 
-	result, _ := config.ProviderConfigureGeneric(t.Context(), d)
-	configuration := result.(*config.ProviderConfiguration)
-	assert.Equal(t, "https://something.live.dynatrace.com", configuration.EnvironmentURL)
+func TestProviderConfigureGeneric(t *testing.T) {
+	t.Run("Direct fields are passed through and URLs cleaned", func(t *testing.T) {
+		cfg := configure(t, mockResourceData{
+			"dt_env_url":           "https://foo.live.dynatrace.com",
+			"dt_api_token":         "api-token",
+			"dt_cluster_api_token": "cluster-token",
+			"dt_cluster_url":       "https://cluster.example.com/ ",
+			"platform_token":       "platform-token",
+		})
+		assert.Equal(t, "api-token", cfg.APIToken)
+		assert.Equal(t, "cluster-token", cfg.ClusterAPIToken)
+		assert.Equal(t, "https://cluster.example.com", cfg.ClusterAPIV2URL)
+		assert.Equal(t, "platform-token", cfg.Platform.PlatformToken)
+	})
 
+	t.Run("Environment URL normalization", func(t *testing.T) {
+		for _, tc := range []struct {
+			name             string
+			envURL           string
+			expectedClassic  string
+			expectedPlatform string
+		}{
+			{
+				name:             "Saas live",
+				envURL:           "https://foo.live.dynatrace.com",
+				expectedClassic:  "https://foo.live.dynatrace.com",
+				expectedPlatform: "https://foo.apps.dynatrace.com",
+			},
+			{
+				name:             "Saas apps normalized to live",
+				envURL:           "https://foo.apps.dynatrace.com",
+				expectedClassic:  "https://foo.live.dynatrace.com",
+				expectedPlatform: "https://foo.apps.dynatrace.com",
+			},
+			{
+				name:             "Trailing slash and space trimmed",
+				envURL:           "https://foo.live.dynatrace.com/ ",
+				expectedClassic:  "https://foo.live.dynatrace.com",
+				expectedPlatform: "https://foo.apps.dynatrace.com",
+			},
+			{
+				name:             "Sprint",
+				envURL:           "https://foo.sprint.dynatracelabs.com",
+				expectedClassic:  "https://foo.sprint.dynatracelabs.com",
+				expectedPlatform: "https://foo.sprint.apps.dynatracelabs.com",
+			},
+			{
+				name:             "Sprint apps normalized",
+				envURL:           "https://foo.sprint.apps.dynatracelabs.com",
+				expectedClassic:  "https://foo.sprint.dynatracelabs.com",
+				expectedPlatform: "https://foo.sprint.apps.dynatracelabs.com",
+			},
+			{
+				name:             "Dev",
+				envURL:           "https://foo.dev.dynatracelabs.com",
+				expectedClassic:  "https://foo.dev.dynatracelabs.com",
+				expectedPlatform: "https://foo.dev.apps.dynatracelabs.com",
+			},
+			{
+				name:             "Dev apps normalized",
+				envURL:           "https://foo.dev.apps.dynatracelabs.com",
+				expectedClassic:  "https://foo.dev.dynatracelabs.com",
+				expectedPlatform: "https://foo.dev.apps.dynatracelabs.com",
+			},
+			{
+				name:             "Managed passthrough",
+				envURL:           "https://managed.example.com/e/abc",
+				expectedClassic:  "https://managed.example.com/e/abc",
+				expectedPlatform: "https://managed.example.com/e/abc",
+			},
+			{
+				name:             "Empty",
+				envURL:           "",
+				expectedClassic:  "",
+				expectedPlatform: "",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := configure(t, mockResourceData{"dt_env_url": tc.envURL})
+				assert.Equal(t, tc.expectedClassic, cfg.EnvironmentURL)
+				assert.Equal(t, tc.expectedPlatform, cfg.Platform.EnvironmentURL)
+			})
+		}
+	})
+
+	t.Run("Explicit platform environment URL overrides derivation", func(t *testing.T) {
+		cfg := configure(t, mockResourceData{
+			"dt_env_url":         "https://foo.live.dynatrace.com",
+			"automation_env_url": "https://custom.apps.example.com/",
+		})
+		assert.Equal(t, "https://foo.live.dynatrace.com", cfg.EnvironmentURL)
+		assert.Equal(t, "https://custom.apps.example.com", cfg.Platform.EnvironmentURL)
+	})
+
+	t.Run("Client ID precedence", func(t *testing.T) {
+		for _, tc := range []struct {
+			name             string
+			data             mockResourceData
+			expectedIAM      string
+			expectedPlatform string
+		}{
+			{
+				name: "Specific keys win per audience",
+				data: mockResourceData{
+					"iam_client_id":        "iam",
+					"client_id":            "generic",
+					"automation_client_id": "automation",
+				},
+				expectedIAM:      "iam",
+				expectedPlatform: "automation",
+			},
+			{
+				name: "Generic client_id shared by both",
+				data: mockResourceData{
+					"client_id": "generic",
+				},
+				expectedIAM:      "generic",
+				expectedPlatform: "generic",
+			},
+			{
+				name: "Only iam_client_id falls through to platform",
+				data: mockResourceData{
+					"iam_client_id": "iam",
+				},
+				expectedIAM:      "iam",
+				expectedPlatform: "iam",
+			},
+			{
+				name: "Only automation_client_id falls through to IAM",
+				data: mockResourceData{
+					"automation_client_id": "automation",
+				},
+				expectedIAM:      "automation",
+				expectedPlatform: "automation",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := configure(t, tc.data)
+				assert.Equal(t, tc.expectedIAM, cfg.IAM.ClientID)
+				assert.Equal(t, tc.expectedPlatform, cfg.Platform.ClientID)
+			})
+		}
+	})
+
+	t.Run("Client secret precedence", func(t *testing.T) {
+		for _, tc := range []struct {
+			name             string
+			data             mockResourceData
+			expectedIAM      string
+			expectedPlatform string
+		}{
+			{
+				name: "Specific keys win per audience",
+				data: mockResourceData{
+					"iam_client_secret":        "iam",
+					"client_secret":            "generic",
+					"automation_client_secret": "automation",
+				},
+				expectedIAM:      "iam",
+				expectedPlatform: "automation",
+			},
+			{
+				name: "Generic client_secret shared by both",
+				data: mockResourceData{
+					"client_secret": "generic",
+				},
+				expectedIAM:      "generic",
+				expectedPlatform: "generic",
+			},
+			{
+				name: "Only iam_client_secret falls through to platform",
+				data: mockResourceData{
+					"iam_client_secret": "iam",
+				},
+				expectedIAM:      "iam",
+				expectedPlatform: "iam",
+			},
+			{
+				name: "Only automation_client_secret falls through to IAM",
+				data: mockResourceData{
+					"automation_client_secret": "automation",
+				},
+				expectedIAM:      "automation",
+				expectedPlatform: "automation",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := configure(t, tc.data)
+				assert.Equal(t, tc.expectedIAM, cfg.IAM.ClientSecret)
+				assert.Equal(t, tc.expectedPlatform, cfg.Platform.ClientSecret)
+			})
+		}
+	})
+
+	t.Run("Account ID precedence and urn prefix trimming", func(t *testing.T) {
+		for _, tc := range []struct {
+			name     string
+			data     mockResourceData
+			expected string
+		}{
+			{
+				name: "iam_account_id wins",
+				data: mockResourceData{
+					"iam_account_id": "iam",
+					"account_id":     "generic",
+				},
+				expected: "iam",
+			},
+			{
+				name: "account_id fallback",
+				data: mockResourceData{
+					"account_id": "generic",
+				},
+				expected: "generic",
+			},
+			{
+				name: "URN prefix trimmed",
+				data: mockResourceData{
+					"iam_account_id": "urn:dtaccount:1234",
+				},
+				expected: "1234",
+			},
+			{
+				name:     "Empty",
+				data:     mockResourceData{},
+				expected: "",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.expected, configure(t, tc.data).IAM.AccountID)
+			})
+		}
+	})
+
+	t.Run("Token URL precedence", func(t *testing.T) {
+		for _, tc := range []struct {
+			name             string
+			data             mockResourceData
+			expectedIAM      string
+			expectedPlatform string
+		}{
+			{
+				name: "Specific keys win per audience",
+				data: mockResourceData{
+					"iam_token_url":        "https://iam.example.com",
+					"token_url":            "https://generic.example.com",
+					"automation_token_url": "https://automation.example.com",
+				},
+				expectedIAM:      "https://iam.example.com",
+				expectedPlatform: "https://automation.example.com",
+			},
+			{
+				name: "Generic token_url shared by both",
+				data: mockResourceData{
+					"token_url": "https://generic.example.com",
+				},
+				expectedIAM:      "https://generic.example.com",
+				expectedPlatform: "https://generic.example.com",
+			},
+			{
+				name: "Only automation_token_url shared by both",
+				data: mockResourceData{
+					"automation_token_url": "https://automation.example.com",
+				},
+				expectedIAM:      "https://automation.example.com",
+				expectedPlatform: "https://automation.example.com",
+			},
+			{
+				name: "Only iam_token_url shared by both",
+				data: mockResourceData{
+					"iam_token_url": "https://iam.example.com",
+				},
+				expectedIAM:      "https://iam.example.com",
+				expectedPlatform: "https://iam.example.com",
+			},
+			{
+				name: "Trailing slash trimmed",
+				data: mockResourceData{
+					"token_url": "https://generic.example.com/",
+				},
+				expectedIAM:      "https://generic.example.com",
+				expectedPlatform: "https://generic.example.com",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := configure(t, tc.data)
+				assert.Equal(t, tc.expectedIAM, cfg.IAM.TokenURL)
+				assert.Equal(t, tc.expectedPlatform, cfg.Platform.TokenURL)
+			})
+		}
+	})
+
+	t.Run("Token and IAM endpoint URL defaults derived from environment", func(t *testing.T) {
+		for _, tc := range []struct {
+			name             string
+			envURL           string
+			expectedTokenURL string
+			expectedEndpoint string
+		}{
+			{
+				name:             "Saas",
+				envURL:           "https://foo.live.dynatrace.com",
+				expectedTokenURL: config.ProdTokenURL,
+				expectedEndpoint: config.ProdIAMEndpointURL,
+			},
+			{
+				name:             "Sprint",
+				envURL:           "https://foo.sprint.dynatracelabs.com",
+				expectedTokenURL: config.SprintTokenURL,
+				expectedEndpoint: config.SprintIAMEndpointURL,
+			},
+			{
+				name:             "Dev",
+				envURL:           "https://foo.dev.dynatracelabs.com",
+				expectedTokenURL: config.DevTokenURL,
+				expectedEndpoint: config.DevIAMEndpointURL,
+			},
+			{
+				name:             "Managed defaults to prod",
+				envURL:           "https://managed.example.com/e/abc",
+				expectedTokenURL: config.ProdTokenURL,
+				expectedEndpoint: config.ProdIAMEndpointURL,
+			},
+			{
+				name:             "Empty defaults to prod",
+				envURL:           "",
+				expectedTokenURL: config.ProdTokenURL,
+				expectedEndpoint: config.ProdIAMEndpointURL,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := configure(t, mockResourceData{"dt_env_url": tc.envURL})
+				assert.Equal(t, tc.expectedTokenURL, cfg.IAM.TokenURL)
+				assert.Equal(t, tc.expectedTokenURL, cfg.Platform.TokenURL)
+				assert.Equal(t, tc.expectedEndpoint, cfg.IAM.EndpointURL)
+			})
+		}
+	})
+
+	t.Run("Explicit IAM endpoint URL overrides derivation", func(t *testing.T) {
+		cfg := configure(t, mockResourceData{
+			"dt_env_url":       "https://foo.sprint.dynatracelabs.com",
+			"iam_endpoint_url": "https://custom-endpoint.example.com/",
+		})
+		assert.Equal(t, "https://custom-endpoint.example.com", cfg.IAM.EndpointURL)
+	})
 }

--- a/provider/config/config_test.go
+++ b/provider/config/config_test.go
@@ -20,10 +20,10 @@
 package config_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockResourceData map[string]any
@@ -33,15 +33,13 @@ func (mrd mockResourceData) Get(k string) any {
 }
 
 func TestProviderConfigure(t *testing.T) {
-	ctx := context.Background()
 	d := mockResourceData{
 		"dt_env_url":   "https://something.live.dynatrace.com",
 		"dt_api_token": "faketoken",
 	}
 
-	result, _ := config.ProviderConfigureGeneric(ctx, d)
+	result, _ := config.ProviderConfigureGeneric(t.Context(), d)
 	configuration := result.(*config.ProviderConfiguration)
-	if configuration.DTenvURL != "https://something.live.dynatrace.com/api/config/v1" {
-		t.Fail()
-	}
+	assert.Equal(t, "https://something.live.dynatrace.com", configuration.EnvironmentURL)
+
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -53,7 +53,7 @@ func TestIAMClientID(t *testing.T) {
 			if !assert.Equal(iam_client_id, credentials.IAM.ClientID, "credentials.IAM.ClientID") {
 				return
 			}
-			if !assert.Equal(iam_client_id, credentials.OAuth.ClientID, "credentials.Automation.ClientID") {
+			if !assert.Equal(iam_client_id, credentials.Platform.ClientID, "credentials.Automation.ClientID") {
 				return
 			}
 		})
@@ -83,7 +83,7 @@ func TestIAMClientSecret(t *testing.T) {
 			if !assert.Equal(iam_client_secret, credentials.IAM.ClientSecret, "credentials.IAM.ClientSecret") {
 				return
 			}
-			if !assert.Equal(iam_client_secret, credentials.OAuth.ClientSecret, "credentials.Automation.ClientSecret") {
+			if !assert.Equal(iam_client_secret, credentials.Platform.ClientSecret, "credentials.Automation.ClientSecret") {
 				return
 			}
 		})
@@ -107,9 +107,8 @@ func TestSSOTokenURL(t *testing.T) {
 		"https://foo.apps.dynatrace.com/ ",
 	} {
 		t.Run(envURL, func(t *testing.T) {
-			os.Setenv("DYNATRACE_ENV_URL", envURL)
-			defer os.Unsetenv("DYNATRACE_ENV_URL")
-
+			t.Setenv("DYNATRACE_ENV_URL", envURL)
+	
 			credentials := createCredentials(&config.ConfigGetter{Provider: provider})
 			if credentials == nil {
 				return
@@ -120,7 +119,7 @@ func TestSSOTokenURL(t *testing.T) {
 			if !assert.Equal(rest.ProdIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
 				return
 			}
-			if !assert.Equal(rest.ProdTokenURL, credentials.OAuth.TokenURL, "credentials.Automation.TokenURL") {
+			if !assert.Equal(rest.ProdTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
 				return
 			}
 		})
@@ -149,7 +148,7 @@ func TestSSOTokenURL(t *testing.T) {
 			if !assert.Equal(rest.SprintIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
 				return
 			}
-			if !assert.Equal(rest.SprintTokenURL, credentials.OAuth.TokenURL, "credentials.Automation.TokenURL") {
+			if !assert.Equal(rest.SprintTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
 				return
 			}
 		})
@@ -178,7 +177,7 @@ func TestSSOTokenURL(t *testing.T) {
 			if !assert.Equal(rest.DevIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
 				return
 			}
-			if !assert.Equal(rest.DevTokenURL, credentials.OAuth.TokenURL, "credentials.Automation.TokenURL") {
+			if !assert.Equal(rest.DevTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
 				return
 			}
 		})

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -108,18 +108,18 @@ func TestSSOTokenURL(t *testing.T) {
 	} {
 		t.Run(envURL, func(t *testing.T) {
 			t.Setenv("DYNATRACE_ENV_URL", envURL)
-	
+
 			credentials := createCredentials(&config.ConfigGetter{Provider: provider})
 			if credentials == nil {
 				return
 			}
-			if !assert.Equal(rest.ProdTokenURL, credentials.IAM.TokenURL, "credentials.IAM.TokenURL") {
+			if !assert.Equal(config.ProdTokenURL, credentials.IAM.TokenURL, "credentials.IAM.TokenURL") {
 				return
 			}
-			if !assert.Equal(rest.ProdIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
+			if !assert.Equal(config.ProdIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
 				return
 			}
-			if !assert.Equal(rest.ProdTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
+			if !assert.Equal(config.ProdTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
 				return
 			}
 		})
@@ -142,13 +142,13 @@ func TestSSOTokenURL(t *testing.T) {
 			if credentials == nil {
 				return
 			}
-			if !assert.Equal(rest.SprintTokenURL, credentials.IAM.TokenURL, "credentials.IAM.TokenURL") {
+			if !assert.Equal(config.SprintTokenURL, credentials.IAM.TokenURL, "credentials.IAM.TokenURL") {
 				return
 			}
-			if !assert.Equal(rest.SprintIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
+			if !assert.Equal(config.SprintIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
 				return
 			}
-			if !assert.Equal(rest.SprintTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
+			if !assert.Equal(config.SprintTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
 				return
 			}
 		})
@@ -171,13 +171,13 @@ func TestSSOTokenURL(t *testing.T) {
 			if credentials == nil {
 				return
 			}
-			if !assert.Equal(rest.DevTokenURL, credentials.IAM.TokenURL, "credentials.IAM.TokenURL") {
+			if !assert.Equal(config.DevTokenURL, credentials.IAM.TokenURL, "credentials.IAM.TokenURL") {
 				return
 			}
-			if !assert.Equal(rest.DevIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
+			if !assert.Equal(config.DevIAMEndpointURL, credentials.IAM.EndpointURL, "credentials.IAM.EndpointURL") {
 				return
 			}
-			if !assert.Equal(rest.DevTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
+			if !assert.Equal(config.DevTokenURL, credentials.Platform.TokenURL, "credentials.Automation.TokenURL") {
 				return
 			}
 		})

--- a/resources/generic.go
+++ b/resources/generic.go
@@ -183,7 +183,7 @@ func (me *Generic) createCredentials(m any) (*rest.Credentials, error) {
 		Token: conf.APIToken,
 		URL:   conf.EnvironmentURL,
 		IAM:   conf.IAM,
-		OAuth: conf.Automation,
+		Platform: conf.Platform,
 	}, nil
 }
 


### PR DESCRIPTION
#### **Why** this PR?
This PR cleans up the provider configuration. While not _strictly_ necessary, it helps to prepare it for subsequent refactoring.

#### **What** has changed and **how** does it do it?
- Unused fields are removed from `config.ProviderConfiguration`.
- The term `Platform` is used to group platform credentials, rather than `OAuth` or `Automation`
- Restructuring of rules used to build the credentials from the provider block with the aim of increasing readability and consistency:
  - When no token URL is explicitly configured, ProviderConfigureGeneric now derives the SSO token endpoint from the environment URL (Sprint→Sprint SSO, Dev→Dev SSO, otherwise Prod) instead of defaulting to production in cases like a Sprint/Dev tenant with automation_env_url set. All explicit precedence rules for token URLs, client IDs/secrets, account ID, and IAM endpoint URL remain unchanged.

#### How is it **tested**?
- Existing tests,
- Extended `provider/config/config_test.go`

#### How does it affect **users**?
For production users, very little effect.  On Sprint/Dev environments, the token URL now defaults to the corresponding non-production SSO endpoint instead of production. URL cleaning is now consistent (whitespace and trailing `/` trimmed).

**Issue:** PS-45615
