### PR TITLE
feat: deprecate dynatrace_mobile_notifications resource

### DIFF
--- a/dynatrace/api/builtin/mobile/notifications/service_test.go
+++ b/dynatrace/api/builtin/mobile/notifications/service_test.go
@@ -26,5 +26,6 @@ import (
 )
 
 func TestAccMobileNotifications(t *testing.T) {
+	t.Skip("Deprecated")
 	api.TestAcc(t)
 }

--- a/dynatrace/api/builtin/mobile/notifications/settings/settings.go
+++ b/dynatrace/api/builtin/mobile/notifications/settings/settings.go
@@ -30,6 +30,10 @@ func (me *Settings) Name() string {
 	return "mobile_notifications"
 }
 
+func (me *Settings) Deprecated() string {
+	return "This resource API endpoint has been deprecated."
+}
+
 func (me *Settings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"enabled": {

--- a/templates/resources/mobile_notifications.md.tmpl
+++ b/templates/resources/mobile_notifications.md.tmpl
@@ -1,12 +1,14 @@
 ---
 layout: ""
 page_title: "dynatrace_mobile_notifications Resource - terraform-provider-dynatrace"
-subcategory: "Notifications"
+subcategory: "Deprecated"
 description: |-
   The resource `dynatrace_mobile_notifications` covers configuration problem notifications sent via Web Hook
 ---
 
 # dynatrace_mobile_notifications (Resource)
+
+!> This resource API endpoint has been deprecated.
 
 -> This resource requires the API token scopes **Read settings** (`settings.read`) and **Write settings** (`settings.write`)
 


### PR DESCRIPTION
#### **Why** this PR?
This resource `dynatrace_mobile_notifications` doesn't exist anymore => schema not found.

#### **What** has changed?
`dynatrace_mobile_notifications` is now shown as deprecated (usage and docs)

#### **How** does it do it?
Adding a deprecation notice and skipping the related tests.

#### How is it **tested**?
N/A

#### How does it affect **users**?
They will see that this resource has been deprecated/removed.

**Issue:** PS-48253