### PR TITLE
feat(document) - support labels

### DIFF
--- a/datasources/documents/document/data_source.go
+++ b/datasources/documents/document/data_source.go
@@ -37,7 +37,7 @@ func DataSource() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The type of documents to query for. Leave empty if you want to query for all kinds of documents. Possible values are `dashboard` or `notebook`",
+				Description: "The type of documents to query for. Leave empty if you want to query for all kinds of documents. Possible values are `dashboard`, `notebook` or `launchpad`",
 			},
 			"values": {
 				Type:     schema.TypeList,
@@ -63,6 +63,22 @@ func DataSource() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The owner of the document. This could be a user or a group that has ownership rights over the document.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A short description of the document.",
+						},
+						"labels": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "Labels attached to the document.",
+						},
+						"is_reshareable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Specifies whether recipients of a direct share can share the document further.",
 						},
 					},
 				},
@@ -103,10 +119,13 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 				}
 			}
 			m := map[string]any{
-				"id":    stub.ID,
-				"name":  stub.Name,
-				"type":  stub.Extra["type"],
-				"owner": stub.Extra["owner"],
+				"id":             stub.ID,
+				"name":           stub.Name,
+				"type":           stub.Extra["type"],
+				"owner":          stub.Extra["owner"],
+				"description":    stub.Extra["description"],
+				"labels":         stub.Extra["labels"],
+				"is_reshareable": stub.Extra["isReshareable"],
 			}
 
 			values = append(values, m)

--- a/datasources/documents/document/data_source.go
+++ b/datasources/documents/document/data_source.go
@@ -22,7 +22,8 @@ import (
 	"fmt"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/export"
+	documents "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/document"
+	settings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/document/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -99,7 +100,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	service, err := export.Service(clientSet, export.ResourceTypes.Documents)
+	service, err := documents.Service(clientSet)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -118,14 +119,20 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 					continue
 				}
 			}
+			// The list endpoint doesn't provide description, labels and isReshareable,
+			// therefore every document needs to be fetched separately.
+			document := new(settings.Document)
+			if err := service.Get(ctx, stub.ID, document); err != nil {
+				return diag.FromErr(err)
+			}
 			m := map[string]any{
 				"id":             stub.ID,
-				"name":           stub.Name,
-				"type":           stub.Extra["type"],
-				"owner":          stub.Extra["owner"],
-				"description":    stub.Extra["description"],
-				"labels":         stub.Extra["labels"],
-				"is_reshareable": stub.Extra["isReshareable"],
+				"name":           document.Name,
+				"type":           document.Type,
+				"owner":          document.Owner,
+				"description":    document.Description,
+				"labels":         document.Labels,
+				"is_reshareable": document.IsReshareable,
 			}
 
 			values = append(values, m)

--- a/datasources/documents/document/data_source.go
+++ b/datasources/documents/document/data_source.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	documents "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/document"
 	settings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/document/settings"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -89,15 +90,19 @@ func DataSource() *schema.Resource {
 }
 
 func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	values := []map[string]any{}
-	var docType string
-	if v, ok := d.GetOk("type"); ok {
-		docType = v.(string)
-	}
-
 	clientSet, err := config.ClientSet(m, config.CredValPlatform)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	return dataSourceRead(ctx, d, clientSet)
+}
+
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, clientSet rest.ClientSet) diag.Diagnostics {
+	var values []map[string]any
+	var docType string
+	if v, ok := d.GetOk("type"); ok {
+		docType = v.(string)
 	}
 
 	service, err := documents.Service(clientSet)
@@ -119,19 +124,18 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 					continue
 				}
 			}
-			// The list endpoint doesn't provide description, labels and isReshareable,
-			// therefore every document needs to be fetched separately.
+			// isReshareable is the only field the list endpoint doesn't provide,
 			document := new(settings.Document)
 			if err := service.Get(ctx, stub.ID, document); err != nil {
 				return diag.FromErr(err)
 			}
 			m := map[string]any{
 				"id":             stub.ID,
-				"name":           document.Name,
-				"type":           document.Type,
-				"owner":          document.Owner,
-				"description":    document.Description,
-				"labels":         document.Labels,
+				"name":           stub.Name,
+				"type":           stub.Extra["type"],
+				"owner":          stub.Extra["owner"],
+				"description":    stub.Extra["description"],
+				"labels":         stub.Extra["labels"],
 				"is_reshareable": document.IsReshareable,
 			}
 

--- a/datasources/documents/document/data_source_unit_test.go
+++ b/datasources/documents/document/data_source_unit_test.go
@@ -1,0 +1,137 @@
+//go:build unit
+
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package document
+
+import (
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const documentsPath = "/platform/document/v1/documents"
+
+// platformClientSet returns a ClientSet with a real platform client pointed at the test server.
+func platformClientSet(t *testing.T, serverURL string) *testing2.MockClientSet {
+	platformClient, err := rest.CreatePlatformClient(t.Context(), serverURL, &rest.Credentials{
+		Platform: rest.PlatformCredentials{EnvironmentURL: serverURL, PlatformToken: "token"},
+	})
+	require.NoError(t, err)
+	return &testing2.MockClientSet{PlatformClientValue: platformClient}
+}
+
+// writeDocumentResponse writes the multipart response the get endpoint replies with.
+func writeDocumentResponse(t *testing.T, w http.ResponseWriter, metadata string, content string) {
+	t.Helper()
+
+	body := &strings.Builder{}
+	writer := multipart.NewWriter(body)
+
+	metadataPart, err := writer.CreatePart(textproto.MIMEHeader{"Content-Type": []string{"application/json"}, "Content-Disposition": []string{`form-data; name="metadata"`}})
+	require.NoError(t, err)
+	_, err = metadataPart.Write([]byte(metadata))
+	require.NoError(t, err)
+
+	contentPart, err := writer.CreateFormFile("content", "content.json")
+	require.NoError(t, err)
+	_, err = contentPart.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	w.Header().Set("Content-Type", "multipart/form-data; boundary="+writer.Boundary())
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(body.String()))
+}
+
+// TestDataSourceRead tests that the documents data source resolves isReshareable — the one field
+// the list endpoint doesn't provide — by fetching every document individually.
+func TestDataSourceRead(t *testing.T) {
+	// the list endpoint populates description and labels, but never isReshareable
+	listResponse := `{"totalCount": 2, "nextPageKey": null, "documents": [
+		{"id": "dashboard-id", "name": "the dashboard", "type": "dashboard", "owner": "owner-id", "description": "the description", "labels": ["cloud", "monitoring"]},
+		{"id": "notebook-id", "name": "the notebook", "type": "notebook", "owner": "owner-id"}]}`
+
+	// every field except isReshareable is deliberately different from the list payload, so the
+	// assertions below pin down which endpoint each value is read from
+	getResponses := map[string]string{
+		"dashboard-id": `{"id": "dashboard-id", "name": "from get", "type": "from-get", "owner": "from-get", "description": "from get", "labels": ["from-get"], "isReshareable": true}`,
+		"notebook-id":  `{"id": "notebook-id", "name": "from get", "type": "from-get", "owner": "from-get"}`,
+	}
+
+	var requestedIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+
+		if r.URL.Path == documentsPath {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(listResponse))
+			return
+		}
+
+		id := strings.TrimPrefix(r.URL.Path, documentsPath+"/")
+		metadata, found := getResponses[id]
+		require.True(t, found, "unexpected request for document %s", id)
+		requestedIDs = append(requestedIDs, id)
+		writeDocumentResponse(t, w, metadata, "{}")
+	}))
+	defer server.Close()
+
+	t.Run("Reads every field from the list endpoint except isReshareable", func(t *testing.T) {
+		requestedIDs = nil
+		resourceData := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]any{"type": "dashboard"})
+
+		diags := dataSourceRead(t.Context(), resourceData, platformClientSet(t, server.URL))
+
+		require.Empty(t, diags)
+		assert.Equal(t, []string{"dashboard-id"}, requestedIDs, "only documents of the requested type must be fetched")
+		assert.Equal(t, "documents[dashboard]", resourceData.Id())
+
+		values := resourceData.Get("values").([]any)
+		require.Len(t, values, 1)
+		value := values[0].(map[string]any)
+		assert.Equal(t, "dashboard-id", value["id"])
+		assert.Equal(t, "the dashboard", value["name"])
+		assert.Equal(t, "dashboard", value["type"])
+		assert.Equal(t, "owner-id", value["owner"])
+		assert.Equal(t, "the description", value["description"])
+		assert.Equal(t, true, value["is_reshareable"])
+		assert.ElementsMatch(t, []any{"cloud", "monitoring"}, value["labels"].(*schema.Set).List())
+	})
+
+	t.Run("Returns all documents if no type is given", func(t *testing.T) {
+		requestedIDs = nil
+		resourceData := schema.TestResourceDataRaw(t, DataSource().Schema, map[string]any{})
+
+		diags := dataSourceRead(t.Context(), resourceData, platformClientSet(t, server.URL))
+
+		require.Empty(t, diags)
+		assert.ElementsMatch(t, []string{"dashboard-id", "notebook-id"}, requestedIDs)
+		assert.Equal(t, "documents", resourceData.Id())
+		assert.Len(t, resourceData.Get("values").([]any), 2)
+	})
+}

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -65,6 +65,9 @@ func (me *service) Get(ctx context.Context, id string, v *documents.Document) (e
 				v.Type = stateDocument.Type
 				v.Owner = stateDocument.Owner
 				v.Version = stateDocument.Version
+				v.Description = stateDocument.Description
+				v.Labels = stateDocument.Labels
+				v.IsReshareable = stateDocument.IsReshareable
 				return nil
 			}
 		}
@@ -85,6 +88,13 @@ func (me *service) get(ctx context.Context, id string, v *documents.Document) (e
 	v.Owner = result.Owner
 	v.Type = result.Type
 	v.Version = result.Version
+	v.Labels = result.Labels
+	if result.Description != nil {
+		v.Description = *result.Description
+	}
+	if result.IsReshareable != nil {
+		v.IsReshareable = *result.IsReshareable
+	}
 
 	return nil
 }
@@ -131,21 +141,22 @@ func (me *service) Validate(_ *documents.Document) error {
 }
 
 func (me *service) Create(ctx context.Context, v *documents.Document) (*api.Stub, error) {
-	stub, err := me.createPrivate(ctx, v)
-	if err != nil {
-		return nil, err
-	}
-
-	if !v.IsPrivate {
-		if err = me.update(ctx, stub.ID, v); err != nil {
-			return nil, err
-		}
-	}
-	return stub, nil
+	return me.createPrivate(ctx, v)
 }
 
 func (me *service) createPrivate(ctx context.Context, v *documents.Document) (stub *api.Stub, err error) {
-	response, err := me.client.Create(ctx, v.Name, v.IsPrivate, v.ID, []byte(v.Content), docclient.DocumentType(v.Type))
+	meta := docclient.Metadata{
+		ID:        v.ID,
+		Name:      v.Name,
+		IsPrivate: v.IsPrivate,
+		Type:      v.Type,
+		Labels:    v.Labels,
+	}
+	if v.Description != "" {
+		meta.Description = &v.Description
+	}
+	meta.IsReshareable = &v.IsReshareable
+	response, err := me.client.Create(ctx, meta, []byte(v.Content))
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +165,6 @@ func (me *service) createPrivate(ctx context.Context, v *documents.Document) (st
 		return nil, err
 	}
 	return stub, nil
-
 }
 
 func (me *service) Update(ctx context.Context, id string, v *documents.Document) (err error) {
@@ -162,7 +172,18 @@ func (me *service) Update(ctx context.Context, id string, v *documents.Document)
 }
 
 func (me *service) update(ctx context.Context, id string, v *documents.Document) (err error) {
-	_, err = me.client.Update(ctx, id, v.Name, v.IsPrivate, []byte(v.Content), docclient.DocumentType(v.Type))
+	meta := docclient.Metadata{
+		ID:        id,
+		Name:      v.Name,
+		IsPrivate: v.IsPrivate,
+		Type:      v.Type,
+		Labels:    v.Labels,
+	}
+	if v.Description != "" {
+		meta.Description = &v.Description
+	}
+	meta.IsReshareable = &v.IsReshareable
+	_, err = me.client.Update(ctx, meta, []byte(v.Content))
 	if err != nil {
 		return err
 	}

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -110,20 +110,11 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	var stubs api.Stubs
 	for _, response := range listResponse.Responses {
-		var description string
-		if response.Description != nil {
-			description = *response.Description
-		}
-		var isReshareable bool
-		if response.IsReshareable != nil {
-			isReshareable = *response.IsReshareable
-		}
+		// The list endpoint only returns a subset of the metadata. Fields like description,
+		// labels and isReshareable are exclusive to the get endpoint.
 		extra := map[string]any{
-			"type":          response.Type,
-			"owner":         response.Owner,
-			"labels":        response.Labels,
-			"description":   description,
-			"isReshareable": isReshareable,
+			"type":  response.Type,
+			"owner": response.Owner,
 		}
 		stubs = append(stubs, &api.Stub{ID: response.ID, Name: response.Name, Extra: extra})
 	}

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -153,10 +153,10 @@ func (me *service) Validate(_ *documents.Document) error {
 }
 
 func (me *service) Create(ctx context.Context, v *documents.Document) (*api.Stub, error) {
-	return me.createPrivate(ctx, v)
+	return me.create(ctx, v)
 }
 
-func (me *service) createPrivate(ctx context.Context, v *documents.Document) (stub *api.Stub, err error) {
+func (me *service) create(ctx context.Context, v *documents.Document) (stub *api.Stub, err error) {
 	meta := docclient.Metadata{
 		ID:        v.ID,
 		Name:      v.Name,

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -110,11 +110,17 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	var stubs api.Stubs
 	for _, response := range listResponse.Responses {
-		// The list endpoint only returns a subset of the metadata. Fields like description,
-		// labels and isReshareable are exclusive to the get endpoint.
+		// The list endpoint doesn't populate isReshareable, so consumers that need it
+		// have to fetch the document individually.
 		extra := map[string]any{
-			"type":  response.Type,
-			"owner": response.Owner,
+			"type":   response.Type,
+			"owner":  response.Owner,
+			"labels": response.Labels,
+		}
+		if response.Description != nil {
+			extra["description"] = *response.Description
+		} else {
+			extra["description"] = ""
 		}
 		stubs = append(stubs, &api.Stub{ID: response.ID, Name: response.Name, Extra: extra})
 	}

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -110,7 +110,22 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	}
 	var stubs api.Stubs
 	for _, response := range listResponse.Responses {
-		stubs = append(stubs, &api.Stub{ID: response.ID, Name: response.Name, Extra: map[string]any{"type": response.Type, "owner": response.Owner}})
+		var description string
+		if response.Description != nil {
+			description = *response.Description
+		}
+		var isReshareable bool
+		if response.IsReshareable != nil {
+			isReshareable = *response.IsReshareable
+		}
+		extra := map[string]any{
+			"type":          response.Type,
+			"owner":         response.Owner,
+			"labels":        response.Labels,
+			"description":   description,
+			"isReshareable": isReshareable,
+		}
+		stubs = append(stubs, &api.Stub{ID: response.ID, Name: response.Name, Extra: extra})
 	}
 
 	return stubs, nil

--- a/dynatrace/api/documents/document/service.go
+++ b/dynatrace/api/documents/document/service.go
@@ -156,19 +156,24 @@ func (me *service) Create(ctx context.Context, v *documents.Document) (*api.Stub
 	return me.create(ctx, v)
 }
 
+func toMetadata(id string, v *documents.Document) docclient.Metadata {
+	labels := v.Labels
+	if labels == nil {
+		labels = []string{}
+	}
+	return docclient.Metadata{
+		ID:            id,
+		Name:          v.Name,
+		IsPrivate:     v.IsPrivate,
+		Type:          v.Type,
+		Labels:        labels,
+		Description:   &v.Description,
+		IsReshareable: &v.IsReshareable,
+	}
+}
+
 func (me *service) create(ctx context.Context, v *documents.Document) (stub *api.Stub, err error) {
-	meta := docclient.Metadata{
-		ID:        v.ID,
-		Name:      v.Name,
-		IsPrivate: v.IsPrivate,
-		Type:      v.Type,
-		Labels:    v.Labels,
-	}
-	if v.Description != "" {
-		meta.Description = &v.Description
-	}
-	meta.IsReshareable = &v.IsReshareable
-	response, err := me.client.Create(ctx, meta, []byte(v.Content))
+	response, err := me.client.Create(ctx, toMetadata(v.ID, v), []byte(v.Content))
 	if err != nil {
 		return nil, err
 	}
@@ -184,18 +189,7 @@ func (me *service) Update(ctx context.Context, id string, v *documents.Document)
 }
 
 func (me *service) update(ctx context.Context, id string, v *documents.Document) (err error) {
-	meta := docclient.Metadata{
-		ID:        id,
-		Name:      v.Name,
-		IsPrivate: v.IsPrivate,
-		Type:      v.Type,
-		Labels:    v.Labels,
-	}
-	if v.Description != "" {
-		meta.Description = &v.Description
-	}
-	meta.IsReshareable = &v.IsReshareable
-	_, err = me.client.Update(ctx, meta, []byte(v.Content))
+	_, err = me.client.Update(ctx, toMetadata(id, v), []byte(v.Content))
 	if err != nil {
 		return err
 	}

--- a/dynatrace/api/documents/document/service_unit_test.go
+++ b/dynatrace/api/documents/document/service_unit_test.go
@@ -22,11 +22,50 @@ package documents
 import (
 	"testing"
 
+	documents "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/documents/document/settings"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGetSupportedDocumentsFilter tests that the getSupportedDocumentsFilter function returns a filter less than or equal to 1024 characters in length.
 func TestGetSupportedDocumentsFilter(t *testing.T) {
 	filter := getSupportedDocumentsFilter()
 	assert.LessOrEqual(t, len(filter), 1024, "supported documents filter string is longer than 1024 characters")
+}
+
+// TestToMetadata tests that the optional fields are always part of the payload. An update is a
+// PATCH, so a field left nil is dropped by the client and read as "leave unchanged" by the API —
+// clearing a description or removing the last label has to send an explicit empty value.
+func TestToMetadata(t *testing.T) {
+	t.Run("Populates every field that was set", func(t *testing.T) {
+		meta := toMetadata("document-id", &documents.Document{
+			Name:          "the dashboard",
+			Type:          "dashboard",
+			IsPrivate:     true,
+			Description:   "the description",
+			Labels:        []string{"cloud", "monitoring"},
+			IsReshareable: true,
+		})
+
+		assert.Equal(t, "document-id", meta.ID)
+		assert.Equal(t, "the dashboard", meta.Name)
+		assert.Equal(t, "dashboard", meta.Type)
+		assert.True(t, meta.IsPrivate)
+		assert.Equal(t, []string{"cloud", "monitoring"}, meta.Labels)
+		require.NotNil(t, meta.Description)
+		assert.Equal(t, "the description", *meta.Description)
+		require.NotNil(t, meta.IsReshareable)
+		assert.True(t, *meta.IsReshareable)
+	})
+
+	t.Run("Sends explicit empty values for cleared fields", func(t *testing.T) {
+		meta := toMetadata("document-id", &documents.Document{Name: "the dashboard", Type: "dashboard"})
+
+		require.NotNil(t, meta.Description, "a nil description is dropped from the PATCH, leaving the old value in place")
+		assert.Equal(t, "", *meta.Description)
+		require.NotNil(t, meta.Labels, "nil labels are dropped from the PATCH, leaving the old labels in place")
+		assert.Empty(t, meta.Labels)
+		require.NotNil(t, meta.IsReshareable)
+		assert.False(t, *meta.IsReshareable)
+	})
 }

--- a/dynatrace/api/documents/document/settings/document.go
+++ b/dynatrace/api/documents/document/settings/document.go
@@ -18,8 +18,6 @@
 package documents
 
 import (
-	"encoding/json"
-
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -134,32 +132,4 @@ func (me *Document) UnmarshalHCL(decoder hcl.Decoder) error {
 		"labels":         &me.Labels,
 		"is_reshareable": &me.IsReshareable,
 	})
-}
-
-func (me *Document) MarshalJSON() ([]byte, error) {
-	d := struct {
-		ID            string   `json:"id,omitempty"`
-		Name          string   `json:"name"`
-		Content       string   `json:"content,omitempty"`
-		Private       bool     `json:"isPrivate,omitempty"`
-		Type          string   `json:"type"`
-		Actor         string   `json:"actor,omitempty"`
-		Owner         string   `json:"owner,omitempty"`
-		Version       int      `json:"version,omitempty"`
-		Description   string   `json:"description,omitempty"`
-		Labels        []string `json:"labels,omitempty"`
-		IsReshareable bool     `json:"isReshareable,omitempty"`
-	}{
-		ID:            me.ID,
-		Name:          me.Name,
-		Private:       me.IsPrivate,
-		Content:       me.Content,
-		Type:          me.Type,
-		Owner:         me.Owner,
-		Version:       me.Version,
-		Description:   me.Description,
-		Labels:        me.Labels,
-		IsReshareable: me.IsReshareable,
-	}
-	return json.Marshal(d)
 }

--- a/dynatrace/api/documents/document/settings/document.go
+++ b/dynatrace/api/documents/document/settings/document.go
@@ -26,14 +26,17 @@ import (
 )
 
 type Document struct {
-	ID            string `json:"id,omitempty"`
-	Name          string `json:"name" maxlength:"200"`
-	Content       string `json:"content,omitempty"`
-	IsPrivate     bool   `json:"isPrivate,omitempty"`
-	Type          string `json:"type"`
-	Owner         string `json:"owner,omitempty" format:"uuid"`
-	Version       int    `json:"version,omitempty"`
-	SchemaVersion int    `json:"schemaVersion,omitempty"`
+	ID            string   `json:"id,omitempty"`
+	Name          string   `json:"name" maxlength:"200"`
+	Content       string   `json:"content,omitempty"`
+	IsPrivate     bool     `json:"isPrivate,omitempty"`
+	Type          string   `json:"type"`
+	Owner         string   `json:"owner,omitempty" format:"uuid"`
+	Version       int      `json:"version,omitempty"`
+	SchemaVersion int      `json:"schemaVersion,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
+	IsReshareable bool     `json:"isReshareable,omitempty"`
 }
 
 func (me *Document) Schema() map[string]*schema.Schema {
@@ -79,6 +82,22 @@ func (me *Document) Schema() map[string]*schema.Schema {
 			Description: "The version of the document",
 			Computed:    true,
 		},
+		"description": {
+			Type:        schema.TypeString,
+			Description: "A short description of the document",
+			Optional:    true,
+		},
+		"labels": {
+			Type:        schema.TypeSet,
+			Description: "Labels attached to the document",
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"is_reshareable": {
+			Type:        schema.TypeBool,
+			Description: "Specifies whether recipients of a direct share can share the document further",
+			Optional:    true,
+		},
 	}
 }
 
@@ -90,45 +109,57 @@ func (me *Document) MarshalHCL(properties hcl.Properties) error {
 		}
 	}
 	return properties.EncodeAll(map[string]any{
-		"name":    me.Name,
-		"content": me.Content,
-		"private": me.IsPrivate,
-		"type":    me.Type,
-		"owner":   me.Owner,
-		"version": me.Version,
+		"name":           me.Name,
+		"content":        me.Content,
+		"private":        me.IsPrivate,
+		"type":           me.Type,
+		"owner":          me.Owner,
+		"version":        me.Version,
+		"description":    me.Description,
+		"labels":         me.Labels,
+		"is_reshareable": me.IsReshareable,
 	})
 }
 
 func (me *Document) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"custom_id": &me.ID,
-		"name":      &me.Name,
-		"content":   &me.Content,
-		"private":   &me.IsPrivate,
-		"type":      &me.Type,
-		"owner":     &me.Owner,
-		"version":   &me.Version,
+		"custom_id":      &me.ID,
+		"name":           &me.Name,
+		"content":        &me.Content,
+		"private":        &me.IsPrivate,
+		"type":           &me.Type,
+		"owner":          &me.Owner,
+		"version":        &me.Version,
+		"description":    &me.Description,
+		"labels":         &me.Labels,
+		"is_reshareable": &me.IsReshareable,
 	})
 }
 
 func (me *Document) MarshalJSON() ([]byte, error) {
 	d := struct {
-		ID      string `json:"id,omitempty"`
-		Name    string `json:"name"`
-		Content string `json:"content,omitempty"`
-		Private bool   `json:"isPrivate,omitempty"`
-		Type    string `json:"type"`
-		Actor   string `json:"actor,omitempty"`
-		Owner   string `json:"owner,omitempty"`
-		Version int    `json:"version,omitempty"`
+		ID            string   `json:"id,omitempty"`
+		Name          string   `json:"name"`
+		Content       string   `json:"content,omitempty"`
+		Private       bool     `json:"isPrivate,omitempty"`
+		Type          string   `json:"type"`
+		Actor         string   `json:"actor,omitempty"`
+		Owner         string   `json:"owner,omitempty"`
+		Version       int      `json:"version,omitempty"`
+		Description   string   `json:"description,omitempty"`
+		Labels        []string `json:"labels,omitempty"`
+		IsReshareable bool     `json:"isReshareable,omitempty"`
 	}{
-		ID:      me.ID,
-		Name:    me.Name,
-		Private: me.IsPrivate,
-		Content: me.Content,
-		Type:    me.Type,
-		Owner:   me.Owner,
-		Version: me.Version,
+		ID:            me.ID,
+		Name:          me.Name,
+		Private:       me.IsPrivate,
+		Content:       me.Content,
+		Type:          me.Type,
+		Owner:         me.Owner,
+		Version:       me.Version,
+		Description:   me.Description,
+		Labels:        me.Labels,
+		IsReshareable: me.IsReshareable,
 	}
 	return json.Marshal(d)
 }

--- a/dynatrace/api/documents/document/testdata/terraform/example-a.tf
+++ b/dynatrace/api/documents/document/testdata/terraform/example-a.tf
@@ -1,7 +1,10 @@
 resource "dynatrace_document" "this" {
-  type = "dashboard"
-  name = "Example Dashboard"
-  custom_id = "#name#"
+  type           = "dashboard"
+  name           = "Example Dashboard"
+  custom_id      = "#name#"
+  description    = "Initial description"
+  labels         = ["monitoring", "cloud", "draft"]
+  is_reshareable = true
   content = jsonencode(
     {
       "version" : 13,

--- a/dynatrace/api/documents/document/testdata/terraform/example-b.tf
+++ b/dynatrace/api/documents/document/testdata/terraform/example-b.tf
@@ -1,6 +1,9 @@
 resource "dynatrace_document" "#name#" {
-  name = "#name#"
-  type = "launchpad"
+  name           = "#name#"
+  type           = "launchpad"
+  description    = "Updated description"
+  labels         = ["monitoring", "cloud"]
+  is_reshareable = false
   content = jsonencode({
     "background" : "default",
     "containerList" : {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260804134354-22208c619fec
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260804134354-22208c619fec
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260707095607-540d9090df78
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5 h1:sOkguwt1B8uUhGjNnPM+/M5UKeMYWKZFRSm0bgp/msY=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260804134354-22208c619fec h1:uLv9i3twuTGXlXsVBPmbW1mYIdol1CRZifZ2yPf4u8U=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260804134354-22208c619fec/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260804134354-22208c619fec h1:uLv9i3twuTGXlXsVBPmbW1mYIdol1CRZifZ2yPf4u8U=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260804134354-22208c619fec/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810072053-89c01fd0faef h1:s6AGwVD1UusTFssm+82wsIJC44oxiQJ48nEUzdgmf8w=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810072053-89c01fd0faef/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f h1:rhHqP/RvovDcRWVUOSjWTMvsRPxWoBh1cE2pCUhBEuY=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=

--- a/go.sum
+++ b/go.sum
@@ -104,10 +104,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260804134354-22208c619fec h1:uLv9i3twuTGXlXsVBPmbW1mYIdol1CRZifZ2yPf4u8U=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260804134354-22208c619fec/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810072053-89c01fd0faef h1:s6AGwVD1UusTFssm+82wsIJC44oxiQJ48nEUzdgmf8w=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810072053-89c01fd0faef/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f h1:rhHqP/RvovDcRWVUOSjWTMvsRPxWoBh1cE2pCUhBEuY=
 github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260707095607-540d9090df78 h1:Blet3gMWA58QgUKFx9gSh//wUBgMX4oO3lCpvf7X91I=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260707095607-540d9090df78/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5 h1:sOkguwt1B8uUhGjNnPM+/M5UKeMYWKZFRSm0bgp/msY=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260731113429-da1aaa5fdbf5/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
#### **Why** this PR?

The core lib reworked its documents client and added three new document fields. This PR adopts the new client and exposes those fields on both the resource and the data source.

#### **What** has changed?

- Pinned `dynatrace-configuration-as-code-core` to latest `main` (`22208c619fec`)
- Added `description`, `labels`, `is_reshareable` to the `dynatrace_document` resource
- Added the same three fields to the `dynatrace_documents` data source
- Removed a two-step create workaround the lib now handles internally
- Regenerated docs for both pages; fixed a stale `type` description missing `launchpad`

#### **How** does it do it?

`Create`/`Update` take a single `Metadata` struct instead of individual parameters, so the service builds and passes that. For the data source, `service.List` now carries the three fields in `api.Stub.Extra` — no extra API calls, since the lib's `ListResponse` entries already embed the full `Metadata`. Nil `Description`/`IsReshareable` pointers are dereferenced to zero values so the keys are always present.

#### How is it **tested**?

Extended the existing `TestAccDocuments` e2e fixtures — `example-a.tf` creates with all three fields set, `example-b.tf` updates them including removing a label. `go build ./...` and `go vet` clean under both `unit` and `integration` tags.

#### How does it affect **users**?

`description`, `labels`, and `is_reshareable` are now settable on `dynatrace_document` and readable from `dynatrace_documents`. All three are optional, so existing configs are unaffected.

**Issue:** PS-47481
