### PR TITLE
refactor: Add shared IAM client to clientset

### DIFF
--- a/datasources/iam/environments/data_source.go
+++ b/datasources/iam/environments/data_source.go
@@ -97,7 +97,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	service := newEnvironmentService(clientSet)
+	service := newEnvironmentService(ctx, clientSet)
 	envs, err := service.Get(ctx)
 	if err != nil {
 		return diag.FromErr(err)

--- a/datasources/iam/environments/data_source.go
+++ b/datasources/iam/environments/data_source.go
@@ -97,7 +97,11 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	service := newEnvironmentService(ctx, clientSet)
+	service, err := newEnvironmentService(clientSet)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	envs, err := service.Get(ctx)
 	if err != nil {
 		return diag.FromErr(err)

--- a/datasources/iam/environments/service.go
+++ b/datasources/iam/environments/service.go
@@ -28,12 +28,12 @@ import (
 const baseURL = "/env/v2/accounts"
 
 type environmentsService struct {
-	credentials *rest.Credentials
+	client rest.IAMClient
 }
 
-func newEnvironmentService(clientSet rest.ClientSet) *environmentsService {
+func newEnvironmentService(ctx context.Context, clientSet rest.ClientSet) *environmentsService {
 	return &environmentsService{
-		credentials: clientSet.Credentials(),
+		client: rest.NewIAMClient(ctx, clientSet.Credentials()),
 	}
 }
 
@@ -49,13 +49,12 @@ type Response struct {
 }
 
 func (ec *environmentsService) Get(ctx context.Context) ([]Environment, error) {
-	u, err := url.JoinPath(baseURL, ec.credentials.IAM.AccountID, "environments")
+	u, err := url.JoinPath(baseURL, ec.client.AccountID(), "environments")
 	if err != nil {
 		return nil, err
 	}
 
-	client := rest.NewIAMClient(ctx, ec.credentials)
-	response, err := client.GET(ctx, u, rest2.RequestOptions{})
+	response, err := ec.client.GET(ctx, u, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/datasources/iam/environments/service.go
+++ b/datasources/iam/environments/service.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
@@ -55,7 +54,7 @@ func (ec *environmentsService) Get(ctx context.Context) ([]Environment, error) {
 		return nil, err
 	}
 
-	client := iam.NewIAMClient(ctx, ec.credentials)
+	client := rest.NewIAMClient(ctx, ec.credentials)
 	response, err := client.GET(ctx, u, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err

--- a/datasources/iam/environments/service.go
+++ b/datasources/iam/environments/service.go
@@ -31,10 +31,15 @@ type environmentsService struct {
 	client rest.IAMClient
 }
 
-func newEnvironmentService(ctx context.Context, clientSet rest.ClientSet) *environmentsService {
-	return &environmentsService{
-		client: rest.NewIAMClient(ctx, clientSet.Credentials()),
+func newEnvironmentService(clientSet rest.ClientSet) (*environmentsService, error) {
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
 	}
+
+	return &environmentsService{
+		client: iamClient,
+	}, nil
 }
 
 type Environment struct {

--- a/datasources/iam/policies/data_source.go
+++ b/datasources/iam/policies/data_source.go
@@ -140,7 +140,11 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 
 	discoveredLevels := map[string]string{}
 
-	service := policies.ServiceWithGlobals(clientSet)
+	service, err := policies.ServiceWithGlobals(clientSet)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	stubs, err := service.ListWithGlobals(ctx)
 	if err != nil {
 		return diag.FromErr(err)

--- a/datasources/iam/policies/data_source.go
+++ b/datasources/iam/policies/data_source.go
@@ -140,7 +140,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 
 	discoveredLevels := map[string]string{}
 
-	service := policies.ServiceWithGloabals(clientSet)
+	service := policies.ServiceWithGlobals(clientSet)
 	stubs, err := service.ListWithGlobals(ctx)
 	if err != nil {
 		return diag.FromErr(err)

--- a/datasources/iam/policies/data_source_single.go
+++ b/datasources/iam/policies/data_source_single.go
@@ -78,7 +78,11 @@ func DataSourceSingleRead(ctx context.Context, d *schema.ResourceData, m any) di
 		return diag.FromErr(err)
 	}
 
-	service := policies.ServiceWithGlobals(clientSet)
+	service, err := policies.ServiceWithGlobals(clientSet)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	stubs, err := service.ListWithGlobals(ctx)
 	if err != nil {
 		return diag.FromErr(err)

--- a/datasources/iam/policies/data_source_single.go
+++ b/datasources/iam/policies/data_source_single.go
@@ -78,7 +78,7 @@ func DataSourceSingleRead(ctx context.Context, d *schema.ResourceData, m any) di
 		return diag.FromErr(err)
 	}
 
-	service := policies.ServiceWithGloabals(clientSet)
+	service := policies.ServiceWithGlobals(clientSet)
 	stubs, err := service.ListWithGlobals(ctx)
 	if err != nil {
 		return diag.FromErr(err)

--- a/dynatrace/api/iam/bindings/service.go
+++ b/dynatrace/api/iam/bindings/service.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	bindings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/bindings/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/policies"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
@@ -68,7 +67,7 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 	if err != nil {
 		return err
 	}
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 
 	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{})
 	if err != nil {
@@ -96,7 +95,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, bindings 
 		return err
 	}
 
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 
 	policyIDs := []string{}
 	for _, policyID := range bindings.PolicyIDs {
@@ -139,7 +138,7 @@ type ListPolicyUUIDsForGroupResponse struct {
 }
 
 func (me *BindingServiceClient) GetPolicyUUIDsForGroup(ctx context.Context, groupID string, levelType string, levelID string) ([]string, error) {
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
@@ -153,7 +152,7 @@ func (me *BindingServiceClient) GetPolicyUUIDsForGroup(ctx context.Context, grou
 }
 
 func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 
 	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", me.credentials.IAM.AccountID), rest2.RequestOptions{})
 	if err != nil {
@@ -227,7 +226,7 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 		if err != nil {
 			return err
 		}
-		if _, err = iam.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), rest2.RequestOptions{}); err != nil {
+		if _, err = rest.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), rest2.RequestOptions{}); err != nil {
 
 			// The API currently returns a 400 Bad Request when the binding does not exist
 			if apiErr, ok := errors.AsType[coreapi.APIError](err); ok && apiErr.StatusCode == http.StatusBadRequest {

--- a/dynatrace/api/iam/bindings/service.go
+++ b/dynatrace/api/iam/bindings/service.go
@@ -154,7 +154,7 @@ func (me *BindingServiceClient) GetPolicyUUIDsForGroup(ctx context.Context, grou
 func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	client := rest.NewIAMClient(ctx, me.credentials)
 
-	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", me.credentials.IAM.AccountID), rest2.RequestOptions{})
+	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 		return nil, err
 	}
 
-	response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.credentials.IAM.AccountID), rest2.RequestOptions{})
+	response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	for _, policy := range policyBindingsResponse.PolicyBindings {
 		for _, group := range policy.Groups {
 			if _, exists := groupIds[group]; !exists {
-				id := join(group, "account", me.credentials.IAM.AccountID)
+				id := join(group, "account", client.AccountID())
 				stubs = append(stubs, &api.Stub{ID: id, Name: "PolicyBindings-" + id})
 				groupIds[group] = true
 			}

--- a/dynatrace/api/iam/bindings/service.go
+++ b/dynatrace/api/iam/bindings/service.go
@@ -35,11 +35,15 @@ import (
 )
 
 type BindingServiceClient struct {
-	credentials *rest.Credentials
+	client rest.IAMClient
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*bindings.PolicyBinding], error) {
-	return &BindingServiceClient{credentials: clientSet.Credentials()}, nil
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
+	}
+	return &BindingServiceClient{client: iamClient}, nil
 }
 
 func (me *BindingServiceClient) SchemaID() string {
@@ -67,9 +71,8 @@ func (me *BindingServiceClient) Get(ctx context.Context, id string, v *bindings.
 	if err != nil {
 		return err
 	}
-	client := rest.NewIAMClient(ctx, me.credentials)
 
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -95,8 +98,6 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, bindings 
 		return err
 	}
 
-	client := rest.NewIAMClient(ctx, me.credentials)
-
 	policyIDs := []string{}
 	for _, policyID := range bindings.PolicyIDs {
 		uuid, policyLevelType, policyLevelID, err := policies.SplitID(policyID, levelType, levelID)
@@ -111,7 +112,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, bindings 
 	}
 	bindings.PolicyIDs = policyIDs
 
-	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), bindings, rest2.RequestOptions{}); err != nil {
+	if _, err = me.client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), bindings, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -138,8 +139,7 @@ type ListPolicyUUIDsForGroupResponse struct {
 }
 
 func (me *BindingServiceClient) GetPolicyUUIDsForGroup(ctx context.Context, groupID string, levelType string, levelID string) ([]string, error) {
-	client := rest.NewIAMClient(ctx, me.credentials)
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -152,9 +152,7 @@ func (me *BindingServiceClient) GetPolicyUUIDsForGroup(ctx context.Context, grou
 }
 
 func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	client := rest.NewIAMClient(ctx, me.credentials)
-
-	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", client.AccountID()), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", me.client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +162,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 		return nil, err
 	}
 
-	response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", client.AccountID()), rest2.RequestOptions{})
+	response, err = me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +177,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	for _, policy := range policyBindingsResponse.PolicyBindings {
 		for _, group := range policy.Groups {
 			if _, exists := groupIds[group]; !exists {
-				id := join(group, "account", client.AccountID())
+				id := join(group, "account", me.client.AccountID())
 				stubs = append(stubs, &api.Stub{ID: id, Name: "PolicyBindings-" + id})
 				groupIds[group] = true
 			}
@@ -187,7 +185,7 @@ func (me *BindingServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	}
 
 	for _, environment := range envResponse.Data {
-		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/bindings", environment.ID), rest2.RequestOptions{})
+		response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/bindings", environment.ID), rest2.RequestOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +224,7 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 		if err != nil {
 			return err
 		}
-		if _, err = rest.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), rest2.RequestOptions{}); err != nil {
+		if _, err = me.client.DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), rest2.RequestOptions{}); err != nil {
 
 			// The API currently returns a 400 Bad Request when the binding does not exist
 			if apiErr, ok := errors.AsType[coreapi.APIError](err); ok && apiErr.StatusCode == http.StatusBadRequest {

--- a/dynatrace/api/iam/boundaries/service.go
+++ b/dynatrace/api/iam/boundaries/service.go
@@ -40,7 +40,6 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*boundaries.PolicyB
 		iamClientGetter: &iamClientGetterImp{
 			credentials: clientSet.Credentials(),
 		},
-		accountID: clientSet.Credentials().IAM.AccountID,
 	}, nil
 }
 
@@ -58,7 +57,6 @@ func (me *iamClientGetterImp) New(ctx context.Context) rest.IAMClient {
 
 type BoundaryServiceClient struct {
 	iamClientGetter iamClientGetter
-	accountID       string
 }
 
 func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
@@ -66,7 +64,7 @@ func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	stubs := api.Stubs{}
 	params := url.Values{}
 	params.Set("size", strconv.Itoa(maxPageSize))
-	endpoint := fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", me.accountID)
+	endpoint := fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", client.AccountID())
 
 	for page := 1; ; page++ {
 		params.Set("page", strconv.Itoa(page))
@@ -93,7 +91,8 @@ func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *BoundaryServiceClient) Get(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
-	response, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id), rest2.RequestOptions{})
+	client := me.iamClientGetter.New(ctx)
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", client.AccountID(), id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -106,9 +105,10 @@ func (me *BoundaryServiceClient) SchemaID() string {
 }
 
 func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.PolicyBoundary) (*api.Stub, error) {
-	response, err := me.iamClientGetter.New(ctx).POST(
+	client := me.iamClientGetter.New(ctx)
+	response, err := client.POST(
 		ctx,
-		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", me.accountID),
+		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", client.AccountID()),
 		v,
 		rest2.RequestOptions{},
 	)
@@ -129,9 +129,10 @@ func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.Polic
 }
 
 func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
-	_, err := me.iamClientGetter.New(ctx).PUT(
+	client := me.iamClientGetter.New(ctx)
+	_, err := client.PUT(
 		ctx,
-		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id),
+		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", client.AccountID(), id),
 		v,
 		rest2.RequestOptions{},
 	)
@@ -142,7 +143,7 @@ func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
 	client := me.iamClientGetter.New(ctx)
 	_, err := client.DELETE(
 		ctx,
-		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id),
+		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", client.AccountID(), id),
 		rest2.RequestOptions{},
 	)
 	if err != nil {
@@ -150,7 +151,7 @@ func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
 			clean.CleanUp.Register(func() {
 				client.DELETE(
 					ctx,
-					fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.accountID, id),
+					fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", client.AccountID(), id),
 					rest2.RequestOptions{},
 				)
 			})

--- a/dynatrace/api/iam/boundaries/service.go
+++ b/dynatrace/api/iam/boundaries/service.go
@@ -36,39 +36,26 @@ import (
 const maxPageSize = 10000
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*boundaries.PolicyBoundary], error) {
-	return &BoundaryServiceClient{
-		iamClientGetter: &iamClientGetterImp{
-			credentials: clientSet.Credentials(),
-		},
-	}, nil
-}
-
-type iamClientGetter interface {
-	New(ctx context.Context) rest.IAMClient
-}
-
-type iamClientGetterImp struct {
-	credentials *rest.Credentials
-}
-
-func (me *iamClientGetterImp) New(ctx context.Context) rest.IAMClient {
-	return rest.NewIAMClient(ctx, me.credentials)
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
+	}
+	return &BoundaryServiceClient{client: iamClient}, nil
 }
 
 type BoundaryServiceClient struct {
-	iamClientGetter iamClientGetter
+	client rest.IAMClient
 }
 
 func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	client := me.iamClientGetter.New(ctx)
 	stubs := api.Stubs{}
 	params := url.Values{}
 	params.Set("size", strconv.Itoa(maxPageSize))
-	endpoint := fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", client.AccountID())
+	endpoint := fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", me.client.AccountID())
 
 	for page := 1; ; page++ {
 		params.Set("page", strconv.Itoa(page))
-		response, err := client.GET(ctx, endpoint, rest2.RequestOptions{QueryParams: params})
+		response, err := me.client.GET(ctx, endpoint, rest2.RequestOptions{QueryParams: params})
 		if err != nil {
 			return nil, err
 		}
@@ -91,8 +78,7 @@ func (me *BoundaryServiceClient) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *BoundaryServiceClient) Get(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
-	client := me.iamClientGetter.New(ctx)
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", client.AccountID(), id), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.client.AccountID(), id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -105,10 +91,9 @@ func (me *BoundaryServiceClient) SchemaID() string {
 }
 
 func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.PolicyBoundary) (*api.Stub, error) {
-	client := me.iamClientGetter.New(ctx)
-	response, err := client.POST(
+	response, err := me.client.POST(
 		ctx,
-		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", client.AccountID()),
+		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries", me.client.AccountID()),
 		v,
 		rest2.RequestOptions{},
 	)
@@ -129,10 +114,9 @@ func (me *BoundaryServiceClient) Create(ctx context.Context, v *boundaries.Polic
 }
 
 func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *boundaries.PolicyBoundary) error {
-	client := me.iamClientGetter.New(ctx)
-	_, err := client.PUT(
+	_, err := me.client.PUT(
 		ctx,
-		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", client.AccountID(), id),
+		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.client.AccountID(), id),
 		v,
 		rest2.RequestOptions{},
 	)
@@ -140,18 +124,18 @@ func (me *BoundaryServiceClient) Update(ctx context.Context, id string, v *bound
 }
 
 func (me *BoundaryServiceClient) Delete(ctx context.Context, id string) error {
-	client := me.iamClientGetter.New(ctx)
-	_, err := client.DELETE(
+
+	_, err := me.client.DELETE(
 		ctx,
-		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", client.AccountID(), id),
+		fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.client.AccountID(), id),
 		rest2.RequestOptions{},
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "Policy boundary is in use") {
 			clean.CleanUp.Register(func() {
-				client.DELETE(
+				me.client.DELETE(
 					ctx,
-					fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", client.AccountID(), id),
+					fmt.Sprintf("/iam/v1/repo/account/%s/boundaries/%s", me.client.AccountID(), id),
 					rest2.RequestOptions{},
 				)
 			})

--- a/dynatrace/api/iam/boundaries/service.go
+++ b/dynatrace/api/iam/boundaries/service.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	boundaries "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/boundaries/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/clean"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
@@ -46,15 +45,15 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*boundaries.PolicyB
 }
 
 type iamClientGetter interface {
-	New(ctx context.Context) iam.IAMClient
+	New(ctx context.Context) rest.IAMClient
 }
 
 type iamClientGetterImp struct {
 	credentials *rest.Credentials
 }
 
-func (me *iamClientGetterImp) New(ctx context.Context) iam.IAMClient {
-	return iam.NewIAMClient(ctx, me.credentials)
+func (me *iamClientGetterImp) New(ctx context.Context) rest.IAMClient {
+	return rest.NewIAMClient(ctx, me.credentials)
 }
 
 type BoundaryServiceClient struct {

--- a/dynatrace/api/iam/boundaries/service_unit_test.go
+++ b/dynatrace/api/iam/boundaries/service_unit_test.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
@@ -36,10 +35,10 @@ import (
 
 const testAccountID = "test-account-id"
 
-func newTestClient(mock rest.IAMClient) *BoundaryServiceClient {
+func newTestClient(mock *testing2.MockIAMClient) *BoundaryServiceClient {
+	mock.AccountIDValue = testAccountID
 	return &BoundaryServiceClient{
 		iamClientGetter: &testing2.MockIAMClientGetter{Client: mock},
-		accountID:       testAccountID,
 	}
 }
 

--- a/dynatrace/api/iam/boundaries/service_unit_test.go
+++ b/dynatrace/api/iam/boundaries/service_unit_test.go
@@ -37,9 +37,7 @@ const testAccountID = "test-account-id"
 
 func newTestClient(mock *testing2.MockIAMClient) *BoundaryServiceClient {
 	mock.AccountIDValue = testAccountID
-	return &BoundaryServiceClient{
-		iamClientGetter: &testing2.MockIAMClientGetter{Client: mock},
-	}
+	return &BoundaryServiceClient{client: mock}
 }
 
 func boundaryPageResponse(items []PolicyBoundary) []byte {

--- a/dynatrace/api/iam/boundaries/service_unit_test.go
+++ b/dynatrace/api/iam/boundaries/service_unit_test.go
@@ -26,9 +26,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ import (
 
 const testAccountID = "test-account-id"
 
-func newTestClient(mock iam.IAMClient) *BoundaryServiceClient {
+func newTestClient(mock rest.IAMClient) *BoundaryServiceClient {
 	return &BoundaryServiceClient{
 		iamClientGetter: &testing2.MockIAMClientGetter{Client: mock},
 		accountID:       testAccountID,

--- a/dynatrace/api/iam/groups/service.go
+++ b/dynatrace/api/iam/groups/service.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	groups "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/groups/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
@@ -66,7 +65,7 @@ func (me *GroupServiceClient) Name() string {
 // FederatedAttributeValues []string           `json:"federatedAttributeValues"`
 // Permissions              groups.Permissions `json:"permissions"`
 func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (*api.Stub, error) {
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", me.credentials.IAM.AccountID), []*groups.Group{group}, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
@@ -95,7 +94,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 }
 
 func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *groups.Group) error {
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.credentials.IAM.AccountID, uuid), group, rest2.RequestOptions{}); err != nil {
 		return err
 	}
@@ -126,7 +125,7 @@ type ListGroupsResponse struct {
 }
 
 func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 	var groupStubs ListGroupsResponse
 	accountID := me.credentials.IAM.AccountID
 	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", accountID), rest2.RequestOptions{})
@@ -147,7 +146,7 @@ func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
 func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Group) (err error) {
 	var groupStub ListGroup
 	accountID := me.credentials.IAM.AccountID
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", accountID, id), rest2.RequestOptions{})
 	if err != nil {
 		return err
@@ -164,7 +163,7 @@ func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Grou
 }
 
 func (me *GroupServiceClient) Delete(ctx context.Context, id string) error {
-	_, err := iam.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.credentials.IAM.AccountID, id), rest2.RequestOptions{})
+	_, err := rest.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.credentials.IAM.AccountID, id), rest2.RequestOptions{})
 
 	// data sources MAY have cached a list of group IDs
 	// Updating the (publicly available) revision signals to them that either a CREATE or DELETE has happened since

--- a/dynatrace/api/iam/groups/service.go
+++ b/dynatrace/api/iam/groups/service.go
@@ -66,7 +66,7 @@ func (me *GroupServiceClient) Name() string {
 // Permissions              groups.Permissions `json:"permissions"`
 func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (*api.Stub, error) {
 	client := rest.NewIAMClient(ctx, me.credentials)
-	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", me.credentials.IAM.AccountID), []*groups.Group{group}, rest2.RequestOptions{})
+	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", client.AccountID()), []*groups.Group{group}, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 	groupName := responseGroups[0].Name
 
 	if len(group.Permissions) > 0 {
-		if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.credentials.IAM.AccountID, groupID), group.Permissions, rest2.RequestOptions{}); err != nil {
+		if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), groupID), group.Permissions, rest2.RequestOptions{}); err != nil {
 			return nil, err
 		}
 	}
@@ -95,7 +95,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 
 func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *groups.Group) error {
 	client := rest.NewIAMClient(ctx, me.credentials)
-	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.credentials.IAM.AccountID, uuid), group, rest2.RequestOptions{}); err != nil {
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", client.AccountID(), uuid), group, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -104,7 +104,7 @@ func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *gr
 	if len(group.Permissions) > 0 {
 		permissions = group.Permissions
 	}
-	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.credentials.IAM.AccountID, uuid), permissions, rest2.RequestOptions{}); err != nil {
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), uuid), permissions, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -127,8 +127,7 @@ type ListGroupsResponse struct {
 func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	client := rest.NewIAMClient(ctx, me.credentials)
 	var groupStubs ListGroupsResponse
-	accountID := me.credentials.IAM.AccountID
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", accountID), rest2.RequestOptions{})
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -145,9 +144,8 @@ func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
 
 func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Group) (err error) {
 	var groupStub ListGroup
-	accountID := me.credentials.IAM.AccountID
 	client := rest.NewIAMClient(ctx, me.credentials)
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", accountID, id), rest2.RequestOptions{})
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -163,7 +161,8 @@ func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Grou
 }
 
 func (me *GroupServiceClient) Delete(ctx context.Context, id string) error {
-	_, err := rest.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.credentials.IAM.AccountID, id), rest2.RequestOptions{})
+	client := rest.NewIAMClient(ctx, me.credentials)
+	_, err := client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", client.AccountID(), id), rest2.RequestOptions{})
 
 	// data sources MAY have cached a list of group IDs
 	// Updating the (publicly available) revision signals to them that either a CREATE or DELETE has happened since

--- a/dynatrace/api/iam/groups/service.go
+++ b/dynatrace/api/iam/groups/service.go
@@ -43,11 +43,15 @@ func GetRevision() string {
 }
 
 type GroupServiceClient struct {
-	credentials *rest.Credentials
+	client rest.IAMClient
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*groups.Group], error) {
-	return &GroupServiceClient{credentials: clientSet.Credentials()}, nil
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
+	}
+	return &GroupServiceClient{client: iamClient}, nil
 }
 
 func (me *GroupServiceClient) SchemaID() string {
@@ -65,8 +69,7 @@ func (me *GroupServiceClient) Name() string {
 // FederatedAttributeValues []string           `json:"federatedAttributeValues"`
 // Permissions              groups.Permissions `json:"permissions"`
 func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (*api.Stub, error) {
-	client := rest.NewIAMClient(ctx, me.credentials)
-	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", client.AccountID()), []*groups.Group{group}, rest2.RequestOptions{})
+	response, err := me.client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", me.client.AccountID()), []*groups.Group{group}, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +82,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 	groupName := responseGroups[0].Name
 
 	if len(group.Permissions) > 0 {
-		if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), groupID), group.Permissions, rest2.RequestOptions{}); err != nil {
+		if _, err = me.client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.client.AccountID(), groupID), group.Permissions, rest2.RequestOptions{}); err != nil {
 			return nil, err
 		}
 	}
@@ -94,8 +97,7 @@ func (me *GroupServiceClient) Create(ctx context.Context, group *groups.Group) (
 }
 
 func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *groups.Group) error {
-	client := rest.NewIAMClient(ctx, me.credentials)
-	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", client.AccountID(), uuid), group, rest2.RequestOptions{}); err != nil {
+	if _, err := me.client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.client.AccountID(), uuid), group, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -104,7 +106,7 @@ func (me *GroupServiceClient) Update(ctx context.Context, uuid string, group *gr
 	if len(group.Permissions) > 0 {
 		permissions = group.Permissions
 	}
-	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), uuid), permissions, rest2.RequestOptions{}); err != nil {
+	if _, err := me.client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.client.AccountID(), uuid), permissions, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -125,9 +127,8 @@ type ListGroupsResponse struct {
 }
 
 func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	client := rest.NewIAMClient(ctx, me.credentials)
 	var groupStubs ListGroupsResponse
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", client.AccountID()), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups", me.client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +145,7 @@ func (me *GroupServiceClient) List(ctx context.Context) (api.Stubs, error) {
 
 func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Group) (err error) {
 	var groupStub ListGroup
-	client := rest.NewIAMClient(ctx, me.credentials)
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), id), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.client.AccountID(), id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -161,8 +161,7 @@ func (me *GroupServiceClient) Get(ctx context.Context, id string, v *groups.Grou
 }
 
 func (me *GroupServiceClient) Delete(ctx context.Context, id string) error {
-	client := rest.NewIAMClient(ctx, me.credentials)
-	_, err := client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", client.AccountID(), id), rest2.RequestOptions{})
+	_, err := me.client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s", me.client.AccountID(), id), rest2.RequestOptions{})
 
 	// data sources MAY have cached a list of group IDs
 	// Updating the (publicly available) revision signals to them that either a CREATE or DELETE has happened since

--- a/dynatrace/api/iam/permissions/service.go
+++ b/dynatrace/api/iam/permissions/service.go
@@ -69,7 +69,7 @@ func (me *PermissionServiceClient) Create(ctx context.Context, permission *permi
 		ScopeType: scopeType,
 		Name:      permission.Name,
 	}}
-	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.clientSet.Credentials().IAM.AccountID, permission.GroupID), payload, rest2.RequestOptions{}); err != nil {
+	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), permission.GroupID), payload, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -88,7 +88,7 @@ func (me *PermissionServiceClient) Get(ctx context.Context, id string, v *permis
 		return err
 	}
 
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.clientSet.Credentials().IAM.AccountID, groupID), rest2.RequestOptions{})
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), groupID), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -139,10 +139,8 @@ func (me *PermissionServiceClient) List(ctx context.Context) (api.Stubs, error) 
 	for _, groupStub := range groupStubs {
 		groupID := groupStub.ID
 
-		accountID := me.clientSet.Credentials().IAM.AccountID
-
 		var groupPermissionsResponse GetGroupPermissionsResponse
-		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", accountID, groupID), rest2.RequestOptions{})
+		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), groupID), rest2.RequestOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -172,7 +170,8 @@ func (me *PermissionServiceClient) Delete(ctx context.Context, id string) error 
 	queryParams.Set("permission-name", name)
 	queryParams.Set("scope-type", scopeType)
 
-	_, err = rest.NewIAMClient(ctx, me.clientSet.Credentials()).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.clientSet.Credentials().IAM.AccountID, groupID), rest2.RequestOptions{QueryParams: queryParams})
+	client := rest.NewIAMClient(ctx, me.clientSet.Credentials())
+	_, err = client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), groupID), rest2.RequestOptions{QueryParams: queryParams})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("Permission %s not found", id)) {
 		return nil
 	}

--- a/dynatrace/api/iam/permissions/service.go
+++ b/dynatrace/api/iam/permissions/service.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/groups"
 	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/permissions/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
@@ -51,7 +50,7 @@ func (me *PermissionServiceClient) Name() string {
 }
 
 func (me *PermissionServiceClient) Create(ctx context.Context, permission *permissions.Permission) (*api.Stub, error) {
-	client := iam.NewIAMClient(ctx, me.clientSet.Credentials())
+	client := rest.NewIAMClient(ctx, me.clientSet.Credentials())
 	scope := ""
 	scopeType := ""
 	if len(permission.Account) > 0 {
@@ -82,7 +81,7 @@ type GetGroupPermissionsResponse struct {
 }
 
 func (me *PermissionServiceClient) Get(ctx context.Context, id string, v *permissions.Permission) error {
-	client := iam.NewIAMClient(ctx, me.clientSet.Credentials())
+	client := rest.NewIAMClient(ctx, me.clientSet.Credentials())
 
 	groupID, name, scope, scopeType, err := splitID(id)
 	if err != nil {
@@ -136,7 +135,7 @@ func (me *PermissionServiceClient) List(ctx context.Context) (api.Stubs, error) 
 
 	var stubs api.Stubs
 
-	client := iam.NewIAMClient(ctx, me.clientSet.Credentials())
+	client := rest.NewIAMClient(ctx, me.clientSet.Credentials())
 	for _, groupStub := range groupStubs {
 		groupID := groupStub.ID
 
@@ -173,7 +172,7 @@ func (me *PermissionServiceClient) Delete(ctx context.Context, id string) error 
 	queryParams.Set("permission-name", name)
 	queryParams.Set("scope-type", scopeType)
 
-	_, err = iam.NewIAMClient(ctx, me.clientSet.Credentials()).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.clientSet.Credentials().IAM.AccountID, groupID), rest2.RequestOptions{QueryParams: queryParams})
+	_, err = rest.NewIAMClient(ctx, me.clientSet.Credentials()).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.clientSet.Credentials().IAM.AccountID, groupID), rest2.RequestOptions{QueryParams: queryParams})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("Permission %s not found", id)) {
 		return nil
 	}

--- a/dynatrace/api/iam/permissions/service.go
+++ b/dynatrace/api/iam/permissions/service.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/groups"
+	groupSettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/groups/settings"
 	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/permissions/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
@@ -34,11 +35,23 @@ import (
 )
 
 type PermissionServiceClient struct {
-	clientSet rest.ClientSet
+	client        rest.IAMClient
+	groupsService settings.CRUDService[*groupSettings.Group]
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*permissions.Permission], error) {
-	return &PermissionServiceClient{clientSet: clientSet}, nil
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
+	}
+	groupsService, err := groups.Service(clientSet)
+	if err != nil {
+		return nil, err
+	}
+	return &PermissionServiceClient{
+		client:        iamClient,
+		groupsService: groupsService,
+	}, nil
 }
 
 func (me *PermissionServiceClient) SchemaID() string {
@@ -50,7 +63,6 @@ func (me *PermissionServiceClient) Name() string {
 }
 
 func (me *PermissionServiceClient) Create(ctx context.Context, permission *permissions.Permission) (*api.Stub, error) {
-	client := rest.NewIAMClient(ctx, me.clientSet.Credentials())
 	scope := ""
 	scopeType := ""
 	if len(permission.Account) > 0 {
@@ -69,7 +81,7 @@ func (me *PermissionServiceClient) Create(ctx context.Context, permission *permi
 		ScopeType: scopeType,
 		Name:      permission.Name,
 	}}
-	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), permission.GroupID), payload, rest2.RequestOptions{}); err != nil {
+	if _, err := me.client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.client.AccountID(), permission.GroupID), payload, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -81,14 +93,13 @@ type GetGroupPermissionsResponse struct {
 }
 
 func (me *PermissionServiceClient) Get(ctx context.Context, id string, v *permissions.Permission) error {
-	client := rest.NewIAMClient(ctx, me.clientSet.Credentials())
 
 	groupID, name, scope, scopeType, err := splitID(id)
 	if err != nil {
 		return err
 	}
 
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), groupID), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.client.AccountID(), groupID), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -124,23 +135,18 @@ func (me *PermissionServiceClient) Update(ctx context.Context, email string, per
 }
 
 func (me *PermissionServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	groupsService, err := groups.Service(me.clientSet)
-	if err != nil {
-		return nil, err
-	}
-	groupStubs, err := groupsService.List(ctx)
+	groupStubs, err := me.groupsService.List(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var stubs api.Stubs
 
-	client := rest.NewIAMClient(ctx, me.clientSet.Credentials())
 	for _, groupStub := range groupStubs {
 		groupID := groupStub.ID
 
 		var groupPermissionsResponse GetGroupPermissionsResponse
-		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), groupID), rest2.RequestOptions{})
+		response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.client.AccountID(), groupID), rest2.RequestOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -170,8 +176,7 @@ func (me *PermissionServiceClient) Delete(ctx context.Context, id string) error 
 	queryParams.Set("permission-name", name)
 	queryParams.Set("scope-type", scopeType)
 
-	client := rest.NewIAMClient(ctx, me.clientSet.Credentials())
-	_, err = client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", client.AccountID(), groupID), rest2.RequestOptions{QueryParams: queryParams})
+	_, err = me.client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/groups/%s/permissions", me.client.AccountID(), groupID), rest2.RequestOptions{QueryParams: queryParams})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("Permission %s not found", id)) {
 		return nil
 	}

--- a/dynatrace/api/iam/policies/policy_level.go
+++ b/dynatrace/api/iam/policies/policy_level.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
@@ -53,7 +52,7 @@ func CheckPolicyExists(ctx context.Context, credentials *rest.Credentials, level
 		UUID string `json:"uuid"`
 		Name string `json:"name"`
 	}{}
-	client := iam.NewIAMClient(ctx, credentials)
+	client := rest.NewIAMClient(ctx, credentials)
 	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, policyUUID), rest2.RequestOptions{})
 	if err != nil {
 		// A 404 Not Found means the policy is not defined at the given level - that is not an error here
@@ -223,7 +222,7 @@ func FetchAllPolicyLevels(ctx context.Context, credentials *rest.Credentials) (m
 }
 
 func fetchGlobalPolicies(ctx context.Context, credentials *rest.Credentials) (results chan *api.Stub) {
-	client := iam.NewIAMClient(ctx, credentials)
+	client := rest.NewIAMClient(ctx, credentials)
 	results = make(chan *api.Stub)
 	go func() {
 		defer func() {
@@ -313,7 +312,7 @@ func fetchAllPolicyLevels(ctx context.Context, credentials *rest.Credentials) (m
 // GetEnvironmentIDs retrieves all environmentIDs reachable via the given IAM Client
 // The operation is NOT guarded by a mutex. See `GetEnvironmentIDs` for a guarded version
 func getEnvironmentIDs(ctx context.Context, credentials *rest.Credentials) ([]string, error) {
-	client := iam.NewIAMClient(ctx, credentials)
+	client := rest.NewIAMClient(ctx, credentials)
 
 	var envResponse ListEnvResponse
 	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", credentials.IAM.AccountID), rest2.RequestOptions{})

--- a/dynatrace/api/iam/policies/policy_level.go
+++ b/dynatrace/api/iam/policies/policy_level.go
@@ -86,11 +86,12 @@ func fetchPolicyLevel(ctx context.Context, credentials *rest.Credentials, uuid s
 		return "global", "global", name, nil
 	}
 
-	if exists, name, err = CheckPolicyExists(ctx, credentials, "account", credentials.IAM.AccountID, uuid); err != nil {
+	accountID := rest.NewIAMClient(ctx, credentials).AccountID()
+	if exists, name, err = CheckPolicyExists(ctx, credentials, "account", accountID, uuid); err != nil {
 		return "", "", name, err
 	}
 	if exists {
-		return "account", credentials.IAM.AccountID, name, nil
+		return "account", accountID, name, nil
 	}
 
 	var environmentIDs []string
@@ -299,7 +300,7 @@ func getEnvironmentIDs(ctx context.Context, credentials *rest.Credentials) ([]st
 	client := rest.NewIAMClient(ctx, credentials)
 
 	var envResponse ListEnvResponse
-	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", credentials.IAM.AccountID), rest2.RequestOptions{})
+	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/iam/policies/policy_level.go
+++ b/dynatrace/api/iam/policies/policy_level.go
@@ -67,22 +67,6 @@ func CheckPolicyExists(ctx context.Context, credentials *rest.Credentials, level
 	return true, levelPolicy.Name, nil
 }
 
-// FetchPolicyLevel determines the `levelType` and `levelID` of a policy identified by its UUID
-// by trial and error, i.e. requests the policy from the REST API using all known combinations
-//
-// Option 1: The policy is a global policy (levelType = global, levelID = global)
-// Option 2: The policy is on the account level, identified by the argument `accountID` (levelType = account, levelID = `accountID` argument)
-// Option 3: The policy is on the environment level. ALL environments reachable via the account are being taken into consideration
-//
-// # If all attempts fail the returned error contains the UUID in its message
-//
-// This operation is guarded by a mutex
-func FetchPolicyLevel(ctx context.Context, credentials *rest.Credentials, uuid string) (levelType string, levelID string, name string, err error) {
-	allPoliciesMutex.Lock()
-	defer allPoliciesMutex.Unlock()
-	return fetchPolicyLevel(ctx, credentials, uuid)
-}
-
 // fetchPolicyLevel determines the `levelType` and `levelID` of a policy identified by its UUID
 // by trial and error, i.e. requests the policy from the REST API using all known combinations
 //

--- a/dynatrace/api/iam/policies/policy_level.go
+++ b/dynatrace/api/iam/policies/policy_level.go
@@ -34,25 +34,25 @@ var envIDFetcMutex sync.Mutex
 
 // GetEnvironmentIDs retrieves all environmentIDs reachable via the given accountID
 // The operation is guarded by a mutex
-func GetEnvironmentIDs(ctx context.Context, credentials *rest.Credentials) ([]string, error) {
+func GetEnvironmentIDs(ctx context.Context, client rest.IAMClient) ([]string, error) {
 	envIDFetcMutex.Lock()
 	defer envIDFetcMutex.Unlock()
 	if cachedEnvironmentIDs != nil {
 		return cachedEnvironmentIDs, nil
 	}
-	return getEnvironmentIDs(ctx, credentials)
+	return getEnvironmentIDs(ctx, client)
 }
 
 // CheckPolicyExists attempts to fetch the details of a policy, identified by the given `policyUUID`
 // and the presumed `levelType` and `levelID`. If the policy is not defined at the given `levelType`
 // and `levelID` it returns false, without returning an error
 // An error is returned ONLY if querying for the existence of the policy failed for another reason than `404 Not Found`
-func CheckPolicyExists(ctx context.Context, credentials *rest.Credentials, levelType string, levelID string, policyUUID string) (bool, string, error) {
+func CheckPolicyExists(ctx context.Context, client rest.IAMClient, levelType string, levelID string, policyUUID string) (bool, string, error) {
 	levelPolicy := struct {
 		UUID string `json:"uuid"`
 		Name string `json:"name"`
 	}{}
-	client := rest.NewIAMClient(ctx, credentials)
+
 	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, policyUUID), rest2.RequestOptions{})
 	if err != nil {
 		// A 404 Not Found means the policy is not defined at the given level - that is not an error here
@@ -77,29 +77,28 @@ func CheckPolicyExists(ctx context.Context, credentials *rest.Credentials, level
 // # If all attempts fail the returned error contains the UUID in its message
 //
 // This operation is NOT guarded by a mutex. See `FetchPolicyLevel` for a guarded version
-func fetchPolicyLevel(ctx context.Context, credentials *rest.Credentials, uuid string) (levelType string, levelID string, name string, err error) {
+func fetchPolicyLevel(ctx context.Context, client rest.IAMClient, uuid string) (levelType string, levelID string, name string, err error) {
 	var exists bool
-	if exists, name, err = CheckPolicyExists(ctx, credentials, "global", "global", uuid); err != nil {
+	if exists, name, err = CheckPolicyExists(ctx, client, "global", "global", uuid); err != nil {
 		return "", "", "", err
 	}
 	if exists {
 		return "global", "global", name, nil
 	}
 
-	accountID := rest.NewIAMClient(ctx, credentials).AccountID()
-	if exists, name, err = CheckPolicyExists(ctx, credentials, "account", accountID, uuid); err != nil {
+	if exists, name, err = CheckPolicyExists(ctx, client, "account", client.AccountID(), uuid); err != nil {
 		return "", "", name, err
 	}
 	if exists {
-		return "account", accountID, name, nil
+		return "account", client.AccountID(), name, nil
 	}
 
 	var environmentIDs []string
-	if environmentIDs, err = GetEnvironmentIDs(ctx, credentials); err != nil {
+	if environmentIDs, err = GetEnvironmentIDs(ctx, client); err != nil {
 		return "", "", name, err
 	}
 	for _, environmentID := range environmentIDs {
-		if exists, name, err = CheckPolicyExists(ctx, credentials, "environment", environmentID, uuid); err != nil {
+		if exists, name, err = CheckPolicyExists(ctx, client, "environment", environmentID, uuid); err != nil {
 			return "", "", name, err
 		}
 		if exists {
@@ -116,10 +115,10 @@ func fetchPolicyLevel(ctx context.Context, credentials *rest.Credentials, uuid s
 //     resolved using trial and error (see `fetchPolicyLevel`)
 //
 // This operation is guarded by a mutex
-func ResolvePolicyLevel(ctx context.Context, credentials *rest.Credentials, uuid string) (levelType string, levelID string, name string, err error) {
+func ResolvePolicyLevel(ctx context.Context, client rest.IAMClient, uuid string) (levelType string, levelID string, name string, err error) {
 	allPoliciesMutex.Lock()
 	defer allPoliciesMutex.Unlock()
-	return resolvePolicyLevel(ctx, credentials, uuid)
+	return resolvePolicyLevel(ctx, client, uuid)
 }
 
 // ResolvePolicyLevel determines the `levelType` and `levelID` of a policy using different strategies
@@ -128,8 +127,8 @@ func ResolvePolicyLevel(ctx context.Context, credentials *rest.Credentials, uuid
 //     resolved using trial and error (see `fetchPolicyLevel`)
 //
 // This operation is NOT guarded by a mutex. See `ResolvePolicyLevel` for a guarded version
-func resolvePolicyLevel(ctx context.Context, credentials *rest.Credentials, uuid string) (levelType string, levelID string, name string, err error) {
-	allPolicyLevels, err := fetchAllPolicyLevels(ctx, credentials)
+func resolvePolicyLevel(ctx context.Context, client rest.IAMClient, uuid string) (levelType string, levelID string, name string, err error) {
+	allPolicyLevels, err := fetchAllPolicyLevels(ctx, client)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -137,8 +136,8 @@ func resolvePolicyLevel(ctx context.Context, credentials *rest.Credentials, uuid
 	if found {
 		return pl.LevelType, pl.LevelID, pl.Name, nil
 	}
-	if levelType, levelID, name, err = fetchPolicyLevel(ctx, credentials, uuid); err == nil {
-		if err2 := registerPolicyLevel(ctx, credentials, PolicyLevel{UUID: uuid, LevelType: levelType, LevelID: levelID, Name: name}); err2 != nil {
+	if levelType, levelID, name, err = fetchPolicyLevel(ctx, client, uuid); err == nil {
+		if err2 := registerPolicyLevel(ctx, client, PolicyLevel{UUID: uuid, LevelType: levelType, LevelID: levelID, Name: name}); err2 != nil {
 			return levelType, levelID, name, err2
 		}
 	}
@@ -163,10 +162,10 @@ var allPoliciesMutex sync.Mutex
 // # An error will be returned in case loading all known polices from the REST API fails for some reason
 //
 // This operation is guarded by a mutex.
-func RegisterPolicyLevel(ctx context.Context, credentials *rest.Credentials, level PolicyLevel) error {
+func RegisterPolicyLevel(ctx context.Context, client rest.IAMClient, level PolicyLevel) error {
 	allPoliciesMutex.Lock()
 	defer allPoliciesMutex.Unlock()
-	return registerPolicyLevel(ctx, credentials, level)
+	return registerPolicyLevel(ctx, client, level)
 }
 
 // registerPolicyLevel notes down the `levelType` and `levelID` of the policy identified by the given `uuid`.
@@ -177,7 +176,7 @@ func RegisterPolicyLevel(ctx context.Context, credentials *rest.Credentials, lev
 // # An error will be returned in case loading all known polices from the REST API fails for some reason
 //
 // This operation is NOT guarded by a mutex. See `RegisterPolicyLevel` for a guarded version
-func registerPolicyLevel(ctx context.Context, credentials *rest.Credentials, level PolicyLevel) error {
+func registerPolicyLevel(ctx context.Context, client rest.IAMClient, level PolicyLevel) error {
 	// fmt.Println("[POLICY-LEVEL]", "[REGISTER]", "["+level.UUID+"]", "BEGIN")
 	// start := time.Now()
 	// defer func() {
@@ -185,7 +184,7 @@ func registerPolicyLevel(ctx context.Context, credentials *rest.Credentials, lev
 	// }()
 
 	if globalAllPolicyLevels == nil {
-		_, err := fetchAllPolicyLevels(ctx, credentials)
+		_, err := fetchAllPolicyLevels(ctx, client)
 		if err != nil {
 			return err
 		}
@@ -200,14 +199,13 @@ func registerPolicyLevel(ctx context.Context, credentials *rest.Credentials, lev
 // # You should use `ResolvePolicyLevel` to look up the `levelType` and `levelID` of a policy identifed by a UUID only
 //
 // This operation is guarded by a mutext
-func FetchAllPolicyLevels(ctx context.Context, credentials *rest.Credentials) (map[string]PolicyLevel, error) {
+func FetchAllPolicyLevels(ctx context.Context, client rest.IAMClient) (map[string]PolicyLevel, error) {
 	allPoliciesMutex.Lock()
 	defer allPoliciesMutex.Unlock()
-	return fetchAllPolicyLevels(ctx, credentials)
+	return fetchAllPolicyLevels(ctx, client)
 }
 
-func fetchGlobalPolicies(ctx context.Context, credentials *rest.Credentials) (results chan *api.Stub) {
-	client := rest.NewIAMClient(ctx, credentials)
+func fetchGlobalPolicies(ctx context.Context, client rest.IAMClient) (results chan *api.Stub) {
 	results = make(chan *api.Stub)
 	go func() {
 		defer func() {
@@ -237,7 +235,7 @@ func fetchGlobalPolicies(ctx context.Context, credentials *rest.Credentials) (re
 // # You should use `ResolvePolicyLevel` to look up the `levelType` and `levelID` of a policy identifed by a UUID only
 //
 // This operation is NOT guarded by a mutext. See `FetchAllPolicyLevels` for a guarded version
-func fetchAllPolicyLevels(ctx context.Context, credentials *rest.Credentials) (m map[string]PolicyLevel, err error) {
+func fetchAllPolicyLevels(ctx context.Context, client rest.IAMClient) (m map[string]PolicyLevel, err error) {
 	if globalAllPolicyLevels != nil {
 		return globalAllPolicyLevels, nil
 	}
@@ -245,11 +243,11 @@ func fetchAllPolicyLevels(ctx context.Context, credentials *rest.Credentials) (m
 	// defer func() {
 	// 	fmt.Println("[POLICY-LEVEL]", "[FETCH-ALL]", fmt.Sprintf("... LASTED %v seconds", int64(time.Since(start).Seconds())))
 	// }()
-	nonGlobalStubs, err := list(ctx, credentials)
+	nonGlobalStubs, err := list(ctx, client)
 	if err != nil {
 		return nil, err
 	}
-	globalStubs := fetchGlobalPolicies(ctx, credentials)
+	globalStubs := fetchGlobalPolicies(ctx, client)
 
 	m = map[string]PolicyLevel{}
 
@@ -296,8 +294,7 @@ func fetchAllPolicyLevels(ctx context.Context, credentials *rest.Credentials) (m
 
 // GetEnvironmentIDs retrieves all environmentIDs reachable via the given IAM Client
 // The operation is NOT guarded by a mutex. See `GetEnvironmentIDs` for a guarded version
-func getEnvironmentIDs(ctx context.Context, credentials *rest.Credentials) ([]string, error) {
-	client := rest.NewIAMClient(ctx, credentials)
+func getEnvironmentIDs(ctx context.Context, client rest.IAMClient) ([]string, error) {
 
 	var envResponse ListEnvResponse
 	response, err := client.GET(ctx, fmt.Sprintf("/env/v2/accounts/%s/environments", client.AccountID()), rest2.RequestOptions{})

--- a/dynatrace/api/iam/policies/service.go
+++ b/dynatrace/api/iam/policies/service.go
@@ -230,7 +230,7 @@ func listForAccount(ctx context.Context, credentials *rest.Credentials) (results
 		defer close(results)
 
 		var response api2.Response
-		if response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/policies", credentials.IAM.AccountID), rest2.RequestOptions{}); err != nil {
+		if response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/policies", client.AccountID()), rest2.RequestOptions{}); err != nil {
 			return
 		}
 
@@ -240,7 +240,7 @@ func listForAccount(ctx context.Context, credentials *rest.Credentials) (results
 		}
 
 		for _, policy := range policiesResponse.Policies {
-			results <- &api.Stub{ID: Join(policy.UUID, "account", credentials.IAM.AccountID), Name: policy.Name}
+			results <- &api.Stub{ID: Join(policy.UUID, "account", client.AccountID()), Name: policy.Name}
 		}
 	}()
 	return results, nil

--- a/dynatrace/api/iam/policies/service.go
+++ b/dynatrace/api/iam/policies/service.go
@@ -41,7 +41,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*policies.Policy], 
 	return &PolicyServiceClient{credentials: clientSet.Credentials()}, nil
 }
 
-func ServiceWithGloabals(clientSet rest.ClientSet) *PolicyServiceClient {
+func ServiceWithGlobals(clientSet rest.ClientSet) *PolicyServiceClient {
 	return &PolicyServiceClient{credentials: clientSet.Credentials()}
 }
 

--- a/dynatrace/api/iam/policies/service.go
+++ b/dynatrace/api/iam/policies/service.go
@@ -34,15 +34,19 @@ import (
 )
 
 type PolicyServiceClient struct {
-	credentials *rest.Credentials
+	client rest.IAMClient
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*policies.Policy], error) {
-	return &PolicyServiceClient{credentials: clientSet.Credentials()}, nil
+	return ServiceWithGlobals(clientSet)
 }
 
-func ServiceWithGlobals(clientSet rest.ClientSet) *PolicyServiceClient {
-	return &PolicyServiceClient{credentials: clientSet.Credentials()}
+func ServiceWithGlobals(clientSet rest.ClientSet) (*PolicyServiceClient, error) {
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
+	}
+	return &PolicyServiceClient{client: iamClient}, nil
 }
 
 func (me *PolicyServiceClient) SchemaID() string {
@@ -60,8 +64,7 @@ type PolicyCreateResponse struct {
 func (me *PolicyServiceClient) Create(ctx context.Context, v *policies.Policy) (*api.Stub, error) {
 	levelType, levelID := getLevel(v)
 
-	client := rest.NewIAMClient(ctx, me.credentials)
-	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", levelType, levelID), v, rest2.RequestOptions{})
+	response, err := me.client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", levelType, levelID), v, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +73,7 @@ func (me *PolicyServiceClient) Create(ctx context.Context, v *policies.Policy) (
 		return nil, err
 	}
 	v.UUID = pcr.UUID
-	_ = RegisterPolicyLevel(ctx, me.credentials, PolicyLevel{UUID: v.UUID, LevelType: levelType, LevelID: levelID})
+	_ = RegisterPolicyLevel(ctx, me.client, PolicyLevel{UUID: v.UUID, LevelType: levelType, LevelID: levelID})
 	return &api.Stub{ID: joinID(pcr.UUID, v), Name: v.Name}, nil
 }
 
@@ -96,10 +99,9 @@ func (me *PolicyServiceClient) get(ctx context.Context, id string, v *policies.P
 	if err != nil {
 		return err
 	}
-	client := rest.NewIAMClient(ctx, me.credentials)
-	var policyName string
 
-	levelType, levelID, policyName, err = ResolvePolicyLevel(ctx, me.credentials, uuid)
+	var policyName string
+	levelType, levelID, policyName, err = ResolvePolicyLevel(ctx, me.client, uuid)
 	if err != nil {
 		return err
 	}
@@ -109,7 +111,7 @@ func (me *PolicyServiceClient) get(ctx context.Context, id string, v *policies.P
 		return nil
 	}
 
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -128,7 +130,7 @@ func (me *PolicyServiceClient) get(ctx context.Context, id string, v *policies.P
 		}
 	}
 	v.UUID = uuid
-	_ = RegisterPolicyLevel(ctx, me.credentials, PolicyLevel{UUID: v.UUID, LevelType: levelType, LevelID: levelID})
+	_ = RegisterPolicyLevel(ctx, me.client, PolicyLevel{UUID: v.UUID, LevelType: levelType, LevelID: levelID})
 	return nil
 }
 
@@ -139,13 +141,12 @@ func (me *PolicyServiceClient) Update(ctx context.Context, id string, user *poli
 	if err != nil {
 		return err
 	}
-	levelType, levelID, _, err = ResolvePolicyLevel(ctx, me.credentials, uuid)
+	levelType, levelID, _, err = ResolvePolicyLevel(ctx, me.client, uuid)
 	if err != nil {
 		return err
 	}
-	client := rest.NewIAMClient(ctx, me.credentials)
 
-	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), user, rest2.RequestOptions{}); err != nil {
+	if _, err = me.client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), user, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -169,11 +170,10 @@ type ListPoliciesResponse struct {
 	Policies []PolicyStub `json:"policies"`
 }
 
-func listForEnvironment(ctx context.Context, credentials *rest.Credentials, environmentID string) (results chan *api.Stub, err error) {
+func listForEnvironment(ctx context.Context, client rest.IAMClient, environmentID string) (results chan *api.Stub, err error) {
 	results = make(chan *api.Stub)
 	go func() {
 		defer close(results)
-		client := rest.NewIAMClient(ctx, credentials)
 
 		var response api2.Response
 		if response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/policies", environmentID), rest2.RequestOptions{}); err != nil {
@@ -191,9 +191,9 @@ func listForEnvironment(ctx context.Context, credentials *rest.Credentials, envi
 	return results, nil
 }
 
-func listForEnvironments(ctx context.Context, credentials *rest.Credentials) (results chan *api.Stub, err error) {
+func listForEnvironments(ctx context.Context, client rest.IAMClient) (results chan *api.Stub, err error) {
 	results = make(chan *api.Stub)
-	environmentIDs, err := GetEnvironmentIDs(ctx, credentials)
+	environmentIDs, err := GetEnvironmentIDs(ctx, client)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func listForEnvironments(ctx context.Context, credentials *rest.Credentials) (re
 	for _, environmentID := range environmentIDs {
 		wg.Add(1)
 		var envIdxChan chan *api.Stub
-		if envIdxChan, err = listForEnvironment(ctx, credentials, environmentID); err != nil {
+		if envIdxChan, err = listForEnvironment(ctx, client, environmentID); err != nil {
 			wg.Done()
 			return nil, err
 		}
@@ -222,8 +222,7 @@ func listForEnvironments(ctx context.Context, credentials *rest.Credentials) (re
 	return results, nil
 }
 
-func listForAccount(ctx context.Context, credentials *rest.Credentials) (results chan *api.Stub, err error) {
-	client := rest.NewIAMClient(ctx, credentials)
+func listForAccount(ctx context.Context, client rest.IAMClient) (results chan *api.Stub, err error) {
 
 	results = make(chan *api.Stub)
 	go func() {
@@ -246,16 +245,16 @@ func listForAccount(ctx context.Context, credentials *rest.Credentials) (results
 	return results, nil
 }
 
-func list(ctx context.Context, credentials *rest.Credentials) (results chan *api.Stub, err error) {
+func list(ctx context.Context, client rest.IAMClient) (results chan *api.Stub, err error) {
 	results = make(chan *api.Stub)
 
 	var envChan chan *api.Stub
 	var accChan chan *api.Stub
 
-	if envChan, err = listForEnvironments(ctx, credentials); err != nil {
+	if envChan, err = listForEnvironments(ctx, client); err != nil {
 		return nil, err
 	}
-	if accChan, err = listForAccount(ctx, credentials); err != nil {
+	if accChan, err = listForAccount(ctx, client); err != nil {
 		return nil, err
 	}
 
@@ -298,7 +297,7 @@ func list(ctx context.Context, credentials *rest.Credentials) (results chan *api
 
 func (me *PolicyServiceClient) List(ctx context.Context) (api.Stubs, error) {
 	stubs := api.Stubs{}
-	policyLevels, err := FetchAllPolicyLevels(ctx, me.credentials)
+	policyLevels, err := FetchAllPolicyLevels(ctx, me.client)
 	if err != nil {
 		return stubs, err
 	}
@@ -313,7 +312,7 @@ func (me *PolicyServiceClient) List(ctx context.Context) (api.Stubs, error) {
 
 func (me *PolicyServiceClient) ListWithGlobals(ctx context.Context) (api.Stubs, error) {
 	stubs := api.Stubs{}
-	policyLevels, err := FetchAllPolicyLevels(ctx, me.credentials)
+	policyLevels, err := FetchAllPolicyLevels(ctx, me.client)
 	if err != nil {
 		return stubs, err
 	}
@@ -328,12 +327,12 @@ func (me *PolicyServiceClient) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	levelType, levelID, _, err := ResolvePolicyLevel(ctx, me.credentials, uuid)
+	levelType, levelID, _, err := ResolvePolicyLevel(ctx, me.client, uuid)
 	if err != nil {
 		return err
 	}
 
-	_, err = rest.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{})
+	_, err = me.client.DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{})
 	return err
 }
 

--- a/dynatrace/api/iam/policies/service.go
+++ b/dynatrace/api/iam/policies/service.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	policies "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/policies/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
@@ -61,7 +60,7 @@ type PolicyCreateResponse struct {
 func (me *PolicyServiceClient) Create(ctx context.Context, v *policies.Policy) (*api.Stub, error) {
 	levelType, levelID := getLevel(v)
 
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies", levelType, levelID), v, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
@@ -97,7 +96,7 @@ func (me *PolicyServiceClient) get(ctx context.Context, id string, v *policies.P
 	if err != nil {
 		return err
 	}
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 	var policyName string
 
 	levelType, levelID, policyName, err = ResolvePolicyLevel(ctx, me.credentials, uuid)
@@ -144,7 +143,7 @@ func (me *PolicyServiceClient) Update(ctx context.Context, id string, user *poli
 	if err != nil {
 		return err
 	}
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 
 	if _, err = client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), user, rest2.RequestOptions{}); err != nil {
 		return err
@@ -174,7 +173,7 @@ func listForEnvironment(ctx context.Context, credentials *rest.Credentials, envi
 	results = make(chan *api.Stub)
 	go func() {
 		defer close(results)
-		client := iam.NewIAMClient(ctx, credentials)
+		client := rest.NewIAMClient(ctx, credentials)
 
 		var response api2.Response
 		if response, err = client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/policies", environmentID), rest2.RequestOptions{}); err != nil {
@@ -224,7 +223,7 @@ func listForEnvironments(ctx context.Context, credentials *rest.Credentials) (re
 }
 
 func listForAccount(ctx context.Context, credentials *rest.Credentials) (results chan *api.Stub, err error) {
-	client := iam.NewIAMClient(ctx, credentials)
+	client := rest.NewIAMClient(ctx, credentials)
 
 	results = make(chan *api.Stub)
 	go func() {
@@ -334,7 +333,7 @@ func (me *PolicyServiceClient) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	_, err = iam.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{})
+	_, err = rest.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/policies/%s", levelType, levelID, uuid), rest2.RequestOptions{})
 	return err
 }
 

--- a/dynatrace/api/iam/serviceusers/service.go
+++ b/dynatrace/api/iam/serviceusers/service.go
@@ -35,28 +35,16 @@ type ServiceUserService interface {
 	GetAll(ctx context.Context) ([]ServiceUserStub, error)
 }
 
-type iamClientGetter interface {
-	New(ctx context.Context) rest.IAMClient
-}
-
-type iamClientGetterImp struct {
-	credentials *rest.Credentials
-}
-
-func (me *iamClientGetterImp) New(ctx context.Context) rest.IAMClient {
-	return rest.NewIAMClient(ctx, me.credentials)
-}
-
 type serviceUserServiceClient struct {
-	iamClientGetter iamClientGetter
+	client rest.IAMClient
 }
 
 func NewService(clientSet rest.ClientSet) (ServiceUserService, error) {
-	return &serviceUserServiceClient{
-		iamClientGetter: &iamClientGetterImp{
-			credentials: clientSet.Credentials(),
-		},
-	}, nil
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
+	}
+	return &serviceUserServiceClient{client: iamClient}, nil
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*serviceusers.ServiceUser], error) {
@@ -75,8 +63,7 @@ type createResponse struct {
 }
 
 func (me *serviceUserServiceClient) Create(ctx context.Context, serviceUser *serviceusers.ServiceUser) (*api.Stub, error) {
-	client := me.iamClientGetter.New(ctx)
-	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users", client.AccountID()), serviceUser, rest2.RequestOptions{})
+	response, err := me.client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users", me.client.AccountID()), serviceUser, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +93,7 @@ type getServiceUserResponse struct {
 }
 
 func (me *serviceUserServiceClient) Get(ctx context.Context, id string, v *serviceusers.ServiceUser) error {
-	client := me.iamClientGetter.New(ctx)
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", client.AccountID(), id), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.client.AccountID(), id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -141,8 +127,7 @@ type getUserPartialResponse struct {
 }
 
 func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email string) ([]string, error) {
-	client := me.iamClientGetter.New(ctx)
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", client.AccountID(), email), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.client.AccountID(), email), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +147,7 @@ func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email str
 
 func (me *serviceUserServiceClient) Update(ctx context.Context, id string, serviceUser *serviceusers.ServiceUser) error {
 	// Update the service user details
-	client := me.iamClientGetter.New(ctx)
-	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", client.AccountID(), id), serviceUser, rest2.RequestOptions{}); err != nil {
+	if _, err := me.client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.client.AccountID(), id), serviceUser, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -176,8 +160,7 @@ func (me *serviceUserServiceClient) updateGroupAssignments(ctx context.Context, 
 	if groups == nil {
 		groups = []string{}
 	}
-	client := me.iamClientGetter.New(ctx)
-	_, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", client.AccountID(), serviceUserEmail), groups, rest2.RequestOptions{})
+	_, err := me.client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.client.AccountID(), serviceUserEmail), groups, rest2.RequestOptions{})
 	return err
 }
 
@@ -197,14 +180,12 @@ type listServiceUsersResponse struct {
 }
 
 func (me *serviceUserServiceClient) GetAll(ctx context.Context) ([]ServiceUserStub, error) {
-	client := me.iamClientGetter.New(ctx)
-
 	var stubs []ServiceUserStub
-	endpoint := fmt.Sprintf("/iam/v1/accounts/%s/service-users", client.AccountID())
+	endpoint := fmt.Sprintf("/iam/v1/accounts/%s/service-users", me.client.AccountID())
 	options := rest2.RequestOptions{}
 
 	for {
-		response, err := client.GET(ctx, endpoint, options)
+		response, err := me.client.GET(ctx, endpoint, options)
 		if err != nil {
 			return nil, err
 		}
@@ -244,7 +225,6 @@ func (me *serviceUserServiceClient) List(ctx context.Context) (api.Stubs, error)
 }
 
 func (me *serviceUserServiceClient) Delete(ctx context.Context, uid string) error {
-	client := me.iamClientGetter.New(ctx)
-	_, err := client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", client.AccountID(), uid), rest2.RequestOptions{})
+	_, err := me.client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.client.AccountID(), uid), rest2.RequestOptions{})
 	return err
 }

--- a/dynatrace/api/iam/serviceusers/service.go
+++ b/dynatrace/api/iam/serviceusers/service.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	serviceusers "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/serviceusers/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
@@ -37,15 +36,15 @@ type ServiceUserService interface {
 }
 
 type iamClientGetter interface {
-	New(ctx context.Context) iam.IAMClient
+	New(ctx context.Context) rest.IAMClient
 }
 
 type iamClientGetterImp struct {
 	credentials *rest.Credentials
 }
 
-func (me *iamClientGetterImp) New(ctx context.Context) iam.IAMClient {
-	return iam.NewIAMClient(ctx, me.credentials)
+func (me *iamClientGetterImp) New(ctx context.Context) rest.IAMClient {
+	return rest.NewIAMClient(ctx, me.credentials)
 }
 
 type serviceUserServiceClient struct {

--- a/dynatrace/api/iam/serviceusers/service.go
+++ b/dynatrace/api/iam/serviceusers/service.go
@@ -49,7 +49,6 @@ func (me *iamClientGetterImp) New(ctx context.Context) rest.IAMClient {
 
 type serviceUserServiceClient struct {
 	iamClientGetter iamClientGetter
-	accountID       string
 }
 
 func NewService(clientSet rest.ClientSet) (ServiceUserService, error) {
@@ -57,7 +56,6 @@ func NewService(clientSet rest.ClientSet) (ServiceUserService, error) {
 		iamClientGetter: &iamClientGetterImp{
 			credentials: clientSet.Credentials(),
 		},
-		accountID: clientSet.Credentials().IAM.AccountID,
 	}, nil
 }
 
@@ -77,7 +75,8 @@ type createResponse struct {
 }
 
 func (me *serviceUserServiceClient) Create(ctx context.Context, serviceUser *serviceusers.ServiceUser) (*api.Stub, error) {
-	response, err := me.iamClientGetter.New(ctx).POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users", me.accountID), serviceUser, rest2.RequestOptions{})
+	client := me.iamClientGetter.New(ctx)
+	response, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users", client.AccountID()), serviceUser, rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +106,8 @@ type getServiceUserResponse struct {
 }
 
 func (me *serviceUserServiceClient) Get(ctx context.Context, id string, v *serviceusers.ServiceUser) error {
-	response, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, id), rest2.RequestOptions{})
+	client := me.iamClientGetter.New(ctx)
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", client.AccountID(), id), rest2.RequestOptions{})
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,8 @@ type getUserPartialResponse struct {
 }
 
 func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email string) ([]string, error) {
-	response, err := me.iamClientGetter.New(ctx).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.accountID, email), rest2.RequestOptions{})
+	client := me.iamClientGetter.New(ctx)
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", client.AccountID(), email), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,8 @@ func (me *serviceUserServiceClient) getUserGroups(ctx context.Context, email str
 
 func (me *serviceUserServiceClient) Update(ctx context.Context, id string, serviceUser *serviceusers.ServiceUser) error {
 	// Update the service user details
-	if _, err := me.iamClientGetter.New(ctx).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, id), serviceUser, rest2.RequestOptions{}); err != nil {
+	client := me.iamClientGetter.New(ctx)
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", client.AccountID(), id), serviceUser, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -174,7 +176,8 @@ func (me *serviceUserServiceClient) updateGroupAssignments(ctx context.Context, 
 	if groups == nil {
 		groups = []string{}
 	}
-	_, err := me.iamClientGetter.New(ctx).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.accountID, serviceUserEmail), groups, rest2.RequestOptions{})
+	client := me.iamClientGetter.New(ctx)
+	_, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", client.AccountID(), serviceUserEmail), groups, rest2.RequestOptions{})
 	return err
 }
 
@@ -197,7 +200,7 @@ func (me *serviceUserServiceClient) GetAll(ctx context.Context) ([]ServiceUserSt
 	client := me.iamClientGetter.New(ctx)
 
 	var stubs []ServiceUserStub
-	endpoint := fmt.Sprintf("/iam/v1/accounts/%s/service-users", me.accountID)
+	endpoint := fmt.Sprintf("/iam/v1/accounts/%s/service-users", client.AccountID())
 	options := rest2.RequestOptions{}
 
 	for {
@@ -241,6 +244,7 @@ func (me *serviceUserServiceClient) List(ctx context.Context) (api.Stubs, error)
 }
 
 func (me *serviceUserServiceClient) Delete(ctx context.Context, uid string) error {
-	_, err := me.iamClientGetter.New(ctx).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", me.accountID, uid), rest2.RequestOptions{})
+	client := me.iamClientGetter.New(ctx)
+	_, err := client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", client.AccountID(), uid), rest2.RequestOptions{})
 	return err
 }

--- a/dynatrace/api/iam/serviceusers/service_test.go
+++ b/dynatrace/api/iam/serviceusers/service_test.go
@@ -35,18 +35,10 @@ import (
 
 const testAccountID = "test-account-id"
 
-func createTestServiceUserServiceClient(client *testing2.MockIAMClient) *serviceUserServiceClient {
-	client.AccountIDValue = testAccountID
-	return &serviceUserServiceClient{
-		iamClientGetter: &testing2.MockIAMClientGetter{
-			Client: client,
-		},
-	}
-}
-
 func TestService_Create(t *testing.T) {
 	t.Run("successful creation", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
 				return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`)}, nil
@@ -57,7 +49,7 @@ func TestService_Create(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name:        "Test User",
 			Description: "Test description",
@@ -72,6 +64,7 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("successful creation with empty groups", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
 				return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`)}, nil
@@ -83,7 +76,7 @@ func TestService_Create(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name:        "Test User",
 			Description: "Test description",
@@ -97,12 +90,13 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("creation fails on POST", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{}, errors.New("POST failed")
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name: "Test User",
 		}
@@ -113,6 +107,7 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("creation fails on group assignment and cleanup succeeds", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`)}, nil
 			},
@@ -124,7 +119,7 @@ func TestService_Create(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name:   "Test User",
 			Groups: []string{"group-1"},
@@ -136,6 +131,7 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("creation fails on group assignment and cleanup fails", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{"uid":"test-uid","email":"test@example.com","name":"Test User"}`)}, nil
 			},
@@ -147,7 +143,7 @@ func TestService_Create(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name:   "Test User",
 			Groups: []string{"group-1"},
@@ -159,12 +155,13 @@ func TestService_Create(t *testing.T) {
 
 	t.Run("creation fails on invalid JSON response", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			POSTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name: "Test User",
 		}
@@ -179,6 +176,7 @@ func TestService_Get(t *testing.T) {
 	t.Run("successful get with groups", func(t *testing.T) {
 		getCallCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				getCallCount++
 				if getCallCount == 1 {
@@ -194,7 +192,7 @@ func TestService_Get(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{}
 
 		err := client.Get(t.Context(), "test-uid", serviceUser)
@@ -209,6 +207,7 @@ func TestService_Get(t *testing.T) {
 	t.Run("successful get without groups", func(t *testing.T) {
 		getCallCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				getCallCount++
 				if getCallCount == 1 {
@@ -224,7 +223,7 @@ func TestService_Get(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{}
 
 		err := client.Get(t.Context(), "test-uid", serviceUser)
@@ -236,12 +235,13 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("get fails on service user fetch", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{}, errors.New("GET failed")
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{}
 
 		err := client.Get(t.Context(), "test-uid", serviceUser)
@@ -251,6 +251,7 @@ func TestService_Get(t *testing.T) {
 	t.Run("get fails on user groups fetch", func(t *testing.T) {
 		getCallCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				getCallCount++
 				if getCallCount == 1 {
@@ -264,7 +265,7 @@ func TestService_Get(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{}
 
 		err := client.Get(t.Context(), "test-uid", serviceUser)
@@ -273,12 +274,13 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("get returns error when service user not found", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{}, errors.New("Service user test-uid does not exist")
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{}
 
 		err := client.Get(t.Context(), "test-uid", serviceUser)
@@ -287,12 +289,13 @@ func TestService_Get(t *testing.T) {
 
 	t.Run("get fails on invalid JSON for service user", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{}
 
 		err := client.Get(t.Context(), "test-uid", serviceUser)
@@ -302,6 +305,7 @@ func TestService_Get(t *testing.T) {
 	t.Run("get fails on invalid JSON for user groups", func(t *testing.T) {
 		getCallCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				getCallCount++
 				if getCallCount == 1 {
@@ -315,7 +319,7 @@ func TestService_Get(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{}
 
 		err := client.Get(t.Context(), "test-uid", serviceUser)
@@ -326,6 +330,7 @@ func TestService_Get(t *testing.T) {
 func TestService_GetAll(t *testing.T) {
 	t.Run("successful get all without pagination", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users", testAccountID), url)
 				return api.Response{Data: []byte(`{
@@ -338,7 +343,7 @@ func TestService_GetAll(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		stubs, err := client.GetAll(t.Context())
 		assert.NoError(t, err)
 		assert.Len(t, stubs, 2)
@@ -355,6 +360,7 @@ func TestService_GetAll(t *testing.T) {
 	t.Run("successful get all with pagination", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
@@ -382,7 +388,7 @@ func TestService_GetAll(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		stubs, err := client.GetAll(t.Context())
 		assert.NoError(t, err)
 		assert.Equal(t, 2, callCount)
@@ -394,6 +400,7 @@ func TestService_GetAll(t *testing.T) {
 	t.Run("successful get all with multiple pagination pages", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
@@ -421,7 +428,7 @@ func TestService_GetAll(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		stubs, err := client.GetAll(t.Context())
 		assert.NoError(t, err)
 		assert.Equal(t, 3, callCount)
@@ -430,12 +437,13 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("get all fails", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{}, errors.New("GET failed")
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		_, err := client.GetAll(t.Context())
 		assert.EqualError(t, err, "GET failed")
 	})
@@ -443,6 +451,7 @@ func TestService_GetAll(t *testing.T) {
 	t.Run("get all fails on second page", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
@@ -456,13 +465,14 @@ func TestService_GetAll(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		_, err := client.GetAll(t.Context())
 		assert.EqualError(t, err, "pagination failed")
 	})
 
 	t.Run("get all empty", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{
 					"count": 0,
@@ -471,7 +481,7 @@ func TestService_GetAll(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		stubs, err := client.GetAll(t.Context())
 		assert.NoError(t, err)
 		assert.Empty(t, stubs)
@@ -479,12 +489,13 @@ func TestService_GetAll(t *testing.T) {
 
 	t.Run("get all fails on invalid JSON response", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		_, err := client.GetAll(t.Context())
 		assert.ErrorContains(t, err, "invalid character")
 	})
@@ -492,6 +503,7 @@ func TestService_GetAll(t *testing.T) {
 	t.Run("get all fails on invalid JSON response on second page", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
@@ -505,7 +517,7 @@ func TestService_GetAll(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		_, err := client.GetAll(t.Context())
 		assert.ErrorContains(t, err, "invalid character")
 	})
@@ -514,6 +526,7 @@ func TestService_GetAll(t *testing.T) {
 func TestService_List(t *testing.T) {
 	t.Run("successful list without pagination", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{
 					"count": 2,
@@ -525,7 +538,7 @@ func TestService_List(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		stubs, err := client.List(t.Context())
 		assert.NoError(t, err)
 		assert.Len(t, stubs, 2)
@@ -538,6 +551,7 @@ func TestService_List(t *testing.T) {
 	t.Run("successful list with pagination", func(t *testing.T) {
 		callCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				callCount++
 				if callCount == 1 {
@@ -565,7 +579,7 @@ func TestService_List(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		stubs, err := client.List(t.Context())
 		assert.NoError(t, err)
 		assert.Equal(t, 2, callCount)
@@ -574,18 +588,20 @@ func TestService_List(t *testing.T) {
 
 	t.Run("list fails", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{}, errors.New("GET failed")
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		_, err := client.List(t.Context())
 		assert.EqualError(t, err, "GET failed")
 	})
 
 	t.Run("list empty", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{
 					"count": 0,
@@ -594,7 +610,7 @@ func TestService_List(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		stubs, err := client.List(t.Context())
 		assert.NoError(t, err)
 		assert.Empty(t, stubs)
@@ -602,12 +618,13 @@ func TestService_List(t *testing.T) {
 
 	t.Run("list fails on invalid JSON response", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			GETFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{Data: []byte(`{invalid json`)}, nil
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		_, err := client.List(t.Context())
 		assert.ErrorContains(t, err, "invalid character")
 	})
@@ -617,6 +634,7 @@ func TestService_Update(t *testing.T) {
 	t.Run("successful update", func(t *testing.T) {
 		putCallCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				putCallCount++
 				if putCallCount == 1 {
@@ -634,7 +652,7 @@ func TestService_Update(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name:        "Updated User",
 			Email:       "test@example.com",
@@ -649,12 +667,13 @@ func TestService_Update(t *testing.T) {
 
 	t.Run("update fails on user details", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{}, errors.New("PUT failed")
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name:  "Updated User",
 			Email: "test@example.com",
@@ -667,6 +686,7 @@ func TestService_Update(t *testing.T) {
 	t.Run("update fails on group assignment", func(t *testing.T) {
 		putCallCount := 0
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			PUTFunc: func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {
 				putCallCount++
 				if putCallCount == 1 {
@@ -682,7 +702,7 @@ func TestService_Update(t *testing.T) {
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		serviceUser := &serviceusers.ServiceUser{
 			Name:   "Updated User",
 			Email:  "test@example.com",
@@ -697,44 +717,49 @@ func TestService_Update(t *testing.T) {
 func TestService_Delete(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				assert.Equal(t, fmt.Sprintf("/iam/v1/accounts/%s/service-users/%s", testAccountID, "test-uid"), url)
 				return api.Response{}, nil
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		err := client.Delete(t.Context(), "test-uid")
 		assert.NoError(t, err)
 	})
 
 	t.Run("delete fails", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{}, errors.New("DELETE failed")
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		err := client.Delete(t.Context(), "test-uid")
 		assert.EqualError(t, err, "DELETE failed")
 	})
 
 	t.Run("delete errors if service user does not exist", func(t *testing.T) {
 		mockClient := &testing2.MockIAMClient{
+			AccountIDValue: testAccountID,
 			DELETEFunc: func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 				return api.Response{}, errors.New("User test-uid does not exist")
 			},
 		}
 
-		client := createTestServiceUserServiceClient(mockClient)
+		client := &serviceUserServiceClient{client: mockClient}
 		err := client.Delete(t.Context(), "test-uid")
 		assert.EqualError(t, err, "User test-uid does not exist")
 	})
 }
 
 func TestService_SchemaID(t *testing.T) {
-	client := createTestServiceUserServiceClient(&testing2.MockIAMClient{})
+	client := &serviceUserServiceClient{client: &testing2.MockIAMClient{
+		AccountIDValue: testAccountID,
+	}}
 	schemaID := client.SchemaID()
 	assert.Equal(t, "accounts:iam:serviceusers", schemaID)
 }

--- a/dynatrace/api/iam/serviceusers/service_test.go
+++ b/dynatrace/api/iam/serviceusers/service_test.go
@@ -36,11 +36,11 @@ import (
 const testAccountID = "test-account-id"
 
 func createTestServiceUserServiceClient(client *testing2.MockIAMClient) *serviceUserServiceClient {
+	client.AccountIDValue = testAccountID
 	return &serviceUserServiceClient{
 		iamClientGetter: &testing2.MockIAMClientGetter{
 			Client: client,
 		},
-		accountID: testAccountID,
 	}
 }
 

--- a/dynatrace/api/iam/users/service.go
+++ b/dynatrace/api/iam/users/service.go
@@ -44,7 +44,7 @@ func (me *UserServiceClient) SchemaID() string {
 
 func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api.Stub, error) {
 	client := rest.NewIAMClient(ctx, me.credentials)
-	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.credentials.IAM.AccountID), user, rest2.RequestOptions{}); err != nil {
+	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", client.AccountID()), user, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -52,7 +52,7 @@ func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.credentials.IAM.AccountID, user.Email), groups, rest2.RequestOptions{}); err != nil {
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", client.AccountID(), user.Email), groups, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +72,7 @@ type GetUserGroupsResponse struct {
 func (me *UserServiceClient) Get(ctx context.Context, email string, v *users.User) error {
 	client := rest.NewIAMClient(ctx, me.credentials)
 
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.credentials.IAM.AccountID, email), rest2.RequestOptions{})
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", client.AccountID(), email), rest2.RequestOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 			return rest.Error{Code: 404, Message: err.Error()}
@@ -99,7 +99,8 @@ func (me *UserServiceClient) Update(ctx context.Context, email string, user *use
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err := rest.NewIAMClient(ctx, me.credentials).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.credentials.IAM.AccountID, user.Email), groups, rest2.RequestOptions{}); err != nil {
+	client := rest.NewIAMClient(ctx, me.credentials)
+	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", client.AccountID(), user.Email), groups, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -116,7 +117,8 @@ type ListUsersResponse struct {
 }
 
 func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	response, err := rest.NewIAMClient(ctx, me.credentials).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.credentials.IAM.AccountID), rest2.RequestOptions{})
+	client := rest.NewIAMClient(ctx, me.credentials)
+	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +135,8 @@ func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *UserServiceClient) Delete(ctx context.Context, email string) error {
-	_, err := rest.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.credentials.IAM.AccountID, email), rest2.RequestOptions{})
+	client := rest.NewIAMClient(ctx, me.credentials)
+	_, err := client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", client.AccountID(), email), rest2.RequestOptions{})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 		return nil
 	}

--- a/dynatrace/api/iam/users/service.go
+++ b/dynatrace/api/iam/users/service.go
@@ -31,11 +31,15 @@ import (
 )
 
 type UserServiceClient struct {
-	credentials *rest.Credentials
+	client rest.IAMClient
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*users.User], error) {
-	return &UserServiceClient{credentials: clientSet.Credentials()}, nil
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
+	}
+	return &UserServiceClient{client: iamClient}, nil
 }
 
 func (me *UserServiceClient) SchemaID() string {
@@ -43,8 +47,7 @@ func (me *UserServiceClient) SchemaID() string {
 }
 
 func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api.Stub, error) {
-	client := rest.NewIAMClient(ctx, me.credentials)
-	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", client.AccountID()), user, rest2.RequestOptions{}); err != nil {
+	if _, err := me.client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.client.AccountID()), user, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -52,7 +55,7 @@ func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", client.AccountID(), user.Email), groups, rest2.RequestOptions{}); err != nil {
+	if _, err := me.client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.client.AccountID(), user.Email), groups, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -70,9 +73,7 @@ type GetUserGroupsResponse struct {
 }
 
 func (me *UserServiceClient) Get(ctx context.Context, email string, v *users.User) error {
-	client := rest.NewIAMClient(ctx, me.credentials)
-
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", client.AccountID(), email), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.client.AccountID(), email), rest2.RequestOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 			return rest.Error{Code: 404, Message: err.Error()}
@@ -99,8 +100,7 @@ func (me *UserServiceClient) Update(ctx context.Context, email string, user *use
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	client := rest.NewIAMClient(ctx, me.credentials)
-	if _, err := client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", client.AccountID(), user.Email), groups, rest2.RequestOptions{}); err != nil {
+	if _, err := me.client.PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.client.AccountID(), user.Email), groups, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -117,8 +117,7 @@ type ListUsersResponse struct {
 }
 
 func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	client := rest.NewIAMClient(ctx, me.credentials)
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", client.AccountID()), rest2.RequestOptions{})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.client.AccountID()), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -135,8 +134,7 @@ func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *UserServiceClient) Delete(ctx context.Context, email string) error {
-	client := rest.NewIAMClient(ctx, me.credentials)
-	_, err := client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", client.AccountID(), email), rest2.RequestOptions{})
+	_, err := me.client.DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.client.AccountID(), email), rest2.RequestOptions{})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 		return nil
 	}

--- a/dynatrace/api/iam/users/service.go
+++ b/dynatrace/api/iam/users/service.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	users "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/users/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
@@ -44,7 +43,7 @@ func (me *UserServiceClient) SchemaID() string {
 }
 
 func (me *UserServiceClient) Create(ctx context.Context, user *users.User) (*api.Stub, error) {
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 	if _, err := client.POST(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.credentials.IAM.AccountID), user, rest2.RequestOptions{}); err != nil {
 		return nil, err
 	}
@@ -71,7 +70,7 @@ type GetUserGroupsResponse struct {
 }
 
 func (me *UserServiceClient) Get(ctx context.Context, email string, v *users.User) error {
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 
 	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.credentials.IAM.AccountID, email), rest2.RequestOptions{})
 	if err != nil {
@@ -100,7 +99,7 @@ func (me *UserServiceClient) Update(ctx context.Context, email string, user *use
 	if len(user.Groups) > 0 {
 		groups = user.Groups
 	}
-	if _, err := iam.NewIAMClient(ctx, me.credentials).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.credentials.IAM.AccountID, user.Email), groups, rest2.RequestOptions{}); err != nil {
+	if _, err := rest.NewIAMClient(ctx, me.credentials).PUT(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s/groups", me.credentials.IAM.AccountID, user.Email), groups, rest2.RequestOptions{}); err != nil {
 		return err
 	}
 
@@ -118,7 +117,7 @@ type ListUsersResponse struct {
 }
 
 func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
-	response, err := iam.NewIAMClient(ctx, me.credentials).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.credentials.IAM.AccountID), rest2.RequestOptions{})
+	response, err := rest.NewIAMClient(ctx, me.credentials).GET(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users", me.credentials.IAM.AccountID), rest2.RequestOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +134,7 @@ func (me *UserServiceClient) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *UserServiceClient) Delete(ctx context.Context, email string) error {
-	_, err := iam.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.credentials.IAM.AccountID, email), rest2.RequestOptions{})
+	_, err := rest.NewIAMClient(ctx, me.credentials).DELETE(ctx, fmt.Sprintf("/iam/v1/accounts/%s/users/%s", me.credentials.IAM.AccountID, email), rest2.RequestOptions{})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("User %s not found", email)) {
 		return nil
 	}

--- a/dynatrace/api/iam/users/service.go
+++ b/dynatrace/api/iam/users/service.go
@@ -112,7 +112,6 @@ type UserStub struct {
 }
 
 type ListUsersResponse struct {
-	Count int        `json:"count:"`
 	Items []UserStub `json:"items"`
 }
 

--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -34,11 +34,15 @@ import (
 )
 
 type BindingServiceClient struct {
-	credentials *rest.Credentials
+	client rest.IAMClient
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*bindings.PolicyBinding], error) {
-	return &BindingServiceClient{credentials: clientSet.Credentials()}, nil
+	iamClient, err := clientSet.IAMClient()
+	if err != nil {
+		return nil, err
+	}
+	return &BindingServiceClient{client: iamClient}, nil
 }
 
 func (me *BindingServiceClient) SchemaID() string {
@@ -102,12 +106,11 @@ func (me *BindingServiceClient) getGroupPolicyBindings(ctx context.Context, id s
 	if err != nil {
 		return GroupPolicyBindings{}, err
 	}
-	client := rest.NewIAMClient(ctx, me.credentials)
 
 	var policyBindings GroupPolicyBindings
 
 	queryParams := url.Values{"details": []string{"true"}}
-	response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{QueryParams: queryParams})
+	response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), rest2.RequestOptions{QueryParams: queryParams})
 	if err != nil {
 		return GroupPolicyBindings{}, err
 	}
@@ -171,7 +174,7 @@ func (me *BindingServiceClient) resolvePolicies(ctx context.Context, uuid string
 		if stateConfig != nil {
 			existingPolicies = stateConfig.Policies
 		}
-		levelType, levelID, _, err := policies.ResolvePolicyLevel(ctx, me.credentials, uuid)
+		levelType, levelID, _, err := policies.ResolvePolicyLevel(ctx, me.client, uuid)
 		if err != nil {
 			return nil, err
 		}
@@ -211,8 +214,6 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 		return err
 	}
 
-	client := rest.NewIAMClient(ctx, me.credentials)
-
 	for _, desiredPolicy := range v.Policies {
 		policyUUID, _, _, _ := policies.SplitID(desiredPolicy.ID, levelType, levelID)
 		payload := bindingPayload{
@@ -220,7 +221,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 			Metadata:   desiredPolicy.Metadata,
 			Boundaries: desiredPolicy.Boundaries,
 		}
-		if _, err = client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), payload, rest2.RequestOptions{}); err != nil {
+		if _, err = me.client.POST(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/%s/%s", levelType, levelID, policyUUID, groupID), payload, rest2.RequestOptions{}); err != nil {
 			return err
 		}
 	}
@@ -244,9 +245,7 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 		}()
 
 		var policyBindings ListPolicyBindingsResponse
-		client := rest.NewIAMClient(ctx, me.credentials)
-
-		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", client.AccountID()), rest2.RequestOptions{})
+		response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.client.AccountID()), rest2.RequestOptions{})
 		if err != nil {
 			return
 		}
@@ -259,7 +258,7 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 		for _, policy := range policyBindings.PolicyBindings {
 			for _, group := range policy.Groups {
 				if _, exists := groupIds[group]; !exists {
-					id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", client.AccountID())
+					id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", me.client.AccountID())
 					stubs = append(stubs, &api.Stub{ID: id, Name: "PolicyV2Bindings-" + id})
 					groupIds[group] = true
 				}
@@ -278,9 +277,8 @@ func (me *BindingServiceClient) FetchEnvironmentBindings(ctx context.Context) ch
 		defer func() {
 			close(results)
 		}()
-		client := rest.NewIAMClient(ctx, me.credentials)
 
-		environmentIDs, err := policies.GetEnvironmentIDs(ctx, me.credentials)
+		environmentIDs, err := policies.GetEnvironmentIDs(ctx, me.client)
 		if err != nil {
 			return
 		}
@@ -288,7 +286,7 @@ func (me *BindingServiceClient) FetchEnvironmentBindings(ctx context.Context) ch
 		var stubs api.Stubs
 		for _, environmentID := range environmentIDs {
 			var policyBindings ListPolicyBindingsResponse
-			response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/bindings", environmentID), rest2.RequestOptions{})
+			response, err := me.client.GET(ctx, fmt.Sprintf("/iam/v1/repo/environment/%s/bindings", environmentID), rest2.RequestOptions{})
 			if err != nil {
 				return
 			}
@@ -363,7 +361,7 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 	groupBindings := groupPolicyBindingsUpdate{
 		PolicyUuids: make([]string, 0),
 	}
-	_, err = rest.NewIAMClient(ctx, me.credentials).PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), groupBindings, rest2.RequestOptions{})
+	_, err = me.client.PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), groupBindings, rest2.RequestOptions{})
 	return err
 }
 

--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -246,7 +246,7 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 		var policyBindings ListPolicyBindingsResponse
 		client := rest.NewIAMClient(ctx, me.credentials)
 
-		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.credentials.IAM.AccountID), rest2.RequestOptions{})
+		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", client.AccountID()), rest2.RequestOptions{})
 		if err != nil {
 			return
 		}
@@ -259,7 +259,7 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 		for _, policy := range policyBindings.PolicyBindings {
 			for _, group := range policy.Groups {
 				if _, exists := groupIds[group]; !exists {
-					id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", me.credentials.IAM.AccountID)
+					id := fmt.Sprintf("%s#-#%s#-#%s", group, "account", client.AccountID())
 					stubs = append(stubs, &api.Stub{ID: id, Name: "PolicyV2Bindings-" + id})
 					groupIds[group] = true
 				}

--- a/dynatrace/api/iam/v2bindings/service.go
+++ b/dynatrace/api/iam/v2bindings/service.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/policies"
 	bindings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/v2bindings/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
@@ -103,7 +102,7 @@ func (me *BindingServiceClient) getGroupPolicyBindings(ctx context.Context, id s
 	if err != nil {
 		return GroupPolicyBindings{}, err
 	}
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 
 	var policyBindings GroupPolicyBindings
 
@@ -212,7 +211,7 @@ func (me *BindingServiceClient) Update(ctx context.Context, id string, v *bindin
 		return err
 	}
 
-	client := iam.NewIAMClient(ctx, me.credentials)
+	client := rest.NewIAMClient(ctx, me.credentials)
 
 	for _, desiredPolicy := range v.Policies {
 		policyUUID, _, _, _ := policies.SplitID(desiredPolicy.ID, levelType, levelID)
@@ -245,7 +244,7 @@ func (me *BindingServiceClient) FetchAccountBindings(ctx context.Context) chan *
 		}()
 
 		var policyBindings ListPolicyBindingsResponse
-		client := iam.NewIAMClient(ctx, me.credentials)
+		client := rest.NewIAMClient(ctx, me.credentials)
 
 		response, err := client.GET(ctx, fmt.Sprintf("/iam/v1/repo/account/%s/bindings", me.credentials.IAM.AccountID), rest2.RequestOptions{})
 		if err != nil {
@@ -279,7 +278,7 @@ func (me *BindingServiceClient) FetchEnvironmentBindings(ctx context.Context) ch
 		defer func() {
 			close(results)
 		}()
-		client := iam.NewIAMClient(ctx, me.credentials)
+		client := rest.NewIAMClient(ctx, me.credentials)
 
 		environmentIDs, err := policies.GetEnvironmentIDs(ctx, me.credentials)
 		if err != nil {
@@ -364,7 +363,7 @@ func (me *BindingServiceClient) Delete(ctx context.Context, id string) error {
 	groupBindings := groupPolicyBindingsUpdate{
 		PolicyUuids: make([]string, 0),
 	}
-	_, err = iam.NewIAMClient(ctx, me.credentials).PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), groupBindings, rest2.RequestOptions{})
+	_, err = rest.NewIAMClient(ctx, me.credentials).PUT(ctx, fmt.Sprintf("/iam/v1/repo/%s/%s/bindings/groups/%s", levelType, levelID, groupID), groupBindings, rest2.RequestOptions{})
 	return err
 }
 

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -151,9 +151,6 @@ func (me *classic_request) Finish(optionalTarget ...any) error {
 	if len(optionalTarget) > 0 {
 		target = optionalTarget[0]
 	}
-
-	PreRequest()
-
 	classicURL := evalClassicURL(me.client.Credentials().URL)
 
 	client, err := createClassicClient(classicURL, me.client.Credentials().Token)

--- a/dynatrace/rest/client_set.go
+++ b/dynatrace/rest/client_set.go
@@ -19,9 +19,10 @@ package rest
 
 // ClientSet is the credential/client provider handed to services, resources and datasources.
 //
-// For now it only exposes the raw Credentials so the existing client factories can be reused
-// unchanged. Concrete clients (e.g. an IAM client, an API-token client) will be added over time and
-// services migrated onto them, at which point Credentials can eventually be retired.
+// It exposes the raw Credentials (so the existing client factories can be reused unchanged) plus
+// concrete clients that are built once and reused. More clients will be added over time and services
+// migrated onto them, at which point Credentials can eventually be retired.
 type ClientSet interface {
 	Credentials() *Credentials
+	IAMClient() (IAMClient, error)
 }

--- a/dynatrace/rest/cluster_v1_client.go
+++ b/dynatrace/rest/cluster_v1_client.go
@@ -113,9 +113,6 @@ func (me *cluster_v1_request) Finish(optionalTarget ...any) error {
 	if len(optionalTarget) > 0 {
 		target = optionalTarget[0]
 	}
-
-	PreRequest()
-
 	clusterURL := strings.TrimSuffix(me.client.Credentials().Cluster.URL, "/") + "/api/v1.0/onpremise"
 
 	client, err := createClusterV1Client(clusterURL, me.client.Credentials().Cluster.Token)

--- a/dynatrace/rest/cluster_v2_client.go
+++ b/dynatrace/rest/cluster_v2_client.go
@@ -113,9 +113,6 @@ func (me *cluster_v2_request) Finish(optionalTarget ...any) error {
 	if len(optionalTarget) > 0 {
 		target = optionalTarget[0]
 	}
-
-	PreRequest()
-
 	clusterV2URL := strings.TrimSuffix(me.client.Credentials().Cluster.URL, "/") + "/api/cluster/v2"
 
 	client, err := createClusterV2Client(clusterV2URL, me.client.Credentials().Cluster.Token)

--- a/dynatrace/rest/credentials.go
+++ b/dynatrace/rest/credentials.go
@@ -19,6 +19,14 @@ package rest
 
 const TestCaseEnvURL = "go-test"
 
+type IAMCredentials struct {
+	ClientID     string
+	AccountID    string
+	ClientSecret string
+	TokenURL     string
+	EndpointURL  string
+}
+
 type PlatformCredentials struct {
 	ClientID       string
 	ClientSecret   string
@@ -27,21 +35,17 @@ type PlatformCredentials struct {
 	PlatformToken  string
 }
 
-type Credentials struct {
+type ClusterCredentials struct {
 	URL   string
 	Token string
-	IAM   struct {
-		ClientID     string
-		AccountID    string
-		ClientSecret string
-		TokenURL     string
-		EndpointURL  string
-	}
+}
+
+type Credentials struct {
+	URL      string
+	Token    string
+	IAM      IAMCredentials
 	Platform PlatformCredentials
-	Cluster  struct {
-		URL   string
-		Token string
-	}
+	Cluster  ClusterCredentials
 }
 
 func (c *Credentials) ContainsOAuth() bool {

--- a/dynatrace/rest/iam_client.go
+++ b/dynatrace/rest/iam_client.go
@@ -53,8 +53,6 @@ type iamClient struct {
 }
 
 func NewIAMClient(ctx context.Context, credentials *Credentials) (IAMClient, error) {
-	PreRequest()
-
 	client, err := clients.Factory().
 		WithHTTPListener(logging.HTTPListener("iam")).
 		WithOAuthCredentials(clientcredentials.Config{

--- a/dynatrace/rest/iam_client.go
+++ b/dynatrace/rest/iam_client.go
@@ -52,10 +52,10 @@ type iamClient struct {
 	accountID string
 }
 
-func NewIAMClient(ctx context.Context, credentials *Credentials) IAMClient {
+func NewIAMClient(ctx context.Context, credentials *Credentials) (IAMClient, error) {
 	PreRequest()
 
-	client, _ := clients.Factory().
+	client, err := clients.Factory().
 		WithHTTPListener(logging.HTTPListener("iam")).
 		WithOAuthCredentials(clientcredentials.Config{
 			ClientID:     credentials.IAM.ClientID,
@@ -73,8 +73,11 @@ func NewIAMClient(ctx context.Context, credentials *Credentials) IAMClient {
 		}).
 		WithAccountURL(credentials.IAM.EndpointURL).
 		AccountRestClient(NewContextWithOAuthRetryClient(ctx))
+	if err != nil {
+		return nil, err
+	}
 
-	return &iamClient{client: client, accountID: credentials.IAM.AccountID}
+	return &iamClient{client: client, accountID: credentials.IAM.AccountID}, nil
 }
 
 func (me *iamClient) AccountID() string {

--- a/dynatrace/rest/iam_client.go
+++ b/dynatrace/rest/iam_client.go
@@ -42,10 +42,14 @@ type IAMClient interface {
 	PUT(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
 	GET(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
 	DELETE(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
+	// AccountID returns the account ID associated with the client. It is a constant fixed when the
+	// client is created.
+	AccountID() string
 }
 
 type iamClient struct {
-	client *rest2.Client
+	client    *rest2.Client
+	accountID string
 }
 
 func NewIAMClient(ctx context.Context, credentials *Credentials) IAMClient {
@@ -70,7 +74,11 @@ func NewIAMClient(ctx context.Context, credentials *Credentials) IAMClient {
 		WithAccountURL(credentials.IAM.EndpointURL).
 		AccountRestClient(NewContextWithOAuthRetryClient(ctx))
 
-	return &iamClient{client: client}
+	return &iamClient{client: client, accountID: credentials.IAM.AccountID}
+}
+
+func (me *iamClient) AccountID() string {
+	return me.accountID
 }
 
 func (me *iamClient) POST(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {

--- a/dynatrace/rest/iam_client.go
+++ b/dynatrace/rest/iam_client.go
@@ -1,6 +1,6 @@
 /**
 * @license
-* Copyright 2025 Dynatrace LLC
+* Copyright 2026 Dynatrace LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 * limitations under the License.
  */
 
-package iam
+package rest
 
 import (
 	"bytes"
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
 	"golang.org/x/oauth2/clientcredentials"
@@ -49,8 +48,8 @@ type iamClient struct {
 	client *rest2.Client
 }
 
-func NewIAMClient(ctx context.Context, credentials *rest.Credentials) IAMClient {
-	rest.PreRequest()
+func NewIAMClient(ctx context.Context, credentials *Credentials) IAMClient {
+	PreRequest()
 
 	client, _ := clients.Factory().
 		WithHTTPListener(logging.HTTPListener("iam")).
@@ -69,7 +68,7 @@ func NewIAMClient(ctx context.Context, credentials *rest.Credentials) IAMClient 
 			},
 		}).
 		WithAccountURL(credentials.IAM.EndpointURL).
-		AccountRestClient(rest.NewContextWithOAuthRetryClient(ctx))
+		AccountRestClient(NewContextWithOAuthRetryClient(ctx))
 
 	return &iamClient{client: client}
 }

--- a/dynatrace/rest/logging/logger_test.go
+++ b/dynatrace/rest/logging/logger_test.go
@@ -32,6 +32,7 @@ import (
 	setboundaries "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam/boundaries/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,16 +121,20 @@ func TestProviderLogging(t *testing.T) {
 		httpServer := httptest.NewServer(&mux)
 		defer httpServer.Close()
 
-		service, err := boundaries.Service(&config.ProviderConfiguration{
-			EnvironmentURL: httpServer.URL,
-			IAM: config.IAM{
+		credentials := &rest.Credentials{
+			IAM: rest.IAMCredentials{
 				ClientID:     "id",
 				AccountID:    "account-id",
 				ClientSecret: "secret",
 				TokenURL:     httpServer.URL + "/sso",
 				EndpointURL:  httpServer.URL,
 			},
-		})
+		}
+
+		clientSet := &testing2.MockClientSet{}
+		clientSet.IAMClientValue, clientSet.IAMClientErr = rest.NewIAMClient(t.Context(), credentials)
+
+		service, err := boundaries.Service(clientSet)
 		require.NoError(t, err)
 		err = service.Get(t.Context(), "test-id", new(setboundaries.PolicyBoundary))
 		require.NoError(t, err)

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -41,8 +41,6 @@ type platform_request request
 var NoPlatformCredentialsErr = errors.New("neither oauth credentials nor platform token present")
 
 func CreatePlatformClient(ctx context.Context, platformURL string, credentials *Credentials) (*rest.Client, error) {
-	PreRequest()
-
 	factory := clients.Factory().
 		WithPlatformURL(platformURL).
 		WithRateLimiter(true).
@@ -75,8 +73,6 @@ func (me *platform_request) Finish(optionalTarget ...any) error {
 	if len(optionalTarget) > 0 {
 		target = optionalTarget[0]
 	}
-
-	PreRequest()
 
 	platformURL := me.evalPlatformURL(me.client.Credentials().URL)
 

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -26,15 +26,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sync"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/google/uuid"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
-
-var preRequestMutex sync.Mutex
 
 type Request interface {
 	Finish(v ...any) error
@@ -58,14 +54,10 @@ type request struct {
 	onResponse func(resp *http.Response)
 }
 
-func PreRequest() {
-	preRequestMutex.Lock()
-	defer preRequestMutex.Unlock()
-
-	if envutils.DynatraceHTTPInsecure.Get() {
-		if transport, ok := http.DefaultTransport.(*http.Transport); ok {
-			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		}
+// SetInsecureSkipVerifyOnDefaultTransport sets the InsecureSkipVerify flag on the default HTTP transport.
+func SetInsecureSkipVerifyOnDefaultTransport(insecure bool) {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
 	}
 }
 

--- a/dynatrace/testing/mockclientset.go
+++ b/dynatrace/testing/mockclientset.go
@@ -1,0 +1,33 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testing
+
+import "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+
+// MockClientSet is a rest.ClientSet whose IAM client and credentials are supplied directly, for
+// injecting a MockIAMClient into IAM services under test.
+type MockClientSet struct {
+	IAMClientValue   rest.IAMClient
+	IAMClientErr     error
+	CredentialsValue *rest.Credentials
+}
+
+func (me *MockClientSet) IAMClient() (rest.IAMClient, error) {
+	return me.IAMClientValue, me.IAMClientErr
+}
+
+func (me *MockClientSet) Credentials() *rest.Credentials { return me.CredentialsValue }

--- a/dynatrace/testing/mockiamclient.go
+++ b/dynatrace/testing/mockiamclient.go
@@ -25,10 +25,15 @@ import (
 )
 
 type MockIAMClient struct {
-	POSTFunc   func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
-	PUTFunc    func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
-	GETFunc    func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
-	DELETEFunc func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
+	POSTFunc       func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
+	PUTFunc        func(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error)
+	GETFunc        func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
+	DELETEFunc     func(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error)
+	AccountIDValue string
+}
+
+func (me *MockIAMClient) AccountID() string {
+	return me.AccountIDValue
 }
 
 func (me *MockIAMClient) POST(ctx context.Context, url string, payload any, options rest2.RequestOptions) (api.Response, error) {

--- a/dynatrace/testing/mockiamclient.go
+++ b/dynatrace/testing/mockiamclient.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
@@ -50,12 +49,4 @@ func (me *MockIAMClient) GET(ctx context.Context, url string, options rest2.Requ
 
 func (me *MockIAMClient) DELETE(ctx context.Context, url string, options rest2.RequestOptions) (api.Response, error) {
 	return me.DELETEFunc(ctx, url, options)
-}
-
-type MockIAMClientGetter struct {
-	Client rest.IAMClient
-}
-
-func (me *MockIAMClientGetter) New(_ context.Context) rest.IAMClient {
-	return me.Client
 }

--- a/dynatrace/testing/mockiamclient.go
+++ b/dynatrace/testing/mockiamclient.go
@@ -19,7 +19,7 @@ package testing
 import (
 	"context"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/iam"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
@@ -48,9 +48,9 @@ func (me *MockIAMClient) DELETE(ctx context.Context, url string, options rest2.R
 }
 
 type MockIAMClientGetter struct {
-	Client iam.IAMClient
+	Client rest.IAMClient
 }
 
-func (me *MockIAMClientGetter) New(_ context.Context) iam.IAMClient {
+func (me *MockIAMClientGetter) New(_ context.Context) rest.IAMClient {
 	return me.Client
 }

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -30,22 +30,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-type IAM struct {
-	ClientID     string
-	AccountID    string
-	ClientSecret string
-	TokenURL     string
-	EndpointURL  string
-}
-
-// ProviderConfiguration contains credentials to communicate with the Dynatrace API
+// ProviderConfiguration contains credentials and clients to communicate with the Dynatrace API
 type ProviderConfiguration struct {
 	EnvironmentURL  string
 	ClusterAPIV2URL string
 	ClusterAPIToken string
 	APIToken        string
-	IAM             IAM
+	IAM             rest.IAMCredentials
 	Platform        rest.PlatformCredentials
+
+	iamClient    rest.IAMClient
+	iamClientErr error
 }
 
 func (c *ProviderConfiguration) Credentials() *rest.Credentials {
@@ -58,6 +53,10 @@ func (c *ProviderConfiguration) Credentials() *rest.Credentials {
 	credentials.Cluster.URL = c.ClusterAPIV2URL
 	credentials.Cluster.Token = c.ClusterAPIToken
 	return credentials
+}
+
+func (c *ProviderConfiguration) IAMClient() (rest.IAMClient, error) {
+	return c.iamClient, c.iamClientErr
 }
 
 type Getter interface {
@@ -99,12 +98,12 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 }
 
 func ProviderConfigureGeneric(ctx context.Context, d Getter) *ProviderConfiguration {
-	return &ProviderConfiguration{
+	pc := &ProviderConfiguration{
 		EnvironmentURL:  getClassicEnvironmentURL(d),
 		APIToken:        getString(d, "dt_api_token"),
 		ClusterAPIToken: getString(d, "dt_cluster_api_token"),
 		ClusterAPIV2URL: getURLString(d, "dt_cluster_url"),
-		IAM: IAM{
+		IAM: rest.IAMCredentials{
 			ClientID:     getIAMClientID(d),
 			AccountID:    getAccountID(d),
 			ClientSecret: getIAMClientSecret(d),
@@ -119,6 +118,14 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) *ProviderConfigurat
 			EnvironmentURL: getPlatformEnvironmentURL(d),
 		},
 	}
+
+	// As the context passed to this function does not live long enough, use context.Background() instead.
+	// The context is used to retrieve and refresh the bearer token but not for the actual API calls.
+	clientCtx := context.Background()
+
+	pc.iamClient, pc.iamClientErr = rest.NewIAMClient(clientCtx, pc.Credentials())
+
+	return pc
 }
 
 func validateCredentials(conf *ProviderConfiguration, CredentialValidation int) error {

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -119,6 +119,10 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) *ProviderConfigurat
 		},
 	}
 
+	if envutils.DynatraceHTTPInsecure.Get() {
+		rest.SetInsecureSkipVerifyOnDefaultTransport(true)
+	}
+
 	// As the context passed to this function does not live long enough, use context.Background() instead.
 	// The context is used to retrieve and refresh the bearer token but not for the actual API calls.
 	clientCtx := context.Background()


### PR DESCRIPTION
#### **Why** this PR?
As IAM always requires OAuth, a single IAMClient instance reduces the number of calls made to the SSO. As this is a bottleneck, this PR improves the stability and performance of IAM resources and data sources.

#### **What** has changed and **how** does it do it?
- The IAM client moves to the `rest` package and gains the `AccountID()` method that provides the fixed account ID it was created with.
- Updates provider and request plumbing in `provider/config/config.go`, `dynatrace/rest/client_set.go`, and `dynatrace/rest/request.go` so IAM client initialization happens once during provider configuration and `DYNATRACE_HTTP_INSECURE` is applied by setting `InsecureSkipVerify` on the default transport up front.
- IAM services are refactored to use a shared IAM client via `clientSet.IAMClient()` instead of building clients or reading `Credentials().IAM.AccountID` directly.
- `dynatrace/api/iam/policies/policy_level.go` updates policy and environment lookup helpers to work with `rest.IAMClient`.
- Follow-on refactoring details by fixing `ServiceWithGloabals` to `ServiceWithGlobals`, handling constructor errors in IAM data sources, and removing unused IAM-related code such as `policies.FetchPolicyLevel(...)` and `ListUsersResponse.Count`.

#### How is it **tested**?
Existing tests are updated.

#### How does it affect **users**?
No effect rather than improved performance of IAM resources and datasources

**Issue:** PS-45615
