### PR TITLE
fix(platform-slo): correct JSON tag for FilterSegment.Variables

### DIFF
--- a/dynatrace/api/slo/settings/filter_segments.go
+++ b/dynatrace/api/slo/settings/filter_segments.go
@@ -46,7 +46,7 @@ func (me *FilterSegments) UnmarshalHCL(decoder hcl.Decoder) error {
 
 type FilterSegment struct {
 	Id        string                 `json:"id"`
-	Variables FilterSegmentVariables `json:"value,omitempty"`
+	Variables FilterSegmentVariables `json:"variables,omitempty"`
 }
 
 func (me *FilterSegment) Schema() map[string]*schema.Schema {


### PR DESCRIPTION
## Context

The `Variables` field on `FilterSegment` was tagged `json:"value"` instead of `json:"variables"`. This caused filter segment variables to be serialised under the wrong key when creating or updating a platform SLO via the Dynatrace API. The API ignored the unknown `"value"` key and silently dropped the entire filter segment, leaving the SLO without any segment scope.

Changing the tag to `json:"variables"` aligns the serialised payload with the Dynatrace Platform SLO API contract.

## **Why** this PR?

Any `dynatrace_platform_slo` resource that uses `filter_segments` would silently lose its segment on every `terraform apply`. The SLO would be written to the API without the segment, rendering it invalid — no error was returned, making the bug hard to diagnose. The root cause was a wrong JSON tag introduced when the platform SLO resource was first added.

## **What** has changed?

One-character fix in `dynatrace/api/slo/settings/filter_segments.go`: the JSON struct tag on `FilterSegment.Variables` is corrected from `json:"value"` to `json:"variables"`.

## **How** does it do it?

The fix aligns the Go struct tag with the field name the Dynatrace Platform SLO API expects in the request body. No logic changes, no schema changes, and HCL is unchanged for users.

## How is it **tested**?

Verified manually by applying a `dynatrace_platform_slo` resource with a `filter_segments` block before and after the fix:

- **Before:** the API received `"value":[...]` and dropped the segment silently.
- **After:** the API receives `"variables":[...]` and persists the segment correctly.

## How does it affect **users**?

Users with `filter_segments` configured on a `dynatrace_platform_slo` resource will find that their segment is now correctly written to the API on create and update. Previously, every apply silently removed the segment. This is a bug fix with no breaking change to HCL or state schema.

**Issue:** N/A