### PR TITLE
docs: Update documentation ready for v1.103.0 release

### DIFF
--- a/docs/data-sources/documents.md
+++ b/docs/data-sources/documents.md
@@ -32,7 +32,7 @@ data "dynatrace_documents" "all-notebooks" {
 
 ### Optional
 
-- `type` (String) The type of documents to query for. Leave empty if you want to query for all kinds of documents. Possible values are `dashboard` or `notebook`
+- `type` (String) The type of documents to query for. Leave empty if you want to query for all kinds of documents. Possible values are `dashboard`, `notebook` or `launchpad`
 
 ### Read-Only
 
@@ -44,7 +44,10 @@ data "dynatrace_documents" "all-notebooks" {
 
 Read-Only:
 
+- `description` (String)
 - `id` (String)
+- `is_reshareable` (Boolean)
+- `labels` (Set of String)
 - `name` (String)
 - `owner` (String)
 - `type` (String)

--- a/docs/resources/automation_scheduling_rule.md
+++ b/docs/resources/automation_scheduling_rule.md
@@ -1808,7 +1808,6 @@ resource "dynatrace_automation_scheduling_rule" "base" {
     months        = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     weekdays      = [ "MO", "TU", "WE" ]
     weeks         = [-2, -1, 1, 2, 3]
-    workdays      = "WORKING"
   }
 }
 
@@ -2490,7 +2489,7 @@ resource "dynatrace_automation_scheduling_rule" "#name#" {
 
 ### Optional
 
-- `business_calendar` (String)
+- `business_calendar` (String) The ID of the business calendar associated with the scheduling rule
 - `description` (String) An optional description for the scheduling rule
 - `fixed_offset` (Block List, Max: 1) (see [below for nested schema](#nestedblock--fixed_offset))
 - `grouping` (Block List, Max: 1) (see [below for nested schema](#nestedblock--grouping))
@@ -2530,7 +2529,6 @@ Required:
 
 - `datestart` (String) The recurrence start. Example: `2017-07-04` represents July 4th 2017
 - `frequency` (String) Possible values are `YEARLY`, `MONTHLY`, `WEEKLY`, `DAILY`, `HOURLY`, `MINUTELY` and `SECONDLY`. Example: `frequency` = `DAILY` and `interval` = `2` schedules for every other day
-- `workdays` (String) Possible values are `WORKING` (Work days), `HOLIDAYS` (Holidays) and `OFF` (Weekends + Holidays)
 
 Optional:
 
@@ -2541,6 +2539,7 @@ Optional:
 - `months` (Set of Number) Restricts the recurrence to specific months. `1` for `January`, `2` for `February`, ..., `12` for `December`
 - `weekdays` (Set of String) Restricts the recurrence to specific week days. Possible values are `MO`, `TU`, `WE`, `TH`, `FR`, `SA` and `SU`
 - `weeks` (Set of Number) Restricts the recurrence to specific weeks within a year. `1`, `2`, `3`, ... refers to the first, second, third week of the year. You can also specify negative values to refer to values relative to the last week. `-1` refers to the last week, `-2` refers to the second to the last week, ...
+- `workdays` (String) Possible values are `WORKING` (Work days), `HOLIDAYS` (Holidays) and `OFF` (Weekends + Holidays)
 
 
 <a id="nestedblock--relative_offset"></a>

--- a/docs/resources/document.md
+++ b/docs/resources/document.md
@@ -22,9 +22,12 @@ description: |-
 
 ```terraform
 resource "dynatrace_document" "this" {
-  type = "dashboard"
-  name = "Example Dashboard"
-  custom_id = "#name#"
+  type           = "dashboard"
+  name           = "Example Dashboard"
+  custom_id      = "#name#"
+  description    = "Initial description"
+  labels         = ["monitoring", "cloud", "draft"]
+  is_reshareable = true
   content = jsonencode(
     {
       "version" : 13,
@@ -179,6 +182,9 @@ resource "dynatrace_document" "this" {
 ### Optional
 
 - `custom_id` (String) If provided, this will be the id of the document. If not provided, a system-generated id is used.
+- `description` (String) A short description of the document
+- `is_reshareable` (Boolean) Specifies whether recipients of a direct share can share the document further
+- `labels` (Set of String) Labels attached to the document
 - `private` (Boolean) Specifies whether the document is private or readable by everybody
 
 ### Read-Only

--- a/docs/resources/hub_extension_v2_config.md
+++ b/docs/resources/hub_extension_v2_config.md
@@ -8,7 +8,7 @@ description: |-
 
 # dynatrace_hub_extension_v2_config (Resource)
 
--> This resource requires the OAuth scopes `extensions:configurations:read` and `extensions:configurations:write`
+-> This resource requires the OAuth scopes `extensions:configurations:read`, `extensions:configurations:write`, and `extensions:definitions:read`.
 
 This resource configures a monitoring configuration for the given extension with the specified version.
 Managing of configurations will fail if the extension has not yet gotten installed for the specified version.


### PR DESCRIPTION
#### **Why** this PR?
To keep the documentation up-to-date, we need to update it based on the template and resource files

#### **What** has changed?
Docs are in line with the templates

#### **How** does it do it?
By running `tfplugindocs`

#### How is it **tested**?
NA

#### How does it affect **users**?
Documentation is up-to-date

**Issue:** PS-49596
