### PR TITLE
fix: new required to optional

### DIFF
--- a/docs/resources/os_services.md
+++ b/docs/resources/os_services.md
@@ -168,7 +168,6 @@ Optional:
 
 Required:
 
-- `key_must_exist` (Boolean) When enabled, the condition requires a resource attribute to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.
 - `metadata_condition` (String) This string has to match a required format.
 
   - `$match(ver*_1.2.?)` – Matches string with wildcards: `*` any number (including zero) of characters and `?` exactly one character.
@@ -184,6 +183,10 @@ Required:
 
   Brackets **(** and **)** that are part of the matched property **must be escaped with a tilde (~)**
 - `metadata_key` (String) Key
+
+Optional:
+
+- `key_must_exist` (Boolean) When enabled, the condition requires a resource attribute to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.
 
 
 
@@ -240,7 +243,6 @@ Optional:
 
 Required:
 
-- `key_must_exist` (Boolean) When enabled, the condition requires a resource attribute to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.
 - `metadata_condition` (String) This string has to match a required format.
 
   - `$match(ver*_1.2.?)` – Matches string with wildcards: `*` any number (including zero) of characters and `?` exactly one character.
@@ -256,6 +258,10 @@ Required:
 
   Brackets **(** and **)** that are part of the matched property **must be escaped with a tilde (~)**
 - `metadata_key` (String) Key
+
+Optional:
+
+- `key_must_exist` (Boolean) When enabled, the condition requires a resource attribute to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.
 
 
 

--- a/docs/resources/update_windows.md
+++ b/docs/resources/update_windows.md
@@ -87,7 +87,7 @@ Required:
 
 - `duration` (Number) Duration (minutes)
 - `start_time` (String) Start time (24-hour clock)
-- `time_zone` (String) Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+07:00`, `GMT+09:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-08:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`
+- `time_zone` (String) Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+03:00`, `GMT+04:00`, `GMT+05:00`, `GMT+06:00`, `GMT+07:00`, `GMT+08:00`, `GMT+09:00`, `GMT+10:00`, `GMT+11:00`, `GMT+12:00`, `GMT-01:00`, `GMT-02:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-07:00`, `GMT-08:00`, `GMT-09:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`
 
 
 
@@ -121,7 +121,7 @@ Required:
 
 - `duration` (Number) Duration (minutes)
 - `start_time` (String) Start time (24-hour clock)
-- `time_zone` (String) Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+07:00`, `GMT+09:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-08:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`
+- `time_zone` (String) Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+03:00`, `GMT+04:00`, `GMT+05:00`, `GMT+06:00`, `GMT+07:00`, `GMT+08:00`, `GMT+09:00`, `GMT+10:00`, `GMT+11:00`, `GMT+12:00`, `GMT-01:00`, `GMT-02:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-07:00`, `GMT-08:00`, `GMT-09:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`
 
 
 
@@ -186,5 +186,5 @@ Required:
 
 - `duration` (Number) Duration (minutes)
 - `start_time` (String) Start time (24-hour clock)
-- `time_zone` (String) Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+07:00`, `GMT+09:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-08:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`
+- `time_zone` (String) Time zone. Possible values: `GMT+00:00`, `GMT+01:00`, `GMT+02:00`, `GMT+03:00`, `GMT+04:00`, `GMT+05:00`, `GMT+06:00`, `GMT+07:00`, `GMT+08:00`, `GMT+09:00`, `GMT+10:00`, `GMT+11:00`, `GMT+12:00`, `GMT-01:00`, `GMT-02:00`, `GMT-03:00`, `GMT-04:00`, `GMT-05:00`, `GMT-06:00`, `GMT-07:00`, `GMT-08:00`, `GMT-09:00`, `GMT-10:00`, `GMT-11:00`, `GMT-12:00`
  

--- a/dynatrace/api/builtin/osservicesmonitoring/settings/host_metadata_condition.go
+++ b/dynatrace/api/builtin/osservicesmonitoring/settings/host_metadata_condition.go
@@ -33,7 +33,8 @@ func (me *HostMetadataCondition) Schema() map[string]*schema.Schema {
 		"key_must_exist": {
 			Type:        schema.TypeBool,
 			Description: "When enabled, the condition requires a resource attribute to exist and match the constraints; when disabled, the key is optional but must still match the constrains if it is present.",
-			Required:    true,
+			Optional:    true,
+			Default:     true,
 		},
 		"metadata_condition": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
#### **Why** this PR?
Reverts the change that key_must_exist is required
and updates the docs

#### **What** has changed?
The field doesn't need to be set (keeping previous behavior)

#### **How** does it do it?
Reverted back to optional + default: true

#### How is it **tested**?
N/A

#### How does it affect **users**?
N/A (same as before)

**Issue:** NOISSUE