### PR TITLE
test: add filter_segment to SLO test file

### DIFF
--- a/dynatrace/api/slo/testdata/terraform/example-b.tf
+++ b/dynatrace/api/slo/testdata/terraform/example-b.tf
@@ -19,5 +19,17 @@ resource "dynatrace_platform_slo" "#name#" {
       | fieldsAdd sli=(((total[]-failures[])/total[])*(100))
       | fieldsRemove total, failures, tags
     EOT
+
+    filter_segments {
+      filter_segment {
+        id = "segment_1"
+        variables {
+          filter_segment_variable {
+            name = "variable_1"
+            values = ["value_1"]
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
#### **Why** this PR?
We recently had a bug in `dynatrace_platform_slo` which we would have caught earlier, had we tested the use of the filter segments field for SLOs. See: #1195 

#### **What** has changed and **How**?
An E2E test example has been extended to make use of filter segments.

#### How is it **tested**?
This is the test.

#### How does it affect **users**?
It doesn't

**Issue:** NOISSUE
