### PR TITLE
feat: update `dynatrace_activegate_updates` to v1.0.4

### DIFF
--- a/dynatrace/api/builtin/deployment/activegate/updates/schema.json
+++ b/dynatrace/api/builtin/deployment/activegate/updates/schema.json
@@ -19,7 +19,7 @@
 				},
 				{
 					"displayName": "Automatic (during update window)",
-					"value": "AUTOMATIC_DURING_MW"
+					"value": "AUTOMATIC_DURING_UW"
 				},
 				{
 					"displayName": "No automatic updates",
@@ -33,15 +33,72 @@
 	"maxObjects": 1,
 	"multiObject": false,
 	"properties": {
-		"autoUpdate": {
-			"default": true,
+		"targetVersion": {
+			"constraints": [
+				{
+					"maxLength": 500,
+					"minLength": 1,
+					"type": "LENGTH"
+				}
+			],
+			"datasource": {
+				"filterProperties": [],
+				"fullContext": false,
+				"identifier": "PrivateActiveGateAutoUpdateVersionsDataSource",
+				"resetValue": "NEVER",
+				"useApiSearch": false,
+				"validate": true
+			},
+			"default": "latest",
 			"description": "",
-			"displayName": "Automatic updates at earliest convenience",
+			"displayName": "Target version",
 			"documentation": "",
 			"maxObjects": 1,
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
-			"type": "boolean"
+			"subType": "datasource",
+			"type": "text"
+		},
+		"updateMode": {
+			"default": "AUTOMATIC",
+			"description": "",
+			"displayName": "Update mode",
+			"documentation": "",
+			"maxObjects": 1,
+			"metadata": {
+				"sortItems": "disabled"
+			},
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": {
+				"$ref": "#/enums/UpdateMode"
+			}
+		},
+		"updateWindows": {
+			"description": "",
+			"displayName": "Update windows",
+			"documentation": "",
+			"items": {
+				"description": "",
+				"displayName": "",
+				"documentation": "",
+				"type": {
+					"$ref": "#/types/updateWindow"
+				}
+			},
+			"maxObjects": 100,
+			"metadata": {
+				"addItemButton": "Add update window"
+			},
+			"minObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": "AUTOMATIC_DURING_UW",
+				"property": "updateMode",
+				"type": "EQUALS"
+			},
+			"type": "set"
 		}
 	},
 	"schemaGroups": [
@@ -49,12 +106,12 @@
 	],
 	"schemaId": "builtin:deployment.activegate.updates",
 	"types": {
-		"maintenanceWindow": {
+		"updateWindow": {
 			"description": "",
-			"displayName": "maintenanceWindow",
+			"displayName": "updateWindow",
 			"documentation": "",
 			"properties": {
-				"maintenanceWindow": {
+				"updateWindow": {
 					"default": "00000000-0000-0000-0000-000000000000",
 					"description": "Select an [update window for ActiveGate updates](/ui/settings/builtin:deployment.management.update-windows)",
 					"displayName": "Update window",
@@ -70,11 +127,11 @@
 					"type": "setting"
 				}
 			},
-			"summaryPattern": "{maintenanceWindow}",
+			"summaryPattern": "{updateWindow}",
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
 		}
 	},
-	"version": "1.0.2"
+	"version": "1.0.4"
 }

--- a/dynatrace/api/builtin/deployment/activegate/updates/service.go
+++ b/dynatrace/api/builtin/deployment/activegate/updates/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.2"
+const SchemaVersion = "1.0.4"
 const SchemaID = "builtin:deployment.activegate.updates"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {

--- a/dynatrace/api/builtin/deployment/activegate/updates/service_test.go
+++ b/dynatrace/api/builtin/deployment/activegate/updates/service_test.go
@@ -28,3 +28,7 @@ import (
 func TestAccActiveGateUpdates(t *testing.T) {
 	api.TestAcc(t)
 }
+
+func TestAccTestCasesActiveGateUpdates(t *testing.T) {
+	api.TestAccTestCases(t)
+}

--- a/dynatrace/api/builtin/deployment/activegate/updates/settings/enums.go
+++ b/dynatrace/api/builtin/deployment/activegate/updates/settings/enums.go
@@ -21,10 +21,10 @@ type UpdateMode string
 
 var UpdateModes = struct {
 	Automatic         UpdateMode
-	AutomaticDuringMw UpdateMode
+	AutomaticDuringUw UpdateMode
 	Manual            UpdateMode
 }{
 	"AUTOMATIC",
-	"AUTOMATIC_DURING_MW",
+	"AUTOMATIC_DURING_UW",
 	"MANUAL",
 }

--- a/dynatrace/api/builtin/deployment/activegate/updates/settings/settings.go
+++ b/dynatrace/api/builtin/deployment/activegate/updates/settings/settings.go
@@ -23,8 +23,10 @@ import (
 )
 
 type Settings struct {
-	AutoUpdate bool    `json:"autoUpdate"`      // Automatic updates at earliest convenience
-	Scope      *string `json:"-" scope:"scope"` // The scope of this setting (ENVIRONMENT_ACTIVE_GATE). Omit this property if you want to cover the whole environment.
+	Scope         *string       `json:"-" scope:"scope"`         // The scope of this setting (ENVIRONMENT_ACTIVE_GATE). Omit this property if you want to cover the whole environment.
+	TargetVersion string        `json:"targetVersion"`           // Target version
+	UpdateMode    UpdateMode    `json:"updateMode"`              // Update mode. Possible values: `AUTOMATIC`, `AUTOMATIC_DURING_UW`, `MANUAL`
+	UpdateWindows UpdateWindows `json:"updateWindows,omitempty"` // Update windows
 }
 
 func (me *Settings) Name() string {
@@ -33,11 +35,6 @@ func (me *Settings) Name() string {
 
 func (me *Settings) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"auto_update": {
-			Type:        schema.TypeBool,
-			Description: "Automatic updates at earliest convenience",
-			Required:    true,
-		},
 		"scope": {
 			Type:        schema.TypeString,
 			Description: "The scope of this setting (ENVIRONMENT_ACTIVE_GATE). Omit this property if you want to cover the whole environment.",
@@ -45,19 +42,46 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Default:     "environment",
 			ForceNew:    true,
 		},
+		"target_version": {
+			Type:        schema.TypeString,
+			Description: "Target version",
+			Required:    true,
+		},
+		"update_mode": {
+			Type:        schema.TypeString,
+			Description: "Update mode. Possible values: `AUTOMATIC`, `AUTOMATIC_DURING_UW`, `MANUAL`",
+			Required:    true,
+		},
+		"update_windows": {
+			Type:        schema.TypeList,
+			Description: "Update windows",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(UpdateWindows).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 	}
 }
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"auto_update": me.AutoUpdate,
-		"scope":       me.Scope,
+		"scope":          me.Scope,
+		"target_version": me.TargetVersion,
+		"update_mode":    me.UpdateMode,
+		"update_windows": me.UpdateWindows,
 	})
+}
+
+func (me *Settings) HandlePreconditions() error {
+	// ---- UpdateWindows UpdateWindows -> {"expectedValue":"AUTOMATIC_DURING_UW","property":"updateMode","type":"EQUALS"}
+	return nil
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"auto_update": &me.AutoUpdate,
-		"scope":       &me.Scope,
+		"scope":          &me.Scope,
+		"target_version": &me.TargetVersion,
+		"update_mode":    &me.UpdateMode,
+		"update_windows": &me.UpdateWindows,
 	})
 }

--- a/dynatrace/api/builtin/deployment/activegate/updates/settings/update_window.go
+++ b/dynatrace/api/builtin/deployment/activegate/updates/settings/update_window.go
@@ -1,0 +1,71 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package updates
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type UpdateWindows []*UpdateWindow
+
+func (me *UpdateWindows) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"update_window": {
+			Type:        schema.TypeSet,
+			Required:    true,
+			MinItems:    1,
+			Description: "",
+			Elem:        &schema.Resource{Schema: new(UpdateWindow).Schema()},
+		},
+	}
+}
+
+func (me UpdateWindows) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeSlice("update_window", me)
+}
+
+func (me *UpdateWindows) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeSlice("update_window", me)
+}
+
+type UpdateWindow struct {
+	UpdateWindow string `json:"updateWindow"` // Select an [update window for ActiveGate updates](/ui/settings/builtin:deployment.management.update-windows)
+}
+
+func (me *UpdateWindow) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"update_window": {
+			Type:        schema.TypeString,
+			Description: "Select an [update window for ActiveGate updates](/ui/settings/builtin:deployment.management.update-windows)",
+			Required:    true,
+		},
+	}
+}
+
+func (me *UpdateWindow) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"update_window": me.UpdateWindow,
+	})
+}
+
+func (me *UpdateWindow) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"update_window": &me.UpdateWindow,
+	})
+}

--- a/dynatrace/api/builtin/deployment/activegate/updates/testcases/update-window-set/create.tf
+++ b/dynatrace/api/builtin/deployment/activegate/updates/testcases/update-window-set/create.tf
@@ -3,14 +3,19 @@ resource "dynatrace_activegate_updates" "example" {
   target_version = "latest"
   update_mode    = "AUTOMATIC_DURING_UW"
   update_windows {
+    // to be removed
     update_window {
-      update_window = dynatrace_update_windows.example.id
+      update_window = dynatrace_update_windows.example[0].id
+    }
+    update_window {
+      update_window = dynatrace_update_windows.example[1].id
     }
   }
 }
 
 resource "dynatrace_update_windows" "example" {
-  name       = "#name#"
+  count      = 2
+  name       = "#name#-${count.index}"
   enabled    = true
   recurrence = "ONCE"
   once_recurrence {

--- a/dynatrace/api/builtin/deployment/activegate/updates/testcases/update-window-set/update.tf
+++ b/dynatrace/api/builtin/deployment/activegate/updates/testcases/update-window-set/update.tf
@@ -3,14 +3,16 @@ resource "dynatrace_activegate_updates" "example" {
   target_version = "latest"
   update_mode    = "AUTOMATIC_DURING_UW"
   update_windows {
+    // one window removed
     update_window {
-      update_window = dynatrace_update_windows.example.id
+      update_window = dynatrace_update_windows.example[1].id
     }
   }
 }
 
 resource "dynatrace_update_windows" "example" {
-  name       = "#name#"
+  count      = 2
+  name       = "#name#-${count.index}"
   enabled    = true
   recurrence = "ONCE"
   once_recurrence {


### PR DESCRIPTION
BREAKING CHANGE

#### **Why** this PR?
The resource `dynatrace_activegate_updates` always shows a non-empty plan. Turns out, the schema was completely changed. The `auto_update` field no longer exists.

#### **What** has changed?
The `dynatrace_activegate_updates` resource is up to date with the schema.

#### **How** does it do it?
The field `auto_update` has been removed.
New required fields `target_version` and `update_mode`.
New conditional field `update_windows`.

#### How is it **tested**?
Example updated. All fields are being used.
New testcase tests added, as the field `update_windows` is of type set.

#### How does it affect **users**?
They can use the resource again

**Issue:** PS-48255