### PR TITLE
chore: update Go to 1.26.5 and extend snyk msgpack expiry

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -27,5 +27,5 @@ ignore:
   SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACK-15702236: &msg-pack-ignore
     - '*':
         reason: 'Transitive dependency via terraform-plugin-sdk/v2; no fixed version available upstream.'
-        expires: 2026-07-06T00:00:00.000Z
+        expires: 2026-08-14T00:00:00.000Z
   SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACKV5-15702238: *msg-pack-ignore

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace-oss/terraform-provider-dynatrace
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
#### **Why** this PR?
To stay up to date and fix some security issues.
Snyk complains again about msgpack (still no fix available)

#### **What** has changed?
Go was updated.
Extended msgpack expire date for another month.

#### **How** does it do it?
By bumping Go to 1.26.5
Setting the expiry date to August 14.

#### How is it **tested**?
N/A

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
