### PR TITLE
fix: avoid panic parsing array-shaped REST error bodies

### DIFF
--- a/dynatrace/rest/error.go
+++ b/dynatrace/rest/error.go
@@ -38,7 +38,7 @@ func Envelope(data []byte, url string, method string) error {
 	}
 
 	var envs []errorEnvelope
-	if err := json.Unmarshal(data, &envs); err == nil && len(envs) > 0 {
+	if err := json.Unmarshal(data, &envs); err == nil && len(envs) > 0 && envs[0].Error != nil {
 		env = envs[0]
 		return Error{Code: env.Error.Code, Method: method, URL: url, Message: env.Error.Message, ConstraintViolations: env.Error.ConstraintViolations}
 	}

--- a/dynatrace/rest/error_test.go
+++ b/dynatrace/rest/error_test.go
@@ -92,3 +92,30 @@ func TestError_IsNotFoundError_False(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvelope_ArrayBodyWithoutErrorDoesNotPanic(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Body     string
+		WantsErr bool
+	}{
+		{Name: "array without error field", Body: `[{"code":400}]`, WantsErr: false},
+		{Name: "array with error field", Body: `[{"error":{"code":400,"message":"bad"}}]`, WantsErr: true},
+		{Name: "object with error field", Body: `{"error":{"code":400,"message":"bad"}}`, WantsErr: true},
+		{Name: "object without error field", Body: `{"code":400}`, WantsErr: false},
+	}
+
+	for _, tcs := range testCases {
+		t.Run(tcs.Name, func(t *testing.T) {
+			var err error
+			assert.NotPanics(t, func() {
+				err = rest.Envelope([]byte(tcs.Body), "https://example.com", http.MethodGet)
+			})
+			if tcs.WantsErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -92,7 +92,7 @@ func unmarshalError(method string, url string, data []byte, response *http.Respo
 		return Error{Code: env.Error.Code, Method: method, URL: url, Message: env.Error.Message, ConstraintViolations: env.Error.ConstraintViolations}
 	} else {
 		var envs []errorEnvelope
-		if err = json.Unmarshal(data, &envs); err == nil && len(envs) > 0 {
+		if err = json.Unmarshal(data, &envs); err == nil && len(envs) > 0 && envs[0].Error != nil {
 			env = envs[0]
 			return Error{Code: env.Error.Code, Method: method, URL: url, Message: env.Error.Message, ConstraintViolations: env.Error.ConstraintViolations}
 		}


### PR DESCRIPTION
#### **Why** this PR?

any non-2xx classic-API response whose body is a JSON array without an `error` field (e.g. `[{"code":400}]`) panics the provider with a nil-pointer dereference

#### **What** has changed?

`Envelope` and `unmarshalError` now guard `envs[0].Error != nil` on the array branch, like the existing single-object branch already does

#### **How** does it do it?

adds `&& envs[0].Error != nil` to the array-branch condition in `dynatrace/rest/error.go` and `dynatrace/rest/request.go`, so a shape-drifted array body falls through instead of dereferencing nil

#### How is it **tested**?

added a table test in `error_test.go` for array/object bodies with and without the `error` field; it panics on the old code and passes on the new

#### How does it affect **users**?

a malformed or array-shaped error response no longer crashes the provider mid-operation

**Issue:** N/A
