### PR TITLE
doc: Add clarifications to api_token.md.tmpl

### DIFF
--- a/templates/resources/api_token.md.tmpl
+++ b/templates/resources/api_token.md.tmpl
@@ -14,6 +14,8 @@ description: |-
 
 -> This resource requires the API token scopes **Read API tokens** (`apiTokens.read`) and **Write API tokens** (`apiTokens.write`)
 
+Use this resource to create and manage access tokens for Dynatrace. This resource can not be used to manage platform tokens.
+
 ## Dynatrace Documentation
 
 - Dynatrace API Tokens and authentication - https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication


### PR DESCRIPTION
#### **Why** this PR?
Users try to use the `dynatrace_api_token` resource to create platform tokens, which does not work.

#### **What** has changed?
The line "Use this resource to create and manage access tokens for Dynatrace. This resource can not be used to manage platform tokens." has been added to the resource's doc template.

#### How does it affect **users**?
It should make it clear for users that platform tokens cannot be managed with this resource.

**Issue:** PS-48668
