### PR TITLE
refactor: Add shared platform client to clientset

### DIFF
--- a/datasources/dql/data_source.go
+++ b/datasources/dql/data_source.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
@@ -108,7 +107,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	restClient, err := rest.CreatePlatformClient(ctx, clientSet.Credentials().Platform.EnvironmentURL, clientSet.Credentials())
+	restClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/datasources/extensions/active_version/data_source.go
+++ b/datasources/extensions/active_version/data_source.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -54,26 +53,18 @@ type ExtensionClient interface {
 	GetEnvironmentConfiguration(ctx context.Context, extensionName string) (coreapi.Response, error)
 }
 
-func createCoreClient(ctx context.Context, clientSet rest.ClientSet) (ExtensionClient, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, clientSet.Credentials().Platform.EnvironmentURL, clientSet.Credentials())
-	if err != nil {
-		return nil, err
-	}
-	return coreextensions.NewClient(platformClient), nil
-}
-
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	clientSet, err := config.ClientSet(m, config.CredValDefault)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client, err := createCoreClient(ctx, clientSet)
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	return DataSourceReadWithClient(ctx, d, client)
+	return DataSourceReadWithClient(ctx, d, coreextensions.NewClient(platformClient))
 }
 
 type environmentConfiguration struct {

--- a/datasources/extensions/latest_version/data_source.go
+++ b/datasources/extensions/latest_version/data_source.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -55,26 +54,18 @@ type ExtensionClient interface {
 	ListExtensionVersions(ctx context.Context, extensionName string) (coreapi.PagedListResponse, error)
 }
 
-func createCoreClient(ctx context.Context, clientSet rest.ClientSet) (ExtensionClient, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, clientSet.Credentials().Platform.EnvironmentURL, clientSet.Credentials())
-	if err != nil {
-		return nil, err
-	}
-	return coreextensions.NewClient(platformClient), nil
-}
-
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	clientSet, err := config.ClientSet(m, config.CredValDefault)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client, err := createCoreClient(ctx, clientSet)
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	return DataSourceReadWithClient(ctx, d, client)
+	return DataSourceReadWithClient(ctx, d, coreextensions.NewClient(platformClient))
 }
 
 type listExtensionVersions struct {

--- a/datasources/slo/objectivetemplates/data_source.go
+++ b/datasources/slo/objectivetemplates/data_source.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
@@ -54,7 +53,10 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	restClient, _ := rest.CreatePlatformClient(ctx, clientSet.Credentials().Platform.EnvironmentURL, clientSet.Credentials())
+	restClient, err := clientSet.PlatformClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	client := NewClient(restClient)
 

--- a/datasources/slo/objectivetemplates/data_source_multi.go
+++ b/datasources/slo/objectivetemplates/data_source_multi.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
@@ -65,7 +64,10 @@ func DataSourceMultiRead(ctx context.Context, d *schema.ResourceData, m any) dia
 		return diag.FromErr(err)
 	}
 
-	restClient, _ := rest.CreatePlatformClient(ctx, clientSet.Credentials().Platform.EnvironmentURL, clientSet.Credentials())
+	restClient, err := clientSet.PlatformClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	client := NewClient(restClient)
 

--- a/dynatrace/api/automation/business_calendars/service.go
+++ b/dynatrace/api/automation/business_calendars/service.go
@@ -31,28 +31,23 @@ import (
 )
 
 func Service(clientSet tfrest.ClientSet) (settings.CRUDService[*business_calendars.Settings], error) {
-	return &service{clientSet}, nil
-}
-
-type service struct {
-	clientSet tfrest.ClientSet
-}
-
-func (me *service) client(ctx context.Context) (*automation.Client, error) {
-	platformClient, err := tfrest.CreatePlatformClient(ctx, me.clientSet.Credentials().Platform.EnvironmentURL, me.clientSet.Credentials())
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return automation.NewClient(platformClient), nil
+
+	return &service{
+		client: automation.NewClient(platformClient),
+	}, nil
+}
+
+type service struct {
+	client *automation.Client
 }
 
 func (me *service) Get(ctx context.Context, id string, v *business_calendars.Settings) (err error) {
-	client, err := me.client(ctx)
+	response, err := me.client.Get(ctx, automation.BusinessCalendars, id)
 	if err != nil {
-		return err
-	}
-	var response cacapi.Response
-	if response, err = client.Get(ctx, automation.BusinessCalendars, id); err != nil {
 		return err
 	}
 	return json.Unmarshal(response.Data, &v)
@@ -68,11 +63,7 @@ type BusinessCalendarStub struct {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
-	listResponse, err := client.List(ctx, automation.BusinessCalendars)
+	listResponse, err := me.client.List(ctx, automation.BusinessCalendars)
 	if err != nil {
 		return nil, err
 	}
@@ -93,16 +84,13 @@ func (me *service) Validate(v *business_calendars.Settings) error {
 }
 
 func (me *service) Create(ctx context.Context, v *business_calendars.Settings) (stub *api.Stub, err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return nil, err
 	}
-	var response cacapi.Response
-	if response, err = client.Create(ctx, automation.BusinessCalendars, data); err != nil {
+
+	response, err := me.client.Create(ctx, automation.BusinessCalendars, data)
+	if err != nil {
 		return nil, err
 	}
 	var bStub BusinessCalendarStub
@@ -113,25 +101,17 @@ func (me *service) Create(ctx context.Context, v *business_calendars.Settings) (
 }
 
 func (me *service) Update(ctx context.Context, id string, v *business_calendars.Settings) (err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return err
 	}
 
-	_, err = client.Update(ctx, automation.BusinessCalendars, id, data)
+	_, err = me.client.Update(ctx, automation.BusinessCalendars, id, data)
 	return err
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	if _, err = client.Delete(ctx, automation.BusinessCalendars, id); err != nil && !cacapi.IsNotFoundError(err) {
+	if _, err := me.client.Delete(ctx, automation.BusinessCalendars, id); err != nil && !cacapi.IsNotFoundError(err) {
 		return err
 	}
 	return nil

--- a/dynatrace/api/automation/scheduling_rules/service.go
+++ b/dynatrace/api/automation/scheduling_rules/service.go
@@ -31,28 +31,23 @@ import (
 )
 
 func Service(clientSet tfrest.ClientSet) (settings.CRUDService[*scheduling_rules.Settings], error) {
-	return &service{clientSet}, nil
-}
-
-type service struct {
-	clientSet tfrest.ClientSet
-}
-
-func (me *service) client(ctx context.Context) (*automation.Client, error) {
-	platformClient, err := tfrest.CreatePlatformClient(ctx, me.clientSet.Credentials().Platform.EnvironmentURL, me.clientSet.Credentials())
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return automation.NewClient(platformClient), nil
+
+	return &service{
+		client: automation.NewClient(platformClient),
+	}, nil
+}
+
+type service struct {
+	client *automation.Client
 }
 
 func (me *service) Get(ctx context.Context, id string, v *scheduling_rules.Settings) (err error) {
-	client, err := me.client(ctx)
+	response, err := me.client.Get(ctx, automation.SchedulingRules, id)
 	if err != nil {
-		return err
-	}
-	var response cacapi.Response
-	if response, err = client.Get(ctx, automation.SchedulingRules, id); err != nil {
 		return err
 	}
 	return json.Unmarshal(response.Data, &v)
@@ -68,11 +63,7 @@ type SchedulingRuleStub struct {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
-	listResponse, err := client.List(ctx, automation.SchedulingRules)
+	listResponse, err := me.client.List(ctx, automation.SchedulingRules)
 	if err != nil {
 		return nil, err
 	}
@@ -92,16 +83,12 @@ func (me *service) Validate(v *scheduling_rules.Settings) error {
 }
 
 func (me *service) Create(ctx context.Context, v *scheduling_rules.Settings) (stub *api.Stub, err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return nil, err
 	}
-	var response cacapi.Response
-	if response, err = client.Create(ctx, automation.SchedulingRules, data); err != nil {
+	response, err := me.client.Create(ctx, automation.SchedulingRules, data)
+	if err != nil {
 		return nil, err
 	}
 	var scStub SchedulingRuleStub
@@ -112,24 +99,16 @@ func (me *service) Create(ctx context.Context, v *scheduling_rules.Settings) (st
 }
 
 func (me *service) Update(ctx context.Context, id string, v *scheduling_rules.Settings) (err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return err
 	}
-	_, err = client.Update(ctx, automation.SchedulingRules, id, data)
+	_, err = me.client.Update(ctx, automation.SchedulingRules, id, data)
 	return err
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	if _, err = client.Delete(ctx, automation.SchedulingRules, id); err != nil && !cacapi.IsNotFoundError(err) {
+	if _, err := me.client.Delete(ctx, automation.SchedulingRules, id); err != nil && !cacapi.IsNotFoundError(err) {
 		return err
 	}
 	return nil

--- a/dynatrace/api/automation/workflows/service.go
+++ b/dynatrace/api/automation/workflows/service.go
@@ -41,33 +41,25 @@ type AutomationClient interface {
 }
 
 type service struct {
-	clientSet    tfrest.ClientSet
-	clientGetter func(ctx context.Context, clientSet tfrest.ClientSet) (AutomationClient, error)
+	client AutomationClient
 }
 
 func Service(clientSet tfrest.ClientSet) (settings.CRUDService[*workflows.Workflow], error) {
-	return &service{clientSet: clientSet, clientGetter: createCoreClient}, nil
-}
-
-func ServiceWithClientGetter(clientGetter func(ctx context.Context, clientSet tfrest.ClientSet) (AutomationClient, error), clientSet tfrest.ClientSet) settings.CRUDService[*workflows.Workflow] {
-	return &service{clientSet: clientSet, clientGetter: clientGetter}
-}
-
-func createCoreClient(ctx context.Context, clientSet tfrest.ClientSet) (AutomationClient, error) {
-	platformClient, err := tfrest.CreatePlatformClient(ctx, clientSet.Credentials().Platform.EnvironmentURL, clientSet.Credentials())
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return automation.NewClient(platformClient), nil
+
+	return &service{client: automation.NewClient(platformClient)}, nil
+}
+
+func ServiceWithAutomationClient(client AutomationClient) settings.CRUDService[*workflows.Workflow] {
+	return &service{client: client}
 }
 
 func (me *service) Get(ctx context.Context, id string, v *workflows.Workflow) error {
-	client, err := me.clientGetter(ctx, me.clientSet)
+	response, err := me.client.Get(ctx, apiClient.Workflows, id)
 	if err != nil {
-		return err
-	}
-	var response cacapi.Response
-	if response, err = client.Get(ctx, apiClient.Workflows, id); err != nil {
 		return err
 	}
 
@@ -120,11 +112,7 @@ type WorkflowStub struct {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := me.clientGetter(ctx, me.clientSet)
-	if err != nil {
-		return nil, err
-	}
-	listResponse, err := client.List(ctx, apiClient.Workflows)
+	listResponse, err := me.client.List(ctx, apiClient.Workflows)
 	if err != nil {
 		return nil, err
 	}
@@ -145,16 +133,12 @@ func (me *service) Validate(v *workflows.Workflow) error {
 }
 
 func (me *service) Create(ctx context.Context, v *workflows.Workflow) (stub *api.Stub, err error) {
-	client, err := me.clientGetter(ctx, me.clientSet)
-	if err != nil {
-		return nil, err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return nil, err
 	}
-	var response cacapi.Response
-	if response, err = client.Create(ctx, apiClient.Workflows, data); err != nil {
+	response, err := me.client.Create(ctx, apiClient.Workflows, data)
+	if err != nil {
 		return nil, err
 	}
 
@@ -166,24 +150,16 @@ func (me *service) Create(ctx context.Context, v *workflows.Workflow) (stub *api
 }
 
 func (me *service) Update(ctx context.Context, id string, v *workflows.Workflow) (err error) {
-	client, err := me.clientGetter(ctx, me.clientSet)
-	if err != nil {
-		return err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return err
 	}
-	_, err = client.Update(ctx, apiClient.Workflows, id, data)
+	_, err = me.client.Update(ctx, apiClient.Workflows, id, data)
 	return err
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	client, err := me.clientGetter(ctx, me.clientSet)
-	if err != nil {
-		return err
-	}
-	if _, err = client.Delete(ctx, apiClient.Workflows, id); err != nil && !cacapi.IsNotFoundError(err) {
+	if _, err := me.client.Delete(ctx, apiClient.Workflows, id); err != nil && !cacapi.IsNotFoundError(err) {
 		return err
 	}
 

--- a/dynatrace/api/automation/workflows/service_unit_test.go
+++ b/dynatrace/api/automation/workflows/service_unit_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/automation/workflows"
 	workflowSettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/automation/workflows/settings"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -62,38 +62,27 @@ func (m *mockAutomationClient) Delete(ctx context.Context, resourceType apiClien
 	return m.deleteFn(ctx, resourceType, id)
 }
 
-func mockClientGetter(client *mockAutomationClient) func(ctx context.Context, credentials rest.ClientSet) (workflows.AutomationClient, error) {
-	return func(ctx context.Context, credentials rest.ClientSet) (workflows.AutomationClient, error) {
-		return client, nil
-	}
-}
-
-func failingClientGetter(err error) func(ctx context.Context, credentials rest.ClientSet) (workflows.AutomationClient, error) {
-	return func(ctx context.Context, credentials rest.ClientSet) (workflows.AutomationClient, error) {
-		return nil, err
-	}
-}
-
 func pagedResponse(objects ...[]byte) coreapi.PagedListResponse {
 	return coreapi.PagedListResponse{
 		{Objects: objects},
 	}
 }
 
-func TestService_Get(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := workflows.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		err := svc.Get(t.Context(), "wf-1", &workflowSettings.Workflow{})
-		assert.ErrorIs(t, err, assert.AnError)
-	})
+// TestServiceCreationFailsIfMissingClient tests that the service creation fails if the platform client is missing.
+func TestServiceCreationFailsIfClientUnavailable(t *testing.T) {
+	service, err := workflows.Service(&testing2.MockClientSet{PlatformClientErr: assert.AnError})
+	require.Nil(t, service)
+	require.ErrorIs(t, err, assert.AnError)
+}
 
+func TestService_Get(t *testing.T) {
 	t.Run("Returns error when client Get fails", func(t *testing.T) {
 		mock := &mockAutomationClient{
 			getFn: func(ctx context.Context, resourceType apiClient.ResourceType, id string) (coreapi.Response, error) {
 				return coreapi.Response{}, assert.AnError
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		err := svc.Get(t.Context(), "wf-1", &workflowSettings.Workflow{})
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -104,7 +93,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: []byte("not-json")}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		err := svc.Get(t.Context(), "wf-1", &workflowSettings.Workflow{})
 		var jsonErr *json.SyntaxError
 		assert.ErrorAs(t, err, &jsonErr)
@@ -121,7 +110,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: responseData}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		v := &workflowSettings.Workflow{}
 		err := svc.Get(t.Context(), "wf-1", v)
 		require.NoError(t, err)
@@ -148,7 +137,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: responseData}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		v := &workflowSettings.Workflow{}
 		// context without a state config (export scenario)
 		err := svc.Get(t.Context(), "wf-1", v)
@@ -164,7 +153,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: responseData}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		stateConfig := &workflowSettings.Workflow{
 			Tasks: workflowSettings.Tasks{
 				{Name: "task1", Position: &workflowSettings.TaskPosition{X: 5, Y: 6}},
@@ -185,7 +174,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: responseData}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		stateConfig := &workflowSettings.Workflow{
 			Tasks: workflowSettings.Tasks{
 				{Name: "task1", Position: &workflowSettings.TaskPosition{X: 5, Y: 6}},
@@ -218,7 +207,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: responseData}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		stateConfig := &workflowSettings.Workflow{
 			Tasks: workflowSettings.Tasks{
 				{Name: "task1"},
@@ -234,19 +223,13 @@ func TestService_Get(t *testing.T) {
 }
 
 func TestService_List(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := workflows.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		_, err := svc.List(t.Context())
-		assert.ErrorIs(t, err, assert.AnError)
-	})
-
 	t.Run("Returns error when client List fails", func(t *testing.T) {
 		mock := &mockAutomationClient{
 			listFn: func(ctx context.Context, resourceType apiClient.ResourceType) (coreapi.PagedListResponse, error) {
 				return nil, assert.AnError
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		_, err := svc.List(t.Context())
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -257,7 +240,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse([]byte("bad-json")), nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		_, err := svc.List(t.Context())
 		var jsonErr *json.SyntaxError
 		assert.ErrorAs(t, err, &jsonErr)
@@ -273,7 +256,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse(wf1JSON, wf2JSON), nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		stubs, err := svc.List(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, apiClient.Workflows, capturedResourceType)
@@ -286,7 +269,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse(), nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		stubs, err := svc.List(t.Context())
 		require.NoError(t, err)
 		assert.Empty(t, stubs)
@@ -294,19 +277,13 @@ func TestService_List(t *testing.T) {
 }
 
 func TestService_Create(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := workflows.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		_, err := svc.Create(t.Context(), &workflowSettings.Workflow{Title: "wf"})
-		assert.ErrorIs(t, err, assert.AnError)
-	})
-
 	t.Run("Returns error when client Create fails", func(t *testing.T) {
 		mock := &mockAutomationClient{
 			createFn: func(ctx context.Context, resourceType apiClient.ResourceType, data []byte) (coreapi.Response, error) {
 				return coreapi.Response{}, assert.AnError
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		_, err := svc.Create(t.Context(), &workflowSettings.Workflow{Title: "wf"})
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -317,7 +294,7 @@ func TestService_Create(t *testing.T) {
 				return coreapi.Response{Data: []byte("bad-json")}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		_, err := svc.Create(t.Context(), &workflowSettings.Workflow{Title: "wf"})
 		var jsonErr *json.SyntaxError
 		assert.ErrorAs(t, err, &jsonErr)
@@ -335,7 +312,7 @@ func TestService_Create(t *testing.T) {
 				return coreapi.Response{Data: respJSON}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		stub, err := svc.Create(t.Context(), &workflowSettings.Workflow{
 			Title:       "My Workflow",
 			Description: "desc",
@@ -349,19 +326,13 @@ func TestService_Create(t *testing.T) {
 }
 
 func TestService_Update(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := workflows.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		err := svc.Update(t.Context(), "wf-1", &workflowSettings.Workflow{})
-		assert.ErrorIs(t, err, assert.AnError)
-	})
-
 	t.Run("Returns error when client Update fails", func(t *testing.T) {
 		mock := &mockAutomationClient{
 			updateFn: func(ctx context.Context, resourceType apiClient.ResourceType, id string, data []byte) (coreapi.Response, error) {
 				return coreapi.Response{}, assert.AnError
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		err := svc.Update(t.Context(), "wf-1", &workflowSettings.Workflow{})
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -379,7 +350,7 @@ func TestService_Update(t *testing.T) {
 				return coreapi.Response{}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		err := svc.Update(t.Context(), "wf-1", &workflowSettings.Workflow{
 			Title:       "Updated",
 			Description: "updated desc",
@@ -393,19 +364,13 @@ func TestService_Update(t *testing.T) {
 }
 
 func TestService_Delete(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := workflows.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		err := svc.Delete(t.Context(), "wf-1")
-		assert.ErrorIs(t, err, assert.AnError)
-	})
-
 	t.Run("Returns error when client Delete fails with non-NotFound error", func(t *testing.T) {
 		mock := &mockAutomationClient{
 			deleteFn: func(ctx context.Context, resourceType apiClient.ResourceType, id string) (coreapi.Response, error) {
 				return coreapi.Response{}, assert.AnError
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		err := svc.Delete(t.Context(), "wf-1")
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -416,7 +381,7 @@ func TestService_Delete(t *testing.T) {
 				return coreapi.Response{}, coreapi.APIError{StatusCode: http.StatusNotFound}
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		err := svc.Delete(t.Context(), "wf-1")
 		assert.NoError(t, err)
 	})
@@ -431,7 +396,7 @@ func TestService_Delete(t *testing.T) {
 				return coreapi.Response{}, nil
 			},
 		}
-		svc := workflows.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := workflows.ServiceWithAutomationClient(mock)
 		err := svc.Delete(t.Context(), "wf-1")
 		require.NoError(t, err)
 		assert.Equal(t, apiClient.Workflows, capturedResourceType)

--- a/dynatrace/api/documents/directshares/service.go
+++ b/dynatrace/api/documents/directshares/service.go
@@ -32,11 +32,16 @@ import (
 )
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*serviceSettings.DirectShare], error) {
-	return &service{clientGetter: createCoreClient, clientSet: clientSet}, nil
+	platformClient, err := clientSet.PlatformClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &service{client: coredirectshares.NewClient(platformClient)}, nil
 }
 
-func ServiceWithClientGetter(clientGetter func(ctx context.Context, clientSet rest.ClientSet) (directSharesClient, error), clientSet rest.ClientSet) settings.CRUDService[*serviceSettings.DirectShare] {
-	return &service{clientGetter: clientGetter, clientSet: clientSet}
+func ServiceWithClient(client directSharesClient) settings.CRUDService[*serviceSettings.DirectShare] {
+	return &service{client: client}
 }
 
 type directSharesClient interface {
@@ -51,8 +56,7 @@ type directSharesClient interface {
 }
 
 type service struct {
-	clientGetter func(ctx context.Context, clientSet rest.ClientSet) (directSharesClient, error)
-	clientSet    rest.ClientSet
+	client directSharesClient
 }
 
 type directShareDTO struct {
@@ -80,21 +84,9 @@ type removeDirectShareRecipientsDTO struct {
 	Ids []string `json:"ids"`
 }
 
-func createCoreClient(ctx context.Context, clientSet rest.ClientSet) (directSharesClient, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, clientSet.Credentials().Platform.EnvironmentURL, clientSet.Credentials())
-	if err != nil {
-		return nil, err
-	}
-	return coredirectshares.NewClient(platformClient), nil
-}
-
 func (me *service) Get(ctx context.Context, id string, v *serviceSettings.DirectShare) (err error) {
-	client, err := me.clientGetter(ctx, me.clientSet)
-	if err != nil {
-		return err
-	}
 
-	result, err := client.Get(ctx, id)
+	result, err := me.client.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -108,7 +100,7 @@ func (me *service) Get(ctx context.Context, id string, v *serviceSettings.Direct
 	v.DocumentId = ds.DocumentId
 	v.Access = strings.Join(ds.Access, "-")
 
-	recipients, err := me.getRecipients(ctx, client, id)
+	recipients, err := me.getRecipients(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -117,8 +109,8 @@ func (me *service) Get(ctx context.Context, id string, v *serviceSettings.Direct
 	return nil
 }
 
-func (me *service) getRecipients(ctx context.Context, client directSharesClient, id string) (serviceSettings.Recipients, error) {
-	recipientsResp, err := client.GetRecipients(ctx, id)
+func (me *service) getRecipients(ctx context.Context, id string) (serviceSettings.Recipients, error) {
+	recipientsResp, err := me.client.GetRecipients(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +136,7 @@ func (me *service) SchemaID() string {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := me.clientGetter(ctx, me.clientSet)
-	if err != nil {
-		return nil, err
-	}
-	listResponse, err := client.List(ctx)
+	listResponse, err := me.client.List(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -172,11 +160,6 @@ func (me *service) Validate(v *serviceSettings.DirectShare) error {
 }
 
 func (me *service) Create(ctx context.Context, v *serviceSettings.DirectShare) (stub *api.Stub, err error) {
-	client, err := me.clientGetter(ctx, me.clientSet)
-	if err != nil {
-		return nil, err
-	}
-
 	recipients := make([]recipientDTO, len(v.Recipients))
 	for i, r := range v.Recipients {
 		recipients[i] = recipientDTO{
@@ -196,7 +179,7 @@ func (me *service) Create(ctx context.Context, v *serviceSettings.DirectShare) (
 		return nil, err
 	}
 
-	result, err := client.Create(ctx, data)
+	result, err := me.client.Create(ctx, data)
 	if err != nil {
 		return nil, err
 	}
@@ -211,28 +194,23 @@ func (me *service) Create(ctx context.Context, v *serviceSettings.DirectShare) (
 }
 
 func (me *service) Update(ctx context.Context, id string, v *serviceSettings.DirectShare) (err error) {
-	client, err := me.clientGetter(ctx, me.clientSet)
+	remoteRecipients, err := me.getRecipients(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	remoteRecipients, err := me.getRecipients(ctx, client, id)
-	if err != nil {
+	if err := me.addRecipients(ctx, id, v.Recipients, remoteRecipients); err != nil {
 		return err
 	}
 
-	if err := me.addRecipients(ctx, client, id, v.Recipients, remoteRecipients); err != nil {
-		return err
-	}
-
-	if err := me.removeRecipients(ctx, client, id, v.Recipients, remoteRecipients); err != nil {
+	if err := me.removeRecipients(ctx, id, v.Recipients, remoteRecipients); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (me *service) addRecipients(ctx context.Context, client directSharesClient, id string, recipients serviceSettings.Recipients, remoteRecipients serviceSettings.Recipients) error {
+func (me *service) addRecipients(ctx context.Context, id string, recipients serviceSettings.Recipients, remoteRecipients serviceSettings.Recipients) error {
 	var add addDirectShareRecipientsDTO
 	for _, desired := range recipients {
 		if !containsRecipient(remoteRecipients, desired) {
@@ -252,10 +230,10 @@ func (me *service) addRecipients(ctx context.Context, client directSharesClient,
 		return err
 	}
 
-	return client.AddRecipients(ctx, id, data)
+	return me.client.AddRecipients(ctx, id, data)
 }
 
-func (me *service) removeRecipients(ctx context.Context, client directSharesClient, id string, recipients serviceSettings.Recipients, remoteRecipients serviceSettings.Recipients) error {
+func (me *service) removeRecipients(ctx context.Context, id string, recipients serviceSettings.Recipients, remoteRecipients serviceSettings.Recipients) error {
 	var remove removeDirectShareRecipientsDTO
 	for _, remote := range remoteRecipients {
 		if !containsRecipient(recipients, remote) {
@@ -272,7 +250,7 @@ func (me *service) removeRecipients(ctx context.Context, client directSharesClie
 		return err
 	}
 
-	return client.RemoveRecipients(ctx, id, data)
+	return me.client.RemoveRecipients(ctx, id, data)
 }
 
 func containsRecipient(recipients serviceSettings.Recipients, target *serviceSettings.Recipient) bool {
@@ -285,11 +263,7 @@ func containsRecipient(recipients serviceSettings.Recipients, target *serviceSet
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	client, err := me.clientGetter(ctx, me.clientSet)
-	if err != nil {
-		return err
-	}
-	return client.Delete(ctx, id)
+	return me.client.Delete(ctx, id)
 }
 
 func (me *service) New() *serviceSettings.DirectShare {

--- a/dynatrace/api/documents/directshares/service_unit_test.go
+++ b/dynatrace/api/documents/directshares/service_unit_test.go
@@ -28,10 +28,10 @@ import (
 	coreapi "github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 
 	serviceSettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/directshares/settings"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 )
 
 type mockDirectSharesClient struct {
@@ -66,33 +66,20 @@ func (m *mockDirectSharesClient) RemoveRecipients(ctx context.Context, id string
 	return m.removeRecipientsFn(ctx, id, data)
 }
 
-func mockClientGetter(client *mockDirectSharesClient) func(ctx context.Context, credentials rest.ClientSet) (directSharesClient, error) {
-	return func(ctx context.Context, credentials rest.ClientSet) (directSharesClient, error) {
-		return client, nil
-	}
-}
-
-func failingClientGetter(err error) func(ctx context.Context, credentials rest.ClientSet) (directSharesClient, error) {
-	return func(ctx context.Context, credentials rest.ClientSet) (directSharesClient, error) {
-		return nil, err
-	}
-}
-
 func pagedResponse(objects ...[]byte) coreapi.PagedListResponse {
 	return coreapi.PagedListResponse{
 		{Objects: objects},
 	}
 }
 
-func TestService_Get(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		clientErr := errors.New("client creation failed")
-		svc := ServiceWithClientGetter(failingClientGetter(clientErr), &config.ProviderConfiguration{})
-		v := &serviceSettings.DirectShare{}
-		err := svc.Get(t.Context(), "id-1", v)
-		assert.ErrorIs(t, err, clientErr)
-	})
+// TestServiceCreationFailsIfMissingClient tests that the service creation fails if the platform client is missing.
+func TestServiceCreationFailsIfClientUnavailable(t *testing.T) {
+	service, err := Service(&testing2.MockClientSet{PlatformClientErr: assert.AnError})
+	require.Nil(t, service)
+	require.ErrorIs(t, err, assert.AnError)
+}
 
+func TestService_Get(t *testing.T) {
 	t.Run("Returns error when Get call fails", func(t *testing.T) {
 		getErr := errors.New("get failed")
 		mock := &mockDirectSharesClient{
@@ -100,7 +87,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{}, getErr
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		v := &serviceSettings.DirectShare{}
 		err := svc.Get(t.Context(), "id-1", v)
 		assert.ErrorIs(t, err, getErr)
@@ -112,7 +99,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: []byte("not-json")}, nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		v := &serviceSettings.DirectShare{}
 		err := svc.Get(t.Context(), "id-1", v)
 		assert.Error(t, err)
@@ -129,7 +116,7 @@ func TestService_Get(t *testing.T) {
 				return nil, recipientsErr
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		v := &serviceSettings.DirectShare{}
 		err := svc.Get(t.Context(), "id-1", v)
 		assert.ErrorIs(t, err, recipientsErr)
@@ -145,7 +132,7 @@ func TestService_Get(t *testing.T) {
 				return pagedResponse([]byte("bad-json")), nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		v := &serviceSettings.DirectShare{}
 		err := svc.Get(t.Context(), "id-1", v)
 		assert.Error(t, err)
@@ -164,7 +151,7 @@ func TestService_Get(t *testing.T) {
 				return pagedResponse(recipientJSON), nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		v := &serviceSettings.DirectShare{}
 		err := svc.Get(t.Context(), "id-1", v)
 		require.NoError(t, err)
@@ -178,13 +165,6 @@ func TestService_Get(t *testing.T) {
 }
 
 func TestService_List(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		clientErr := errors.New("client creation failed")
-		svc := ServiceWithClientGetter(failingClientGetter(clientErr), &config.ProviderConfiguration{})
-		_, err := svc.List(t.Context())
-		assert.ErrorIs(t, err, clientErr)
-	})
-
 	t.Run("Returns error when List call fails", func(t *testing.T) {
 		listErr := errors.New("list failed")
 		mock := &mockDirectSharesClient{
@@ -192,7 +172,7 @@ func TestService_List(t *testing.T) {
 				return nil, listErr
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		_, err := svc.List(t.Context())
 		assert.ErrorIs(t, err, listErr)
 	})
@@ -203,7 +183,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse([]byte("bad-json")), nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		_, err := svc.List(t.Context())
 		assert.Error(t, err)
 	})
@@ -216,7 +196,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse(ds1, ds2), nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		stubs, err := svc.List(t.Context())
 		require.NoError(t, err)
 		require.Len(t, stubs, 2)
@@ -232,7 +212,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse(), nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		stubs, err := svc.List(t.Context())
 		require.NoError(t, err)
 		assert.Nil(t, stubs)
@@ -240,13 +220,6 @@ func TestService_List(t *testing.T) {
 }
 
 func TestService_Create(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		clientErr := errors.New("client creation failed")
-		svc := ServiceWithClientGetter(failingClientGetter(clientErr), &config.ProviderConfiguration{})
-		_, err := svc.Create(t.Context(), &serviceSettings.DirectShare{})
-		assert.ErrorIs(t, err, clientErr)
-	})
-
 	t.Run("Returns error when Create call fails", func(t *testing.T) {
 		createErr := errors.New("create failed")
 		mock := &mockDirectSharesClient{
@@ -254,7 +227,7 @@ func TestService_Create(t *testing.T) {
 				return coreapi.Response{}, createErr
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		_, err := svc.Create(t.Context(), &serviceSettings.DirectShare{
 			DocumentId: "doc-1",
 			Access:     "read",
@@ -268,7 +241,7 @@ func TestService_Create(t *testing.T) {
 				return coreapi.Response{Data: []byte("bad-json")}, nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		_, err := svc.Create(t.Context(), &serviceSettings.DirectShare{
 			DocumentId: "doc-1",
 			Access:     "read",
@@ -286,7 +259,7 @@ func TestService_Create(t *testing.T) {
 				return coreapi.Response{Data: respJSON}, nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		stub, err := svc.Create(t.Context(), &serviceSettings.DirectShare{
 			DocumentId: "doc-1",
 			Access:     "read",
@@ -309,13 +282,6 @@ func TestService_Create(t *testing.T) {
 }
 
 func TestService_Update(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		clientErr := errors.New("client creation failed")
-		svc := ServiceWithClientGetter(failingClientGetter(clientErr), &config.ProviderConfiguration{})
-		err := svc.Update(t.Context(), "id-1", &serviceSettings.DirectShare{})
-		assert.ErrorIs(t, err, clientErr)
-	})
-
 	t.Run("Returns error when GetRecipients fails", func(t *testing.T) {
 		recipientsErr := errors.New("get recipients failed")
 		mock := &mockDirectSharesClient{
@@ -323,7 +289,7 @@ func TestService_Update(t *testing.T) {
 				return nil, recipientsErr
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		err := svc.Update(t.Context(), "id-1", &serviceSettings.DirectShare{})
 		assert.ErrorIs(t, err, recipientsErr)
 	})
@@ -345,7 +311,7 @@ func TestService_Update(t *testing.T) {
 				return json.Unmarshal(data, &removedPayload)
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		err := svc.Update(t.Context(), "id-1", &serviceSettings.DirectShare{
 			Recipients: serviceSettings.Recipients{
 				{ID: "existing-user", Type: "user"},
@@ -376,7 +342,7 @@ func TestService_Update(t *testing.T) {
 				return nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		err := svc.Update(t.Context(), "id-1", &serviceSettings.DirectShare{
 			Recipients: serviceSettings.Recipients{
 				{ID: "user-1", Type: "user"},
@@ -400,7 +366,7 @@ func TestService_Update(t *testing.T) {
 				return nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		err := svc.Update(t.Context(), "id-1", &serviceSettings.DirectShare{
 			Recipients: serviceSettings.Recipients{
 				{ID: "new-user", Type: "user"},
@@ -420,7 +386,7 @@ func TestService_Update(t *testing.T) {
 				return addErr
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		err := svc.Update(t.Context(), "id-1", &serviceSettings.DirectShare{
 			Recipients: serviceSettings.Recipients{
 				{ID: "user-1", Type: "user"},
@@ -443,20 +409,13 @@ func TestService_Update(t *testing.T) {
 				return removeErr
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		err := svc.Update(t.Context(), "id-1", &serviceSettings.DirectShare{})
 		assert.ErrorIs(t, err, removeErr)
 	})
 }
 
 func TestService_Delete(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		clientErr := errors.New("client creation failed")
-		svc := ServiceWithClientGetter(failingClientGetter(clientErr), &config.ProviderConfiguration{})
-		err := svc.Delete(t.Context(), "id-1")
-		assert.ErrorIs(t, err, clientErr)
-	})
-
 	t.Run("Returns error when Delete call fails", func(t *testing.T) {
 		deleteErr := errors.New("delete failed")
 		mock := &mockDirectSharesClient{
@@ -464,7 +423,7 @@ func TestService_Delete(t *testing.T) {
 				return deleteErr
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		err := svc.Delete(t.Context(), "id-1")
 		assert.ErrorIs(t, err, deleteErr)
 	})
@@ -477,7 +436,7 @@ func TestService_Delete(t *testing.T) {
 				return nil
 			},
 		}
-		svc := ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := ServiceWithClient(mock)
 		err := svc.Delete(t.Context(), "id-1")
 		require.NoError(t, err)
 		assert.Equal(t, "id-1", capturedID)

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -40,19 +40,16 @@ var supportedDocumentTypes = []docclient.DocumentType{
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*documents.Document], error) {
-	return &service{clientSet: clientSet}, nil
-}
-
-type service struct {
-	clientSet rest.ClientSet
-}
-
-func (me *service) client(ctx context.Context) (*docclient.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, me.clientSet.Credentials().Platform.EnvironmentURL, me.clientSet.Credentials())
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return docclient.NewClient(platformClient), nil
+
+	return &service{client: docclient.NewClient(platformClient)}, nil
+}
+
+type service struct {
+	client *docclient.Client
 }
 
 func (me *service) Get(ctx context.Context, id string, v *documents.Document) (err error) {
@@ -76,11 +73,7 @@ func (me *service) Get(ctx context.Context, id string, v *documents.Document) (e
 }
 
 func (me *service) get(ctx context.Context, id string, v *documents.Document) (err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	result, err := client.Get(ctx, id)
+	result, err := me.client.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -101,18 +94,7 @@ func (me *service) SchemaID() string {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	if me == nil {
-		return api.Stubs{}, nil
-	}
-	cl, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if cl == nil {
-		return api.Stubs{}, nil
-	}
-	listResponse, err := cl.List(ctx, getSupportedDocumentsFilter())
+	listResponse, err := me.client.List(ctx, getSupportedDocumentsFilter())
 	if err != nil {
 		return nil, err
 	}
@@ -163,11 +145,7 @@ func (me *service) Create(ctx context.Context, v *documents.Document) (*api.Stub
 }
 
 func (me *service) createPrivate(ctx context.Context, v *documents.Document) (stub *api.Stub, err error) {
-	c, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
-	response, err := c.Create(ctx, v.Name, v.IsPrivate, v.ID, []byte(v.Content), docclient.DocumentType(v.Type))
+	response, err := me.client.Create(ctx, v.Name, v.IsPrivate, v.ID, []byte(v.Content), docclient.DocumentType(v.Type))
 	if err != nil {
 		return nil, err
 	}
@@ -184,11 +162,7 @@ func (me *service) Update(ctx context.Context, id string, v *documents.Document)
 }
 
 func (me *service) update(ctx context.Context, id string, v *documents.Document) (err error) {
-	c, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	_, err = c.Update(ctx, id, v.Name, v.IsPrivate, []byte(v.Content), docclient.DocumentType(v.Type))
+	_, err = me.client.Update(ctx, id, v.Name, v.IsPrivate, []byte(v.Content), docclient.DocumentType(v.Type))
 	if err != nil {
 		return err
 	}
@@ -197,11 +171,7 @@ func (me *service) update(ctx context.Context, id string, v *documents.Document)
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	_, err = client.Delete(ctx, id)
+	_, err := me.client.Delete(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/dynatrace/api/extensions/monitoringconfigurations/service.go
+++ b/dynatrace/api/extensions/monitoringconfigurations/service.go
@@ -57,24 +57,20 @@ type ExtensionClient interface {
 }
 
 type service struct {
-	clientGetter func(ctx context.Context, clientSet rest.ClientSet) (ExtensionClient, error)
-	clientSet    rest.ClientSet
+	client ExtensionClient
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*serviceSettings.Settings], error) {
-	return &service{clientGetter: createCoreClient, clientSet: clientSet}, nil
-}
-
-func ServiceWithClientGetter(clientGetter func(ctx context.Context, clientSet rest.ClientSet) (ExtensionClient, error), clientSet rest.ClientSet) settings.CRUDService[*serviceSettings.Settings] {
-	return &service{clientGetter: clientGetter, clientSet: clientSet}
-}
-
-func createCoreClient(ctx context.Context, clientSet rest.ClientSet) (ExtensionClient, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, clientSet.Credentials().Platform.EnvironmentURL, clientSet.Credentials())
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return coreextensions.NewClient(platformClient), nil
+
+	return &service{client: coreextensions.NewClient(platformClient)}, nil
+}
+
+func ServiceWithClient(client ExtensionClient) settings.CRUDService[*serviceSettings.Settings] {
+	return &service{client: client}
 }
 
 func (s *service) SchemaID() string {
@@ -82,16 +78,12 @@ func (s *service) SchemaID() string {
 }
 
 func (s *service) Get(ctx context.Context, id string, v *serviceSettings.Settings) error {
-	client, err := s.clientGetter(ctx, s.clientSet)
-	if err != nil {
-		return err
-	}
-
 	extensionName, configID, err := splitID(id)
 	if err != nil {
 		return err
 	}
-	response, err := client.GetMonitoringConfiguration(ctx, extensionName, configID)
+
+	response, err := s.client.GetMonitoringConfiguration(ctx, extensionName, configID)
 	if err != nil {
 		return err
 	}
@@ -110,12 +102,7 @@ func (s *service) Get(ctx context.Context, id string, v *serviceSettings.Setting
 }
 
 func (s *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := s.clientGetter(ctx, s.clientSet)
-	if err != nil {
-		return nil, err
-	}
-
-	extensionsResponse, err := client.ListExtensions(ctx)
+	extensionsResponse, err := s.client.ListExtensions(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +117,7 @@ func (s *service) List(ctx context.Context) (api.Stubs, error) {
 			return nil, err
 		}
 
-		configurationsResponse, err := client.ListMonitoringConfigurations(ctx, extension.ExtensionName)
+		configurationsResponse, err := s.client.ListMonitoringConfigurations(ctx, extension.ExtensionName)
 		if err != nil {
 			return nil, err
 		}
@@ -155,10 +142,6 @@ func (s *service) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (s *service) Create(ctx context.Context, v *serviceSettings.Settings) (stub *api.Stub, err error) {
-	client, err := s.clientGetter(ctx, s.clientSet)
-	if err != nil {
-		return nil, err
-	}
 	body, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
@@ -167,7 +150,7 @@ func (s *service) Create(ctx context.Context, v *serviceSettings.Settings) (stub
 		ID string `json:"objectId"`
 	}
 
-	response, err := client.CreateMonitoringConfiguration(ctx, v.Name, body)
+	response, err := s.client.CreateMonitoringConfiguration(ctx, v.Name, body)
 	if err != nil {
 		return nil, err
 	}
@@ -179,10 +162,6 @@ func (s *service) Create(ctx context.Context, v *serviceSettings.Settings) (stub
 }
 
 func (s *service) Update(ctx context.Context, id string, v *serviceSettings.Settings) error {
-	client, err := s.clientGetter(ctx, s.clientSet)
-	if err != nil {
-		return err
-	}
 	body, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -191,20 +170,18 @@ func (s *service) Update(ctx context.Context, id string, v *serviceSettings.Sett
 	if err != nil {
 		return err
 	}
-	_, err = client.UpdateMonitoringConfiguration(ctx, extensionName, configID, body)
+
+	_, err = s.client.UpdateMonitoringConfiguration(ctx, extensionName, configID, body)
 	return err
 }
 
 func (s *service) Delete(ctx context.Context, id string) error {
-	client, err := s.clientGetter(ctx, s.clientSet)
-	if err != nil {
-		return err
-	}
 	extensionName, configID, err := splitID(id)
 	if err != nil {
 		return err
 	}
-	return client.DeleteMonitoringConfiguration(ctx, extensionName, configID)
+
+	return s.client.DeleteMonitoringConfiguration(ctx, extensionName, configID)
 }
 
 func joinID(extensionName string, configurationID string) string {

--- a/dynatrace/api/extensions/monitoringconfigurations/service_unit_test.go
+++ b/dynatrace/api/extensions/monitoringconfigurations/service_unit_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/extensions/monitoringconfigurations"
 	serviceSettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/extensions/monitoringconfigurations/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -80,20 +80,21 @@ func pagedResponse(objects ...[]byte) coreapi.PagedListResponse {
 	}
 }
 
-func TestService_Get(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := monitoringconfigurations.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		err := svc.Get(t.Context(), "com.example.ext#-#cfg-1", &serviceSettings.Settings{})
-		assert.ErrorIs(t, err, assert.AnError)
-	})
+// TestServiceCreationFailsIfMissingClient tests that the service creation fails if the platform client is missing.
+func TestServiceCreationFailsIfMissingClient(t *testing.T) {
+	service, err := monitoringconfigurations.Service(&testing2.MockClientSet{PlatformClientErr: assert.AnError})
+	require.Nil(t, service)
+	require.ErrorIs(t, err, assert.AnError)
+}
 
+func TestService_Get(t *testing.T) {
 	t.Run("Returns error when GetMonitoringConfiguration fails", func(t *testing.T) {
 		mock := &mockExtensionClient{
 			getMonitoringConfigurationFn: func(ctx context.Context, extensionName string, configurationID string) (coreapi.Response, error) {
 				return coreapi.Response{}, assert.AnError
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		err := svc.Get(t.Context(), "com.example.ext#-#cfg-1", &serviceSettings.Settings{})
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -104,7 +105,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: []byte("not-json")}, nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		err := svc.Get(t.Context(), "com.example.ext#-#cfg-1", &serviceSettings.Settings{})
 		assert.Error(t, err)
 	})
@@ -122,7 +123,7 @@ func TestService_Get(t *testing.T) {
 				return coreapi.Response{Data: responseData}, nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		v := &serviceSettings.Settings{}
 		err := svc.Get(t.Context(), "com.example.ext#-#cfg-1", v)
 		require.NoError(t, err)
@@ -134,19 +135,13 @@ func TestService_Get(t *testing.T) {
 }
 
 func TestService_List(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := monitoringconfigurations.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		_, err := svc.List(t.Context())
-		assert.ErrorIs(t, err, assert.AnError)
-	})
-
 	t.Run("Returns error when ListExtensions fails", func(t *testing.T) {
 		mock := &mockExtensionClient{
 			listExtensionsFn: func(ctx context.Context) (coreapi.PagedListResponse, error) {
 				return nil, assert.AnError
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		_, err := svc.List(t.Context())
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -157,7 +152,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse([]byte("bad-json")), nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		_, err := svc.List(t.Context())
 		assert.Error(t, err)
 	})
@@ -172,7 +167,7 @@ func TestService_List(t *testing.T) {
 				return nil, assert.AnError
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		_, err := svc.List(t.Context())
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -187,7 +182,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse([]byte("bad-json")), nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		_, err := svc.List(t.Context())
 		assert.Error(t, err)
 	})
@@ -211,7 +206,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse(), nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		stubs, err := svc.List(t.Context())
 		require.NoError(t, err)
 		require.Len(t, stubs, 2)
@@ -227,7 +222,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse(), nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		stubs, err := svc.List(t.Context())
 		require.NoError(t, err)
 		assert.Empty(t, stubs)
@@ -243,7 +238,7 @@ func TestService_List(t *testing.T) {
 				return pagedResponse(), nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		stubs, err := svc.List(t.Context())
 		require.NoError(t, err)
 		assert.Empty(t, stubs)
@@ -251,19 +246,13 @@ func TestService_List(t *testing.T) {
 }
 
 func TestService_Create(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := monitoringconfigurations.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		_, err := svc.Create(t.Context(), &serviceSettings.Settings{Name: "com.example.ext"})
-		assert.ErrorIs(t, err, assert.AnError)
-	})
-
 	t.Run("Returns error when CreateMonitoringConfiguration fails", func(t *testing.T) {
 		mock := &mockExtensionClient{
 			createMonitoringConfigurationFn: func(ctx context.Context, extensionName string, data []byte) (coreapi.Response, error) {
 				return coreapi.Response{}, assert.AnError
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		_, err := svc.Create(t.Context(), &serviceSettings.Settings{
 			Name:  "com.example.ext",
 			Scope: "HOST-ABC123",
@@ -277,7 +266,7 @@ func TestService_Create(t *testing.T) {
 				return coreapi.Response{Data: []byte("bad-json")}, nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		_, err := svc.Create(t.Context(), &serviceSettings.Settings{
 			Name:  "com.example.ext",
 			Scope: "HOST-ABC123",
@@ -297,7 +286,7 @@ func TestService_Create(t *testing.T) {
 				return coreapi.Response{Data: respJSON}, nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		stub, err := svc.Create(t.Context(), &serviceSettings.Settings{
 			Name:  "com.example.ext",
 			Scope: "HOST-ABC123",
@@ -311,19 +300,13 @@ func TestService_Create(t *testing.T) {
 }
 
 func TestService_Update(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := monitoringconfigurations.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		err := svc.Update(t.Context(), "com.example.ext#-#cfg-1", &serviceSettings.Settings{})
-		assert.ErrorIs(t, err, assert.AnError)
-	})
-
 	t.Run("Returns error when UpdateMonitoringConfiguration fails", func(t *testing.T) {
 		mock := &mockExtensionClient{
 			updateMonitoringConfigurationFn: func(ctx context.Context, extensionName string, configurationID string, data []byte) (coreapi.Response, error) {
 				return coreapi.Response{}, assert.AnError
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		err := svc.Update(t.Context(), "com.example.ext#-#cfg-1", &serviceSettings.Settings{})
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -340,7 +323,7 @@ func TestService_Update(t *testing.T) {
 				return coreapi.Response{}, nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		err := svc.Update(t.Context(), "com.example.ext#-#cfg-1", &serviceSettings.Settings{
 			Scope: "HOST-ABC123",
 			Value: map[string]any{"key": "val"},
@@ -353,19 +336,13 @@ func TestService_Update(t *testing.T) {
 }
 
 func TestService_Delete(t *testing.T) {
-	t.Run("Returns error when client creation fails", func(t *testing.T) {
-		svc := monitoringconfigurations.ServiceWithClientGetter(failingClientGetter(assert.AnError), &config.ProviderConfiguration{})
-		err := svc.Delete(t.Context(), "com.example.ext#-#cfg-1")
-		assert.ErrorIs(t, err, assert.AnError)
-	})
-
 	t.Run("Returns error when DeleteMonitoringConfiguration fails", func(t *testing.T) {
 		mock := &mockExtensionClient{
 			deleteMonitoringConfigurationFn: func(ctx context.Context, extensionName string, configurationID string) error {
 				return assert.AnError
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		err := svc.Delete(t.Context(), "com.example.ext#-#cfg-1")
 		assert.ErrorIs(t, err, assert.AnError)
 	})
@@ -379,7 +356,7 @@ func TestService_Delete(t *testing.T) {
 				return nil
 			},
 		}
-		svc := monitoringconfigurations.ServiceWithClientGetter(mockClientGetter(mock), &config.ProviderConfiguration{})
+		svc := monitoringconfigurations.ServiceWithClient(mock)
 		err := svc.Delete(t.Context(), "com.example.ext#-#cfg-1")
 		require.NoError(t, err)
 		assert.Equal(t, "com.example.ext", capturedExtName)

--- a/dynatrace/api/grail/segments/service.go
+++ b/dynatrace/api/grail/segments/service.go
@@ -31,27 +31,20 @@ import (
 )
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*segments.Segment], error) {
-	return &service{clientSet}, nil
-}
-
-type service struct {
-	clientSet rest.ClientSet
-}
-
-func (me *service) client(ctx context.Context) (*segmentsclient.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, me.clientSet.Credentials().Platform.EnvironmentURL, me.clientSet.Credentials())
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return segmentsclient.NewClient(platformClient), nil
+
+	return &service{client: segmentsclient.NewClient(platformClient)}, nil
+}
+
+type service struct {
+	client *segmentsclient.Client
 }
 
 func (me *service) Get(ctx context.Context, id string, v *segments.Segment) (err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	response, err := client.Get(ctx, id)
+	response, err := me.client.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -70,11 +63,7 @@ type SegmentStub struct {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
-	listResponse, err := client.List(ctx)
+	listResponse, err := me.client.List(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -99,15 +88,11 @@ func (me *service) Validate(_ *segments.Segment) error {
 }
 
 func (me *service) Create(ctx context.Context, v *segments.Segment) (stub *api.Stub, err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return nil, err
 	}
-	response, err := client.Create(ctx, data)
+	response, err := me.client.Create(ctx, data)
 	if err != nil {
 		return nil, err
 	}
@@ -121,16 +106,12 @@ func (me *service) Create(ctx context.Context, v *segments.Segment) (stub *api.S
 }
 
 func (me *service) Update(ctx context.Context, id string, v *segments.Segment) (err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return err
 	}
 
-	_, err = client.Update(ctx, id, data)
+	_, err = me.client.Update(ctx, id, data)
 	if err != nil {
 		return err
 	}
@@ -139,11 +120,7 @@ func (me *service) Update(ctx context.Context, id string, v *segments.Segment) (
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	_, err = client.Delete(ctx, id)
+	_, err := me.client.Delete(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/dynatrace/api/grail/segments/service_unit_test.go
+++ b/dynatrace/api/grail/segments/service_unit_test.go
@@ -26,19 +26,28 @@ import (
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/grail/segments"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestList(t *testing.T) {
-	t.Run("Returns an error if the client creation fails", func(t *testing.T) {
-		service, err := segments.Service(&config.ProviderConfiguration{})
-		require.NoError(t, err)
-		_, err = service.List(t.Context())
-		assert.ErrorIs(t, err, rest.NoPlatformCredentialsErr)
+// platformClientSet returns a ClientSet with a real platform client pointed at the test server.
+func platformClientSet(t *testing.T, serverURL string) *testing2.MockClientSet {
+	platformClient, err := rest.CreatePlatformClient(t.Context(), serverURL, &rest.Credentials{
+		Platform: rest.PlatformCredentials{EnvironmentURL: serverURL, PlatformToken: "token"},
 	})
+	require.NoError(t, err)
+	return &testing2.MockClientSet{PlatformClientValue: platformClient}
+}
 
+// TestServiceCreationFailsIfMissingClient tests that the service creation fails if the platform client is missing.
+func TestServiceCreationFailsIfClientUnavailable(t *testing.T) {
+	service, err := segments.Service(&testing2.MockClientSet{PlatformClientErr: assert.AnError})
+	require.Nil(t, service)
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestList(t *testing.T) {
 	t.Run("Returns the list of segments ignoring ready-made ones", func(t *testing.T) {
 		apiResponse := `{"filterSegments": [
 			{"uid": "1", "name": "ready-made-false", "isPublic": false, "isReadyMade": false},
@@ -54,12 +63,7 @@ func TestList(t *testing.T) {
 		}))
 		defer server.Close()
 
-		service, err := segments.Service(&config.ProviderConfiguration{
-			Platform: rest.PlatformCredentials{
-				EnvironmentURL: server.URL,
-				PlatformToken:  "token",
-			},
-		})
+		service, err := segments.Service(platformClientSet(t, server.URL))
 		require.NoError(t, err)
 		result, err := service.List(t.Context())
 

--- a/dynatrace/api/openpipeline/service.go
+++ b/dynatrace/api/openpipeline/service.go
@@ -32,74 +32,72 @@ import (
 )
 
 func EventsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "events", schemaSuffix: "events"}, nil
+	return createService(clientSet, "events", "events")
 }
 
 func LogsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "logs", schemaSuffix: "logs"}, nil
+	return createService(clientSet, "logs", "logs")
 }
 
 func BusinessEventsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "bizevents", schemaSuffix: "events.business"}, nil
+	return createService(clientSet, "bizevents", "events.business")
 }
 
 func SecurityEventsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "events.security", schemaSuffix: "events.security"}, nil
+	return createService(clientSet, "events.security", "events.security")
 }
 
 func SDLCEventsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "events.sdlc", schemaSuffix: "events.sdlc"}, nil
+	return createService(clientSet, "events.sdlc", "events.sdlc")
 }
 
 func MetricsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "metrics", schemaSuffix: "metrics"}, nil
+	return createService(clientSet, "metrics", "metrics")
 }
 
 func UserSessionsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "usersessions", schemaSuffix: "user.sessions"}, nil
+	return createService(clientSet, "usersessions", "user.sessions")
 }
 
 func DavisProblemsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "davis.problems", schemaSuffix: "davis.problems"}, nil
+	return createService(clientSet, "davis.problems", "davis.problems")
 }
 
 func DavisEventsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "davis.events", schemaSuffix: "davis.events"}, nil
+	return createService(clientSet, "davis.events", "davis.events")
 }
 
 func SystemEventsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "system.events", schemaSuffix: "system.events"}, nil
+	return createService(clientSet, "system.events", "system.events")
 }
 
 func UserEventsService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "user.events", schemaSuffix: "user.events"}, nil
+	return createService(clientSet, "user.events", "user.events")
 }
 
 func SpansService(clientSet rest.ClientSet) (settings.CRUDService[*openpipeline.Configuration], error) {
-	return &service{clientSet: clientSet, kind: "spans", schemaSuffix: "spans"}, nil
+	return createService(clientSet, "spans", "spans")
 }
 
 type service struct {
 	kind         string
 	schemaSuffix string
-	clientSet    rest.ClientSet
+	client       *caclib.Client
+	envURL       string
 }
 
-func (s *service) createClient(ctx context.Context) (*caclib.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, s.clientSet.Credentials().Platform.EnvironmentURL, s.clientSet.Credentials())
+func createService(clientSet rest.ClientSet, kind string, schemaSuffix string) (settings.CRUDService[*openpipeline.Configuration], error) {
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return caclib.NewClient(platformClient), nil
+
+	return &service{client: caclib.NewClient(platformClient), kind: kind, schemaSuffix: schemaSuffix, envURL: clientSet.Credentials().Platform.EnvironmentURL}, nil
 }
 
 func (s *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := s.createClient(ctx)
-	if err != nil {
-		return nil, err
-	}
 	// after migration the resource isn't available anymore (404)
-	if _, err = client.Get(ctx, s.kind); err != nil {
+	if _, err := s.client.Get(ctx, s.kind); err != nil {
 		return nil, err
 	}
 
@@ -108,16 +106,11 @@ func (s *service) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (s *service) Get(ctx context.Context, id string, v *openpipeline.Configuration) error {
-	client, err := s.createClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	response, err := client.Get(ctx, s.kind)
+	response, err := s.client.Get(ctx, s.kind)
 	if err != nil {
 		apiErr := cacapi.APIError{}
 		if errors.As(err, &apiErr) {
-			return rest.Envelope(apiErr.Body, s.clientSet.Credentials().Platform.EnvironmentURL, "GET")
+			return rest.Envelope(apiErr.Body, s.envURL, "GET")
 		}
 		return err
 	}
@@ -144,10 +137,6 @@ func (s *service) Create(ctx context.Context, v *openpipeline.Configuration) (*a
 }
 
 func (s *service) Update(ctx context.Context, id string, v *openpipeline.Configuration) error {
-	client, err := s.createClient(ctx)
-	if err != nil {
-		return err
-	}
 
 	v.Kind = id
 
@@ -155,7 +144,7 @@ func (s *service) Update(ctx context.Context, id string, v *openpipeline.Configu
 	if err != nil {
 		return err
 	}
-	_, err = client.Update(ctx, s.kind, b)
+	_, err = s.client.Update(ctx, s.kind, b)
 	return err
 }
 

--- a/dynatrace/api/openpipeline/service_unit_test.go
+++ b/dynatrace/api/openpipeline/service_unit_test.go
@@ -27,19 +27,29 @@ import (
 	api2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/openpipeline"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestList(t *testing.T) {
-	t.Run("Returns an error if the client creation fails", func(t *testing.T) {
-		service, err := openpipeline.EventsService(&config.ProviderConfiguration{})
-		require.NoError(t, err)
-		_, err = service.List(t.Context())
-		assert.ErrorIs(t, err, rest.NoPlatformCredentialsErr)
-	})
+// platformClientSet returns a ClientSet with a real platform client pointed at the test server.
+func platformClientSet(t *testing.T, serverURL string) *testing2.MockClientSet {
+	credentials := &rest.Credentials{
+		Platform: rest.PlatformCredentials{EnvironmentURL: serverURL, PlatformToken: "token"},
+	}
+	platformClient, err := rest.CreatePlatformClient(t.Context(), serverURL, credentials)
+	require.NoError(t, err)
+	return &testing2.MockClientSet{PlatformClientValue: platformClient, CredentialsValue: credentials}
+}
 
+// TestServiceCreationFailsIfMissingClient tests that the service creation fails if the platform client is missing.
+func TestServiceCreationFailsIfMissingClient(t *testing.T) {
+	service, err := openpipeline.EventsService(&testing2.MockClientSet{PlatformClientErr: assert.AnError})
+	require.Nil(t, service)
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestList(t *testing.T) {
 	t.Run("Returns an error if the config doesn't exist anymore", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(404)
@@ -47,12 +57,7 @@ func TestList(t *testing.T) {
 			require.NoError(t, err)
 		}))
 		defer server.Close()
-		service, err := openpipeline.EventsService(&config.ProviderConfiguration{
-			Platform: rest.PlatformCredentials{
-				EnvironmentURL: server.URL,
-				PlatformToken:  "token",
-			},
-		})
+		service, err := openpipeline.EventsService(platformClientSet(t, server.URL))
 		require.NoError(t, err)
 		_, err = service.List(t.Context())
 		assert.ErrorContains(t, err, "Not Found")
@@ -64,12 +69,7 @@ func TestList(t *testing.T) {
 		}))
 		defer server.Close()
 
-		service, err := openpipeline.EventsService(&config.ProviderConfiguration{
-			Platform: rest.PlatformCredentials{
-				EnvironmentURL: server.URL,
-				PlatformToken:  "token",
-			},
-		})
+		service, err := openpipeline.EventsService(platformClientSet(t, server.URL))
 		require.NoError(t, err)
 		configs, err := service.List(t.Context())
 		require.NoError(t, err)

--- a/dynatrace/api/platform/buckets/service.go
+++ b/dynatrace/api/platform/buckets/service.go
@@ -36,19 +36,17 @@ import (
 )
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*buckets.Bucket], error) {
-	return &service{clientSet}, nil
-}
-
-type service struct {
-	clientSet rest.ClientSet
-}
-
-func (me *service) client(ctx context.Context) (*bucket.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, me.clientSet.Credentials().Platform.EnvironmentURL, me.clientSet.Credentials())
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return bucket.NewClient(platformClient), nil
+
+	return &service{client: bucket.NewClient(platformClient), envURL: clientSet.Credentials().Platform.EnvironmentURL}, nil
+}
+
+type service struct {
+	client *bucket.Client
+	envURL string
 }
 
 func (me *service) Get(ctx context.Context, id string, v *buckets.Bucket) (err error) {
@@ -71,15 +69,11 @@ func (me *service) Get(ctx context.Context, id string, v *buckets.Bucket) (err e
 }
 
 func (me *service) get(ctx context.Context, id string, v *buckets.Bucket) (err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
 	var result coreapi.Response
-	if result, err = client.Get(ctx, id); err != nil {
+	if result, err = me.client.Get(ctx, id); err != nil {
 		apiErr := coreapi.APIError{}
 		if errors.As(err, &apiErr) {
-			return rest.Envelope(apiErr.Body, me.clientSet.Credentials().Platform.EnvironmentURL, "GET")
+			return rest.Envelope(apiErr.Body, me.envURL, "GET")
 		}
 		return err
 	}
@@ -92,11 +86,7 @@ func (me *service) SchemaID() string {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result, err := client.List(ctx)
+	result, err := me.client.List(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -116,19 +106,15 @@ func (me *service) Validate(v *buckets.Bucket) error {
 }
 
 func (me *service) Create(ctx context.Context, v *buckets.Bucket) (stub *api.Stub, err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return nil, err
-	}
 	var data []byte
 	if data, err = json.Marshal(v); err != nil {
 		return nil, err
 	}
 
-	if _, err = client.Create(ctx, v.Name, data); err != nil {
+	if _, err = me.client.Create(ctx, v.Name, data); err != nil {
 		apiErr := coreapi.APIError{}
 		if errors.As(err, &apiErr) {
-			return nil, rest.Envelope(apiErr.Body, me.clientSet.Credentials().Platform.EnvironmentURL, "POST")
+			return nil, rest.Envelope(apiErr.Body, me.envURL, "POST")
 		}
 		return nil, err
 	}
@@ -140,7 +126,7 @@ func (me *service) Create(ctx context.Context, v *buckets.Bucket) (stub *api.Stu
 	var responseBucket buckets.Bucket
 	for requiredSuccessesLeft > 0 || len(responseBucket.Status) == 0 || responseBucket.Status == buckets.Statuses.Creating {
 		responseBucket = buckets.Bucket{}
-		response, err := client.Get(ctx, v.Name)
+		response, err := me.client.Get(ctx, v.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -164,10 +150,6 @@ func (me *service) Create(ctx context.Context, v *buckets.Bucket) (stub *api.Stu
 }
 
 func (me *service) Update(ctx context.Context, id string, v *buckets.Bucket) (err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
 	var oldBucket buckets.Bucket
 	me.Get(ctx, id, &oldBucket)
 	oldVersion := oldBucket.Version
@@ -176,11 +158,11 @@ func (me *service) Update(ctx context.Context, id string, v *buckets.Bucket) (er
 		return err
 	}
 
-	_, err = client.Update(ctx, id, data)
+	_, err = me.client.Update(ctx, id, data)
 	if err != nil {
 		apiErr := coreapi.APIError{}
 		if errors.As(err, &apiErr) {
-			return rest.Envelope(apiErr.Body, me.clientSet.Credentials().Platform.EnvironmentURL, "PUT")
+			return rest.Envelope(apiErr.Body, me.envURL, "PUT")
 		}
 		return err
 	}
@@ -208,17 +190,12 @@ func (me *service) Update(ctx context.Context, id string, v *buckets.Bucket) (er
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	_, err = client.Delete(ctx, id)
-	if err != nil {
+	if _, err := me.client.Delete(ctx, id); err != nil {
 		return err
 	}
 	maxConfirmationRetries := envutils.DTBucketsRetries.Get()
 	retries := 0
-	response, err := client.Get(ctx, id)
+	response, err := me.client.Get(ctx, id)
 	for response.StatusCode != 404 {
 		if err != nil {
 			if apiErr, ok := err.(coreapi.APIError); ok {
@@ -227,7 +204,7 @@ func (me *service) Delete(ctx context.Context, id string) error {
 				}
 			}
 		}
-		response, err = client.Get(ctx, id)
+		response, err = me.client.Get(ctx, id)
 		retries++
 		if retries > maxConfirmationRetries {
 			break

--- a/dynatrace/api/slo/service.go
+++ b/dynatrace/api/slo/service.go
@@ -30,27 +30,20 @@ import (
 )
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*slo.SLO], error) {
-	return &service{clientSet}, nil
-}
-
-type service struct {
-	clientSet rest.ClientSet
-}
-
-func (me *service) client(ctx context.Context) (*sloclient.Client, error) {
-	platformClient, err := rest.CreatePlatformClient(ctx, me.clientSet.Credentials().Platform.EnvironmentURL, me.clientSet.Credentials())
+	platformClient, err := clientSet.PlatformClient()
 	if err != nil {
 		return nil, err
 	}
-	return sloclient.NewClient(platformClient), nil
+
+	return &service{client: sloclient.NewClient(platformClient)}, nil
 }
 
-func (me *service) Get(ctx context.Context, id string, v *slo.SLO) (err error) {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	response, err := client.Get(ctx, id)
+type service struct {
+	client *sloclient.Client
+}
+
+func (me *service) Get(ctx context.Context, id string, v *slo.SLO) error {
+	response, err := me.client.Get(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -63,14 +56,11 @@ func (me *service) SchemaID() string {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	client, err := me.client(ctx)
+	listResponse, err := me.client.List(ctx)
 	if err != nil {
 		return nil, err
 	}
-	listResponse, err := client.List(ctx)
-	if err != nil {
-		return nil, err
-	}
+
 	var stubs api.Stubs
 	for _, r := range listResponse.All() {
 		var stub api.Stub
@@ -88,15 +78,12 @@ func (me *service) Validate(_ *slo.SLO) error {
 }
 
 func (me *service) Create(ctx context.Context, v *slo.SLO) (*api.Stub, error) {
-	client, err := me.client(ctx)
+	data, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
-	var data []byte
-	if data, err = json.Marshal(v); err != nil {
-		return nil, err
-	}
-	response, err := client.Create(ctx, data)
+
+	response, err := me.client.Create(ctx, data)
 	if err != nil {
 		return nil, err
 	}
@@ -109,17 +96,13 @@ func (me *service) Create(ctx context.Context, v *slo.SLO) (*api.Stub, error) {
 	return &stub, nil
 }
 
-func (me *service) Update(ctx context.Context, id string, v *slo.SLO) (err error) {
-	client, err := me.client(ctx)
+func (me *service) Update(ctx context.Context, id string, v *slo.SLO) error {
+	data, err := json.Marshal(v)
 	if err != nil {
 		return err
 	}
-	var data []byte
-	if data, err = json.Marshal(v); err != nil {
-		return err
-	}
 
-	_, err = client.Update(ctx, id, data)
+	_, err = me.client.Update(ctx, id, data)
 	if err != nil {
 		return err
 	}
@@ -128,11 +111,7 @@ func (me *service) Update(ctx context.Context, id string, v *slo.SLO) (err error
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	client, err := me.client(ctx)
-	if err != nil {
-		return err
-	}
-	_, err = client.Delete(ctx, id)
+	_, err := me.client.Delete(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/dynatrace/api/v2/settings/objects/permissions/service.go
+++ b/dynatrace/api/v2/settings/objects/permissions/service.go
@@ -33,39 +33,20 @@ import (
 )
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*permissions.SettingPermissions], error) {
-	return &ServiceImpl{ClientSet: clientSet}, nil
+	restClient, err := clientSet.PlatformClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceImpl{
+		Client:         permissions2.NewClient(restClient),
+		SettingsClient: NewPlatformSettingsClient(restClient),
+	}, nil
 }
 
 type ServiceImpl struct {
-	ClientSet      rest.ClientSet
 	Client         permissions.PermissionClient
 	SettingsClient PlatformSettingsClient
-}
-
-func (me *ServiceImpl) getClient(ctx context.Context) (permissions.PermissionClient, error) {
-	if me.Client != nil {
-		return me.Client, nil
-	}
-	restClient, err := rest.CreatePlatformClient(ctx, me.ClientSet.Credentials().Platform.EnvironmentURL, me.ClientSet.Credentials())
-	if err != nil {
-		return nil, err
-	}
-
-	me.Client = permissions2.NewClient(restClient)
-	return me.Client, nil
-}
-
-func (me *ServiceImpl) getSettingsClient(ctx context.Context) (PlatformSettingsClient, error) {
-	if me.SettingsClient != nil {
-		return me.SettingsClient, nil
-	}
-	restClient, err := rest.CreatePlatformClient(ctx, me.ClientSet.Credentials().Platform.EnvironmentURL, me.ClientSet.Credentials())
-	if err != nil {
-		return nil, err
-	}
-
-	me.SettingsClient = NewPlatformSettingsClient(restClient)
-	return me.SettingsClient, nil
 }
 
 func (me *ServiceImpl) Get(ctx context.Context, objectID string, v *permissions.SettingPermissions) error {
@@ -82,16 +63,13 @@ func (me *ServiceImpl) Get(ctx context.Context, objectID string, v *permissions.
 }
 
 func (me *ServiceImpl) get(ctx context.Context, objectID string) (data *permissions.SettingPermissions, adminAccess bool, err error) {
-	client, err := me.getClient(ctx)
-	if err != nil {
-		return nil, false, err
-	}
 	req, err, adminAccess := rest.DoWithAdminAccessRetry(func(adminAccess bool) (cacapi.Response, error) {
-		return client.GetAllAccessors(ctx, objectID, adminAccess)
+		return me.Client.GetAllAccessors(ctx, objectID, adminAccess)
 	})
 	if err != nil {
 		return nil, false, err
 	}
+
 	var permissionObjects permissions.PermissionObjects
 	err = json.Unmarshal(req.Data, &permissionObjects)
 	if err != nil {
@@ -105,18 +83,14 @@ func (me *ServiceImpl) SchemaID() string {
 }
 
 func (me *ServiceImpl) List(ctx context.Context) (api.Stubs, error) {
-	client, err := me.getSettingsClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	schemaIds, err := client.GetSchemaIDsWithOwnerBasedAccessControl(ctx)
+	schemaIds, err := me.SettingsClient.GetSchemaIDsWithOwnerBasedAccessControl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	stubs := api.Stubs{}
 	for _, schemaID := range schemaIds {
-		objectIDs, err := client.ListObjectsIDsOfSchema(ctx, schemaID)
+		objectIDs, err := me.SettingsClient.ListObjectsIDsOfSchema(ctx, schemaID)
 		if err != nil {
 			return nil, err
 		}
@@ -132,16 +106,12 @@ func (me *ServiceImpl) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func (me *ServiceImpl) Upsert(ctx context.Context, v *permissions.SettingPermissions) (*api.Stub, error) {
-	client, err := me.getClient(ctx)
-	if err != nil {
-		return nil, err
-	}
 	data, adminAccess, err := me.get(ctx, v.SettingsObjectID)
 	if err != nil {
 		return nil, err
 	}
 
-	err = reconcile.CompareAndUpdate(ctx, client, data, v, adminAccess)
+	err = reconcile.CompareAndUpdate(ctx, me.Client, data, v, adminAccess)
 	if err != nil {
 		return nil, err
 	}

--- a/dynatrace/api/v2/settings/objects/permissions/service_unit_test.go
+++ b/dynatrace/api/v2/settings/objects/permissions/service_unit_test.go
@@ -27,8 +27,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	permissionService "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions"
 	permissions "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v2/settings/objects/permissions/settings"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -83,6 +82,12 @@ func (c *settingsClientStub) ListObjectsIDsOfSchema(ctx context.Context, schemaI
 }
 
 func TestService(t *testing.T) {
+	t.Run("Service creation fails if the platform client is missing", func(t *testing.T) {
+		service, err := permissionService.Service(&testing2.MockClientSet{PlatformClientErr: assert.AnError})
+		require.Nil(t, service)
+		require.ErrorIs(t, err, assert.AnError)
+	})
+
 	t.Run("Get", func(t *testing.T) {
 		t.Run("It gets permissions", func(t *testing.T) {
 			client := &clientStub{
@@ -154,16 +159,7 @@ func TestService(t *testing.T) {
 				SettingsObjectID: "objectID",
 			}
 			err := service.Get(t.Context(), "objectID", &value)
-			assert.Error(t, err)
-			assert.ErrorIs(t, assert.AnError, err)
-		})
-
-		t.Run("It errors during client creation", func(t *testing.T) {
-			service := permissionService.ServiceImpl{
-				ClientSet: &config.ProviderConfiguration{},
-			}
-			err := service.Get(t.Context(), "objectID", &permissions.SettingPermissions{})
-			assert.ErrorIs(t, rest.NoPlatformCredentialsErr, err)
+			assert.ErrorIs(t, err, assert.AnError)
 		})
 	})
 
@@ -216,15 +212,6 @@ func TestService(t *testing.T) {
 			service := permissionService.ServiceImpl{SettingsClient: settingsClient}
 			stubs, err := service.List(t.Context())
 			assert.ErrorIs(t, err, assert.AnError)
-			assert.Nil(t, stubs)
-		})
-
-		t.Run("Returns error if getSettingsClient fails", func(t *testing.T) {
-			service := permissionService.ServiceImpl{
-				ClientSet: &config.ProviderConfiguration{},
-			}
-			stubs, err := service.List(t.Context())
-			assert.ErrorIs(t, err, rest.NoPlatformCredentialsErr)
 			assert.Nil(t, stubs)
 		})
 	})
@@ -301,26 +288,7 @@ func TestService(t *testing.T) {
 				SettingsObjectID: "objectID",
 			}
 			_, err := service.Create(t.Context(), &value)
-			assert.Error(t, err)
-			assert.ErrorIs(t, assert.AnError, err)
-		})
-
-		t.Run("It errors during client creation", func(t *testing.T) {
-			service := permissionService.ServiceImpl{
-				ClientSet: &config.ProviderConfiguration{},
-			}
-			_, err := service.Create(t.Context(), &permissions.SettingPermissions{})
-			assert.ErrorIs(t, rest.NoPlatformCredentialsErr, err)
-		})
-	})
-
-	t.Run("Update", func(t *testing.T) {
-		t.Run("It errors during client creation", func(t *testing.T) {
-			service := permissionService.ServiceImpl{
-				ClientSet: &config.ProviderConfiguration{},
-			}
-			err := service.Update(t.Context(), "", &permissions.SettingPermissions{})
-			assert.ErrorIs(t, rest.NoPlatformCredentialsErr, err)
+			assert.ErrorIs(t, err, assert.AnError)
 		})
 	})
 
@@ -378,12 +346,6 @@ func TestService(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, int32(1), deleteAllUserCalled.Load())
 		assert.Equal(t, int32(2), deleteAccessorCalled.Load())
-	})
-
-	t.Run("Service returns a new instance", func(t *testing.T) {
-		service, err := permissionService.Service(nil)
-		require.NoError(t, err)
-		assert.IsType(t, &permissionService.ServiceImpl{}, service)
 	})
 
 	t.Run("Returns the schema ID", func(t *testing.T) {

--- a/dynatrace/rest/client_set.go
+++ b/dynatrace/rest/client_set.go
@@ -17,6 +17,8 @@
 
 package rest
 
+import rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+
 // ClientSet is the credential/client provider handed to services, resources and datasources.
 //
 // It exposes the raw Credentials (so the existing client factories can be reused unchanged) plus
@@ -25,4 +27,5 @@ package rest
 type ClientSet interface {
 	Credentials() *Credentials
 	IAMClient() (IAMClient, error)
+	PlatformClient() (*rest2.Client, error)
 }

--- a/dynatrace/testing/mockclientset.go
+++ b/dynatrace/testing/mockclientset.go
@@ -16,18 +16,26 @@
 
 package testing
 
-import "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+)
 
 // MockClientSet is a rest.ClientSet whose IAM client and credentials are supplied directly, for
 // injecting a MockIAMClient into IAM services under test.
 type MockClientSet struct {
-	IAMClientValue   rest.IAMClient
-	IAMClientErr     error
-	CredentialsValue *rest.Credentials
+	IAMClientValue      rest.IAMClient
+	IAMClientErr        error
+	PlatformClientValue *rest2.Client
+	PlatformClientErr   error
+	CredentialsValue    *rest.Credentials
 }
 
 func (me *MockClientSet) IAMClient() (rest.IAMClient, error) {
 	return me.IAMClientValue, me.IAMClientErr
+}
+func (me *MockClientSet) PlatformClient() (*rest2.Client, error) {
+	return me.PlatformClientValue, me.PlatformClientErr
 }
 
 func (me *MockClientSet) Credentials() *rest.Credentials { return me.CredentialsValue }

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -41,6 +42,9 @@ type ProviderConfiguration struct {
 
 	iamClient    rest.IAMClient
 	iamClientErr error
+
+	platformClient    *rest2.Client
+	platformClientErr error
 }
 
 func (c *ProviderConfiguration) Credentials() *rest.Credentials {
@@ -57,6 +61,10 @@ func (c *ProviderConfiguration) Credentials() *rest.Credentials {
 
 func (c *ProviderConfiguration) IAMClient() (rest.IAMClient, error) {
 	return c.iamClient, c.iamClientErr
+}
+
+func (c *ProviderConfiguration) PlatformClient() (*rest2.Client, error) {
+	return c.platformClient, c.platformClientErr
 }
 
 type Getter interface {
@@ -128,6 +136,7 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) *ProviderConfigurat
 	clientCtx := context.Background()
 
 	pc.iamClient, pc.iamClientErr = rest.NewIAMClient(clientCtx, pc.Credentials())
+	pc.platformClient, pc.platformClientErr = rest.CreatePlatformClient(clientCtx, pc.Platform.EnvironmentURL, pc.Credentials())
 
 	return pc
 }


### PR DESCRIPTION
#### **Why** this PR?
Platform-backed resources and data sources were repeatedly creating platform clients on demand, which increased load on the SSO as each operation requested a new bearer token.

#### **What** has changed and **how** does it do it?
- Adds a shared `PlatformClient()` to `rest.ClientSet` so platform client initialization happens once and can be reused across the provider.
- Updates platform-backed services and data sources to request the shared client from `clientSet` instead of calling `rest.CreatePlatformClient(...)` directly.
- Simplifies test wiring by updating `dynatrace/testing/mockclientset.go` and replacing callback-based injection with direct client injection.

#### How is it **tested**?
- Existing tests cover most of the changes.

#### How does it affect **users**?
NA

**Issue:** PS-45605

