### PR TITLE
docs: update needed scopes for extension monitoring config

### DIFF
--- a/templates/resources/hub_extension_v2_config.md.tmpl
+++ b/templates/resources/hub_extension_v2_config.md.tmpl
@@ -8,7 +8,7 @@ description: |-
 
 # dynatrace_hub_extension_v2_config (Resource)
 
--> This resource requires the OAuth scopes `extensions:configurations:read` and `extensions:configurations:write`
+-> This resource requires the OAuth scopes `extensions:configurations:read`, `extensions:configurations:write`, and `extensions:definitions:read`.
 
 This resource configures a monitoring configuration for the given extension with the specified version.
 Managing of configurations will fail if the extension has not yet gotten installed for the specified version.


### PR DESCRIPTION
#### **Why** this PR?
If the underlying user and platform token (or OAuth) only specify `extension:configuration:read`/write, it's not enough to manage extension configurations.

#### **What** has changed?
Also mentions that `extensions:definitions:read` is needed for the underlying user

#### **How** does it do it?
By adding it to the docs.

#### How is it **tested**?
N/A

#### How does it affect **users**?
They will correctly see which scopes are needed for the monitoring configurations.

**Issue:** NOISSUE
