### PR TITLE
Feat/document lables

### DIFF
--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -36,7 +36,6 @@ func Service(credentials *rest.Credentials) settings.CRUDService[*documents.Docu
 	return &service{credentials}
 }
 
-
 type service struct {
 	credentials *rest.Credentials
 }
@@ -62,6 +61,9 @@ func (me *service) Get(ctx context.Context, id string, v *documents.Document) (e
 				v.Type = stateDocument.Type
 				v.Owner = stateDocument.Owner
 				v.Version = stateDocument.Version
+				v.Description = stateDocument.Description
+				v.Labels = stateDocument.Labels
+				v.IsReshareable = stateDocument.IsReshareable
 				return nil
 			}
 		}
@@ -86,6 +88,13 @@ func (me *service) get(ctx context.Context, id string, v *documents.Document) (e
 	v.Owner = result.Owner
 	v.Type = result.Type
 	v.Version = result.Version
+	v.Labels = result.Labels
+	if result.Description != nil {
+		v.Description = *result.Description
+	}
+	if result.IsReshareable != nil {
+		v.IsReshareable = *result.IsReshareable
+	}
 
 	return nil
 }
@@ -123,17 +132,7 @@ func (me *service) Validate(_ *documents.Document) error {
 }
 
 func (me *service) Create(ctx context.Context, v *documents.Document) (*api.Stub, error) {
-	stub, err := me.createPrivate(ctx, v)
-	if err != nil {
-		return nil, err
-	}
-
-	if !v.IsPrivate {
-		if err = me.update(ctx, stub.ID, v); err != nil {
-			return nil, err
-		}
-	}
-	return stub, nil
+	return me.createPrivate(ctx, v)
 }
 
 func (me *service) createPrivate(ctx context.Context, v *documents.Document) (stub *api.Stub, err error) {
@@ -141,7 +140,18 @@ func (me *service) createPrivate(ctx context.Context, v *documents.Document) (st
 	if err != nil {
 		return nil, err
 	}
-	response, err := c.Create(ctx, v.Name, v.IsPrivate, v.ID, []byte(v.Content), docclient.DocumentType(v.Type))
+	meta := docclient.Metadata{
+		ID:        v.ID,
+		Name:      v.Name,
+		IsPrivate: v.IsPrivate,
+		Type:      v.Type,
+		Labels:    v.Labels,
+	}
+	if v.Description != "" {
+		meta.Description = &v.Description
+	}
+	meta.IsReshareable = &v.IsReshareable
+	response, err := c.Create(ctx, meta, []byte(v.Content))
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +160,6 @@ func (me *service) createPrivate(ctx context.Context, v *documents.Document) (st
 		return nil, err
 	}
 	return stub, nil
-
 }
 
 func (me *service) Update(ctx context.Context, id string, v *documents.Document) (err error) {
@@ -162,7 +171,18 @@ func (me *service) update(ctx context.Context, id string, v *documents.Document)
 	if err != nil {
 		return err
 	}
-	_, err = c.Update(ctx, id, v.Name, v.IsPrivate, []byte(v.Content), docclient.DocumentType(v.Type))
+	meta := docclient.Metadata{
+		ID:        id,
+		Name:      v.Name,
+		IsPrivate: v.IsPrivate,
+		Type:      v.Type,
+		Labels:    v.Labels,
+	}
+	if v.Description != "" {
+		meta.Description = &v.Description
+	}
+	meta.IsReshareable = &v.IsReshareable
+	_, err = c.Update(ctx, meta, []byte(v.Content))
 	if err != nil {
 		return err
 	}

--- a/dynatrace/api/documents/document/settings/document.go
+++ b/dynatrace/api/documents/document/settings/document.go
@@ -26,14 +26,17 @@ import (
 )
 
 type Document struct {
-	ID            string `json:"id,omitempty"`
-	Name          string `json:"name" maxlength:"200"`
-	Content       string `json:"content,omitempty"`
-	IsPrivate     bool   `json:"isPrivate,omitempty"`
-	Type          string `json:"type"`
-	Owner         string `json:"owner,omitempty" format:"uuid"`
-	Version       int    `json:"version,omitempty"`
-	SchemaVersion int    `json:"schemaVersion,omitempty"`
+	ID            string   `json:"id,omitempty"`
+	Name          string   `json:"name" maxlength:"200"`
+	Content       string   `json:"content,omitempty"`
+	IsPrivate     bool     `json:"isPrivate,omitempty"`
+	Type          string   `json:"type"`
+	Owner         string   `json:"owner,omitempty" format:"uuid"`
+	Version       int      `json:"version,omitempty"`
+	SchemaVersion int      `json:"schemaVersion,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
+	IsReshareable bool     `json:"isReshareable,omitempty"`
 }
 
 func (me *Document) Schema() map[string]*schema.Schema {
@@ -79,6 +82,22 @@ func (me *Document) Schema() map[string]*schema.Schema {
 			Description: "The version of the document",
 			Computed:    true,
 		},
+		"description": {
+			Type:        schema.TypeString,
+			Description: "A short description of the document",
+			Optional:    true,
+		},
+		"labels": {
+			Type:        schema.TypeSet,
+			Description: "Labels attached to the document",
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"is_reshareable": {
+			Type:        schema.TypeBool,
+			Description: "Specifies whether recipients of a direct share can share the document further",
+			Optional:    true,
+		},
 	}
 }
 
@@ -90,45 +109,57 @@ func (me *Document) MarshalHCL(properties hcl.Properties) error {
 		}
 	}
 	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"content": me.Content,
-		"private": me.IsPrivate,
-		"type":    me.Type,
-		"owner":   me.Owner,
-		"version": me.Version,
+		"name":           me.Name,
+		"content":        me.Content,
+		"private":        me.IsPrivate,
+		"type":           me.Type,
+		"owner":          me.Owner,
+		"version":        me.Version,
+		"description":    me.Description,
+		"labels":         me.Labels,
+		"is_reshareable": me.IsReshareable,
 	})
 }
 
 func (me *Document) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"custom_id": &me.ID,
-		"name":      &me.Name,
-		"content":   &me.Content,
-		"private":   &me.IsPrivate,
-		"type":      &me.Type,
-		"owner":     &me.Owner,
-		"version":   &me.Version,
+		"custom_id":      &me.ID,
+		"name":           &me.Name,
+		"content":        &me.Content,
+		"private":        &me.IsPrivate,
+		"type":           &me.Type,
+		"owner":          &me.Owner,
+		"version":        &me.Version,
+		"description":    &me.Description,
+		"labels":         &me.Labels,
+		"is_reshareable": &me.IsReshareable,
 	})
 }
 
 func (me *Document) MarshalJSON() ([]byte, error) {
 	d := struct {
-		ID      string `json:"id,omitempty"`
-		Name    string `json:"name"`
-		Content string `json:"content,omitempty"`
-		Private bool   `json:"isPrivate,omitempty"`
-		Type    string `json:"type"`
-		Actor   string `json:"actor,omitempty"`
-		Owner   string `json:"owner,omitempty"`
-		Version int    `json:"version,omitempty"`
+		ID            string   `json:"id,omitempty"`
+		Name          string   `json:"name"`
+		Content       string   `json:"content,omitempty"`
+		Private       bool     `json:"isPrivate,omitempty"`
+		Type          string   `json:"type"`
+		Actor         string   `json:"actor,omitempty"`
+		Owner         string   `json:"owner,omitempty"`
+		Version       int      `json:"version,omitempty"`
+		Description   string   `json:"description,omitempty"`
+		Labels        []string `json:"labels,omitempty"`
+		IsReshareable bool     `json:"isReshareable,omitempty"`
 	}{
-		ID:      me.ID,
-		Name:    me.Name,
-		Private: me.IsPrivate,
-		Content: me.Content,
-		Type:    me.Type,
-		Owner:   me.Owner,
-		Version: me.Version,
+		ID:            me.ID,
+		Name:          me.Name,
+		Private:       me.IsPrivate,
+		Content:       me.Content,
+		Type:          me.Type,
+		Owner:         me.Owner,
+		Version:       me.Version,
+		Description:   me.Description,
+		Labels:        me.Labels,
+		IsReshareable: me.IsReshareable,
 	}
 	return json.Marshal(d)
 }

--- a/dynatrace/api/documents/document/testdata/terraform/example-a.tf
+++ b/dynatrace/api/documents/document/testdata/terraform/example-a.tf
@@ -1,7 +1,10 @@
 resource "dynatrace_document" "this" {
-  type = "dashboard"
-  name = "Example Dashboard"
-  custom_id = "#name#"
+  type           = "dashboard"
+  name           = "Example Dashboard"
+  custom_id      = "#name#"
+  description    = "Initial description"
+  labels         = ["monitoring", "cloud", "draft"]
+  is_reshareable = true
   content = jsonencode(
     {
       "version" : 13,

--- a/dynatrace/api/documents/document/testdata/terraform/example-b.tf
+++ b/dynatrace/api/documents/document/testdata/terraform/example-b.tf
@@ -1,6 +1,9 @@
 resource "dynatrace_document" "#name#" {
-  name = "#name#"
-  type = "launchpad"
+  name           = "#name#"
+  type           = "launchpad"
+  description    = "Updated description"
+  labels         = ["monitoring", "cloud"]
+  is_reshareable = false
   content = jsonencode({
     "background" : "default",
     "containerList" : {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203 h1:kzNnEcxFIvdGGIAP4uyxCsRnKqFu9Th5/9VG0Ibnr+U=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260603140430-e4e946cfe203/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5 h1:sOkguwt1B8uUhGjNnPM+/M5UKeMYWKZFRSm0bgp/msY=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
#### **Why** this PR?

The core lib updated its documents client with breaking API changes and added three new fields. This PR fixes the breakage and exposes the new fields.

#### **What** has changed?

- Bumped `dynatrace-configuration-as-code-core` to `feat/documents-labels-api-update`
- Added `description`, `labels`, and `is_reshareable` to the `dynatrace_document` resource
- Removed a two-step create workaround that the new lib now handles internally

#### **How** does it do it?

The new lib changed `Create`/`Update` to accept a single `Metadata` struct instead of individual parameters. The service now builds that struct and passes it through. The two-step create (create private → update to public) is gone because the lib handles that internally now.

#### How is it **tested**?

Extended the existing `TestAccDocuments` e2e fixtures — `example-a.tf` creates with all three new fields set, `example-b.tf` updates them including removing a label.

#### How does it affect **users**?

Users can now set `description`, `labels`, and `is_reshareablea` on `dynatrace_document`. All three are optional so existing configs are unaffected.

**Issue:**
PS-47481