### PR TITLE
docs: fixed dynatrace_update_windows documentation

### DIFF
--- a/dynatrace/api/builtin/deployment/management/updatewindows/settings/enums.go
+++ b/dynatrace/api/builtin/deployment/management/updatewindows/settings/enums.go
@@ -34,31 +34,55 @@ var RecurrenceEnums = struct {
 type TimezoneEnum string
 
 var TimezoneEnums = struct {
-	Gmt0000 TimezoneEnum
-	Gmt0100 TimezoneEnum
-	Gmt0200 TimezoneEnum
-	Gmt0300 TimezoneEnum
-	Gmt0400 TimezoneEnum
-	Gmt0500 TimezoneEnum
-	Gmt0600 TimezoneEnum
-	Gmt0700 TimezoneEnum
-	Gmt0800 TimezoneEnum
-	Gmt0900 TimezoneEnum
-	Gmt1000 TimezoneEnum
-	Gmt1100 TimezoneEnum
-	Gmt1200 TimezoneEnum
+	GmtMinus0100 TimezoneEnum
+	GmtMinus0200 TimezoneEnum
+	GmtMinus0300 TimezoneEnum
+	GmtMinus0400 TimezoneEnum
+	GmtMinus0500 TimezoneEnum
+	GmtMinus0600 TimezoneEnum
+	GmtMinus0700 TimezoneEnum
+	GmtMinus0800 TimezoneEnum
+	GmtMinus0900 TimezoneEnum
+	GmtMinus1000 TimezoneEnum
+	GmtMinus1100 TimezoneEnum
+	GmtMinus1200 TimezoneEnum
+	GmtPlus0000  TimezoneEnum
+	GmtPlus0100  TimezoneEnum
+	GmtPlus0200  TimezoneEnum
+	GmtPlus0300  TimezoneEnum
+	GmtPlus0400  TimezoneEnum
+	GmtPlus0500  TimezoneEnum
+	GmtPlus0600  TimezoneEnum
+	GmtPlus0700  TimezoneEnum
+	GmtPlus0800  TimezoneEnum
+	GmtPlus0900  TimezoneEnum
+	GmtPlus1000  TimezoneEnum
+	GmtPlus1100  TimezoneEnum
+	GmtPlus1200  TimezoneEnum
 }{
-	"GMT+00:00",
-	"GMT+01:00",
-	"GMT+02:00",
+	"GMT-01:00",
+	"GMT-02:00",
 	"GMT-03:00",
 	"GMT-04:00",
 	"GMT-05:00",
 	"GMT-06:00",
-	"GMT+07:00",
+	"GMT-07:00",
 	"GMT-08:00",
-	"GMT+09:00",
+	"GMT-09:00",
 	"GMT-10:00",
 	"GMT-11:00",
 	"GMT-12:00",
+	"GMT+00:00",
+	"GMT+01:00",
+	"GMT+02:00",
+	"GMT+03:00",
+	"GMT+04:00",
+	"GMT+05:00",
+	"GMT+06:00",
+	"GMT+07:00",
+	"GMT+08:00",
+	"GMT+09:00",
+	"GMT+10:00",
+	"GMT+11:00",
+	"GMT+12:00",
 }

--- a/dynatrace/api/builtin/deployment/management/updatewindows/settings/update_time.go
+++ b/dynatrace/api/builtin/deployment/management/updatewindows/settings/update_time.go
@@ -25,7 +25,7 @@ import (
 type UpdateTime struct {
 	Duration  int          `json:"duration"`  // Duration (minutes)
 	StartTime string       `json:"startTime"` // Start time (24-hour clock)
-	TimeZone  TimezoneEnum `json:"timeZone"`  // Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+07:00`, `GMT+09:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-08:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`
+	TimeZone  TimezoneEnum `json:"timeZone"`  // Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+03:00`, `GMT+04:00`, `GMT+05:00`, `GMT+06:00`, `GMT+07:00`, `GMT+08:00`, `GMT+09:00`, `GMT+10:00`, `GMT+11:00`, `GMT+12:00`, `GMT-01:00`, `GMT-02:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-07:00`, `GMT-08:00`, `GMT-09:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`
 }
 
 func (me *UpdateTime) Schema() map[string]*schema.Schema {
@@ -42,7 +42,7 @@ func (me *UpdateTime) Schema() map[string]*schema.Schema {
 		},
 		"time_zone": {
 			Type:        schema.TypeString,
-			Description: "Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+07:00`, `GMT+09:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-08:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`",
+			Description: "Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+03:00`, `GMT+04:00`, `GMT+05:00`, `GMT+06:00`, `GMT+07:00`, `GMT+08:00`, `GMT+09:00`, `GMT+10:00`, `GMT+11:00`, `GMT+12:00`, `GMT-01:00`, `GMT-02:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-07:00`, `GMT-08:00`, `GMT-09:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`",
 			Required:    true,
 		},
 	}


### PR DESCRIPTION
#### **Why** this PR?
Enum values weren't correctly added if they contained special characters

#### **What** has changed?
Documentation for dynatrace_update_windows is fixed to mention all possible enums

#### **How** does it do it?
By fixing the description of the affected field.

#### How is it **tested**?
N/A

#### How does it affect **users**?
They'll see the correct documentation

**Issue:** NOISSUE