### PR TITLE
fix: set enable_python in `dynatrace_vulnerability_settings` to optional

### DIFF
--- a/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings/technology.go
+++ b/dynatrace/api/builtin/appsec/runtimevulnerabilitydetection/settings/technology.go
@@ -88,7 +88,8 @@ func (me *Technology) Schema() map[string]*schema.Schema {
 		"enable_python": {
 			Type:        schema.TypeBool,
 			Description: "Python",
-			Required:    true,
+			Optional:    true, // nullable
+			Default:     true,
 		},
 		"enable_python_runtime": {
 			Type:        schema.TypeBool,


### PR DESCRIPTION
#### **Why** this PR?
For `dynatrace_vulnerability_settings`, `enable_python` was now set to "required". This represents the schema, but it was a newly introduced field before, where we added a default value. So the regression coming from https://github.com/dynatrace-oss/terraform-provider-dynatrace/pull/1199 should be fixed.

#### **What** has changed?
Reverted the change that `enable_python` is required. Still, leaving `enable_python_runtime` without a default value because of conditional fields

#### **How** does it do it?
By setting `enable_python` as optional and giving it a default value of `true`

#### How is it **tested**?
Tests are working again

#### How does it affect **users**?
Compared to the previous change: They now have to set `enable_python_runtime` to `true`, as the default value has been removed, because it is and was a conditional field. `enable_python` works as before

**Issue:** NOISSUE
