### PR TITLE
fix: unskip browser monitor test to check e2e test failues

### DIFF
--- a/dynatrace/api/v1/config/synthetic/monitors/browser/service_test.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/service_test.go
@@ -30,7 +30,5 @@ func TestAccBrowserMonitors(t *testing.T) {
 }
 
 func TestAccTestCasesBrowserMonitors(t *testing.T) {
-	t.Skip("Skipping because the eventual consistency time is way too high")
-
 	api.TestAccTestCases(t)
 }

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/testdata/terraform/example_a.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/testdata/terraform/example_a.tf
@@ -42,7 +42,9 @@ resource "dynatrace_browser_monitor" "monitor" {
       bypass_csp = true
       user_agent = "Mozilla"
       bandwidth {
-        network_type = "GPRS"
+        download = 0
+        latency  = 0
+        upload   = 0
       }
       device {
         name        = "Apple iPhone 8"


### PR DESCRIPTION
#### **Why** this PR?

#### **What** has changed?

#### **How** does it do it?

#### How is it **tested**?

#### How does it affect **users**?

**Issue:**
