### PR TITLE
test: execute GCP connector related tests sequentially

### DIFF
--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /**
 * @license

--- a/dynatrace/api/builtin/openpipeline/bizevents/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/bizevents/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/davis/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/davis/problems/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/davis/problems/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/events/sdlc/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/events/sdlc/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/logs/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/logs/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/metrics/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/metrics/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/security/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/security/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/spans/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/spans/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/system/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/system/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/user/events/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/user/events/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license

--- a/dynatrace/api/builtin/openpipeline/usersessions/dataforwarding/service_test.go
+++ b/dynatrace/api/builtin/openpipeline/usersessions/dataforwarding/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration && connector
+//go:build sequential_integration && connector
 
 /*
  * @license


### PR DESCRIPTION
#### **Why** this PR?
Currently, we have flaky E2E tests because we can't have more than one GCP connection with the same service account ID => `serviceAccountImpersonation/serviceAccountId: This service account is already used by another connection`

#### **What** has changed?
The tests aren't flaky anymore (run sequentially in a concurrency group).

If you think "we could just create a connector in the setup and re-use it in the tests":
- Our settings data source doesn't return the object ID
- I would be against having a variable that holds the connection ID.

#### **How** does it do it?
By using the `sequential_integration` tag instead of `integration`.

#### How is it **tested**?
This "just" moves the test to a different job queue.

#### How does it affect **users**?
N/A

**Issue:** NOISSUE
