### PR TITLE
fix: dynatrace_browser_monitor should consider 0 for bandwidth fields

### DIFF
--- a/dynatrace/api/v1/config/synthetic/monitors/browser/settings/bandwidth.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/settings/bandwidth.go
@@ -18,6 +18,8 @@
 package browser
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -84,5 +86,38 @@ func (me *Bandwidth) UnmarshalHCL(decoder hcl.Decoder) error {
 	if err := decoder.Decode("upload", &me.Upload); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (me *Bandwidth) HandlePreconditions() error {
+	// The type/payload is either
+	// - predefinedBandwidth: network_type (required)
+	// - bandwidthOptions:    latency, download, upload (all required)
+
+	if me.NetworkType == nil {
+		// set default values of "0", because we can't differentiate between "not set" and "0" (plugin SDK).
+		// As they must be in the payload, the default values aren't a problem.
+
+		if me.Latency == nil {
+			me.Latency = new(int)
+		}
+		if me.Download == nil {
+			me.Download = new(int)
+		}
+		if me.Upload == nil {
+			me.Upload = new(int)
+		}
+		return nil
+	}
+	if me.Latency != nil {
+		return fmt.Errorf("'latency' must not be specified if 'network_type' is set'")
+	}
+	if me.Download != nil {
+		return fmt.Errorf("'download' must not be specified if 'network_type' is set'")
+	}
+	if me.Upload != nil {
+		return fmt.Errorf("'upload' must not be specified if 'network_type' is set'")
+	}
+
 	return nil
 }

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/settings/script_config.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/settings/script_config.go
@@ -28,8 +28,8 @@ import (
 // ScriptConfig contains the setup of the monitor
 type ScriptConfig struct {
 	UserAgent          *string                 `json:"userAgent,omitempty"`          // The user agent of the request
-	Device             *Device                 `json:"device,omitempty"`             // The emulated device of the monitor—holds either the parameters of the custom device or the name and orientation of the preconfigured device.\n\nIf not set, then the Desktop preconfigured device is used
-	Bandwidth          *Bandwidth              `json:"bandwidth,omitempty"`          // The emulated network conditions of the monitor.\n\nIf not set, then the full available bandwidth is used
+	Device             *Device                 `json:"device,omitempty"`             // The emulated device of the monitor—holds either the parameters of the custom device or the name and orientation of the preconfigured device.\n  \n  If not set, then the Desktop preconfigured device is used
+	Bandwidth          *Bandwidth              `json:"bandwidth,omitempty"`          // The emulated network conditions of the monitor.\n  \n  If not set, then the full available bandwidth is used
 	RequestHeaders     *request.HeadersSection `json:"requestHeaders,omitempty"`     // The list of HTTP headers to be sent with requests of the monitor
 	Cookies            request.Cookies         `json:"cookies,omitempty"`            // These cookies are added before execution of the first step
 	BlockRequests      []string                `json:"blockRequests,omitempty"`      // Block these URLs
@@ -80,7 +80,7 @@ func (me *ScriptConfig) Schema() map[string]*schema.Schema {
 		},
 		"device": {
 			Type:        schema.TypeList,
-			Description: "The emulated device of the monitor—holds either the parameters of the custom device or the name and orientation of the preconfigured device.\n\nIf not set, then the Desktop preconfigured device is used",
+			Description: "The emulated device of the monitor—holds either the parameters of the custom device or the name and orientation of the preconfigured device.\n  \n  If not set, then the Desktop preconfigured device is used",
 			Optional:    true,
 			MaxItems:    1,
 			Elem:        &schema.Resource{Schema: new(Device).Schema()},

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/settings/script_config.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/settings/script_config.go
@@ -86,11 +86,12 @@ func (me *ScriptConfig) Schema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: new(Device).Schema()},
 		},
 		"bandwidth": {
-			Type:        schema.TypeList,
-			Description: "The emulated device of the monitor—holds either the parameters of the custom device or the name and orientation of the preconfigured device.\n\nIf not set, then the Desktop preconfigured device is used",
-			Optional:    true,
-			MaxItems:    1,
-			Elem:        &schema.Resource{Schema: new(Bandwidth).Schema()},
+			Type: schema.TypeList,
+			Description: "The emulated device of the monitor—holds either the parameters of the custom device or the name and orientation of the preconfigured device.\n  \n  If not set, then the Desktop preconfigured device is used." +
+				"\n  Set either `network_type`, or all of `latency`, `download`, and `upload` (mutually exclusive).",
+			Optional: true,
+			MaxItems: 1,
+			Elem:     &schema.Resource{Schema: new(Bandwidth).Schema()},
 		},
 		"headers": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/settings/synthetic_monitor.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/settings/synthetic_monitor.go
@@ -75,12 +75,12 @@ func (me *SyntheticMonitor) Schema() map[string]*schema.Schema {
 		},
 		"frequency": {
 			Type:        schema.TypeInt,
-			Description: "The frequency of the monitor, in minutes.\n\nYou can use one of the following values: `5`, `10`, `15`, `30`, and `60`.",
+			Description: "The frequency of the monitor, in minutes.\n  \n  You can use one of the following values: `5`, `10`, `15`, `30`, and `60`.",
 			Required:    true,
 		},
 		"locations": {
 			Type:        schema.TypeSet,
-			Description: "A list of locations from which the monitor is executed.\n\nTo specify a location, use its entity ID.",
+			Description: "A list of locations from which the monitor is executed.\n  \n  To specify a location, use its entity ID.",
 			Optional:    true,
 			MinItems:    1,
 			Elem:        &schema.Schema{Type: schema.TypeString},
@@ -102,7 +102,7 @@ func (me *SyntheticMonitor) Schema() map[string]*schema.Schema {
 		},
 		"tags": {
 			Type:        schema.TypeList,
-			Description: "A set of tags assigned to the monitor.\n\nYou can specify only the value of the tag here and the `CONTEXTLESS` context and source 'USER' will be added automatically.",
+			Description: "A set of tags assigned to the monitor.\n  \n  You can specify only the value of the tag here and the `CONTEXTLESS` context and source 'USER' will be added automatically.",
 			Optional:    true,
 			Elem:        &schema.Resource{Schema: new(monitors.TagsWithSourceInfo).Schema()},
 		},

--- a/dynatrace/api/v1/config/synthetic/monitors/browser/testdata/terraform/example_script_bandwidth.tf
+++ b/dynatrace/api/v1/config/synthetic/monitors/browser/testdata/terraform/example_script_bandwidth.tf
@@ -1,0 +1,154 @@
+data "dynatrace_synthetic_location" "location" {
+  name = "Location"
+}
+
+data "dynatrace_application" "web_application" {
+  name = "Web Application"
+}
+
+resource "dynatrace_credentials" "credentials_vault" {
+  name        = "#name#"
+  description = "my credentials vault"
+  scopes      = ["SYNTHETIC"]
+  username    = "username"
+  password    = "password"
+}
+
+# check that bandwidth with 0 values is working
+resource "dynatrace_browser_monitor" "monitor" {
+  name                   = "#name#"
+  frequency              = 15
+  locations              = [data.dynatrace_synthetic_location.location.id]
+  manually_assigned_apps = [data.dynatrace_application.web_application.id]
+  anomaly_detection {
+    loading_time_thresholds {
+      enabled = true
+    }
+    outage_handling {
+      global_outage  = true
+      retry_on_error = true
+      global_outage_policy {
+        consecutive_runs = 1
+      }
+    }
+  }
+  key_performance_metrics {
+    load_action_kpm = "VISUALLY_COMPLETE"
+    xhr_action_kpm  = "VISUALLY_COMPLETE"
+  }
+  script {
+    type = "clickpath"
+    configuration {
+      bypass_csp = true
+      user_agent = "Mozilla"
+      bandwidth {
+        latency  = 0
+        upload   = 0
+        download = 0
+      }
+      device {
+        name        = "Apple iPhone 8"
+        orientation = "landscape"
+      }
+      headers {
+        header {
+          name  = "kjh"
+          value = "kjh"
+        }
+      }
+      ignored_error_codes {
+        status_codes = "400"
+      }
+      javascript_setttings {
+        timeout_settings {
+          action_limit  = 3
+          total_timeout = 100
+        }
+        visually_complete_options {
+          image_size_threshold = 0
+          inactivity_timeout   = 0
+          mutation_timeout     = 0
+        }
+      }
+    }
+    events {
+      event {
+        description = "Loading of \"https://example.com\""
+        navigate {
+          url = "https://example.com"
+          authentication {
+            type  = "http_authentication"
+            creds = dynatrace_credentials.credentials_vault.id
+          }
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+      event {
+        description = "jhjhjh"
+        navigate {
+          url = "https://example.com"
+          authentication {
+            type  = "http_authentication"
+            creds = dynatrace_credentials.credentials_vault.id
+          }
+          validate {
+            validation {
+              type  = "text_match"
+              match = "kkl"
+              regex = true
+              target {
+                window = "k"
+              }
+            }
+          }
+          wait {
+            timeout  = 60000
+            wait_for = "validation"
+            validation {
+              type  = "element_match"
+              match = "kjkj"
+              target {
+                locators {
+                  locator {
+                    type  = "css"
+                    value = "jjj"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      event {
+        description = "fvf"
+        click {
+          button = 0
+          validate {
+            validation {
+              type = "text_match"
+            }
+          }
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+      event {
+        description = "jsfoo"
+        javascript {
+          code = <<-EOT
+            let x = 3;
+            for (var i = 0; i < x; x++) {
+                console.log("asdf");
+            }
+          EOT
+          wait {
+            wait_for = "page_complete"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/v1/config/synthetic/monitors/tag_with_source_info.go
+++ b/dynatrace/api/v1/config/synthetic/monitors/tag_with_source_info.go
@@ -72,17 +72,17 @@ func (me *TagWithSourceInfo) Schema() map[string]*schema.Schema {
 		},
 		"context": {
 			Type:        schema.TypeString,
-			Description: "The origin of the tag. Supported values are `AWS`, `AWS_GENERIC`, `AZURE`, `CLOUD_FOUNDRY`, `CONTEXTLESS`, `ENVIRONMENT`, `GOOGLE_CLOUD` and `KUBERNETES`.\n\nCustom tags use the `CONTEXTLESS` value.",
+			Description: "The origin of the tag. Supported values are `AWS`, `AWS_GENERIC`, `AZURE`, `CLOUD_FOUNDRY`, `CONTEXTLESS`, `ENVIRONMENT`, `GOOGLE_CLOUD` and `KUBERNETES`.\n  \n  Custom tags use the `CONTEXTLESS` value.",
 			Required:    true,
 		},
 		"key": {
 			Type:        schema.TypeString,
-			Description: "The key of the tag.\n\nCustom tags have the tag value here.",
+			Description: "The key of the tag.\n  \n  Custom tags have the tag value here.",
 			Required:    true,
 		},
 		"value": {
 			Type:        schema.TypeString,
-			Description: " The value of the tag.\n\nNot applicable to custom tags.",
+			Description: " The value of the tag.\n  \n  Not applicable to custom tags.",
 			Optional:    true,
 		},
 	}


### PR DESCRIPTION
#### **Why** this PR?
`script.configuration.bandwidth` in dynatrace_browser_monitor omits `0` values, which leads to a failed request. `0` is a valid value for `latency`, `download`, and `upload`.

#### **What** has changed?
`0` can now be set for `latency`, `download`, and `upload` and isn't omitted.
Added conditional errors => It's either `network_type`, or all of `latency`, `download`, and `upload` (mutually exclusive).
Also fixed some documentation line breaks.

#### **How** does it do it?
- Adds preconditions for the mutually exclusive fields
- Sets `nil` values to `0` if possible (if `network_type` isn't set)

#### How is it **tested**?
New E2E added to apply a config with `0` values for bandwidth.

#### How does it affect **users**?
They can now specify `0` for `latency`, `download`, and `upload`.

**Issue:** PS-48229