### PR TITLE
feat: support platform credentials for several classic resources

### DIFF
--- a/datasources/apitoken/data_source.go
+++ b/datasources/apitoken/data_source.go
@@ -21,7 +21,6 @@ import (
 	"context"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -84,7 +83,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	service, err := srv.ServiceWithClient(rest.ClassicHybridClient(clientSet))
+	service, err := srv.Service(clientSet) // use srv.ServiceWithClient(rest.ClassicHybridClient(clientSet)) once the API is fixed
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/datasources/apitoken/data_source.go
+++ b/datasources/apitoken/data_source.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -83,7 +84,7 @@ func DataSourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	service, err := srv.Service(clientSet)
+	service, err := srv.ServiceWithClient(rest.ClassicHybridClient(clientSet))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/datasources/apitoken/data_source_multiple.go
+++ b/datasources/apitoken/data_source_multiple.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
@@ -52,7 +53,7 @@ func DataSourceReadMultiple(ctx context.Context, d *schema.ResourceData, m any) 
 		return diag.FromErr(err)
 	}
 
-	service, err := srv.Service(clientSet)
+	service, err := srv.ServiceWithClient(rest.ClassicHybridClient(clientSet))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/datasources/apitoken/data_source_multiple.go
+++ b/datasources/apitoken/data_source_multiple.go
@@ -21,7 +21,6 @@ import (
 	"context"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
@@ -53,7 +52,7 @@ func DataSourceReadMultiple(ctx context.Context, d *schema.ResourceData, m any) 
 		return diag.FromErr(err)
 	}
 
-	service, err := srv.ServiceWithClient(rest.ClassicHybridClient(clientSet))
+	service, err := srv.Service(clientSet) // use srv.ServiceWithClient(rest.ClassicHybridClient(clientSet)) once the API is fixed
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/datasources/apitoken/data_source_test.go
+++ b/datasources/apitoken/data_source_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package apitoken_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccApiTokenDataSource(t *testing.T) {
+	api.AccEnvsGiven(t)
+
+	setup, identifier := api.ReadTfConfig(t, "./testdata/api_token_setup.tf")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: api.GetProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				// First we have to create the API token with a classic token (create not possible with OAuth)
+				Config: setup,
+				Check: func(state *terraform.State) error {
+					// then we can check the data sources with platform and classic credentials
+					api.TestAccClassicHybrid(t, api.TestAccOptions{Identifier: identifier})
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/datasources/apitoken/data_source_test.go
+++ b/datasources/apitoken/data_source_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestAccApiTokenDataSource(t *testing.T) {
+	t.Skip("API doesn't return tokens when queried via OAuth")
 	api.AccEnvsGiven(t)
 
 	setup, identifier := api.ReadTfConfig(t, "./testdata/api_token_setup.tf")

--- a/datasources/apitoken/testdata/api_token_setup.tf
+++ b/datasources/apitoken/testdata/api_token_setup.tf
@@ -1,0 +1,4 @@
+resource "dynatrace_api_token" "example" {
+  name   = "#name#"
+  scopes = ["apiTokens.read"]
+}

--- a/datasources/apitoken/testdata/terraform/example.tf
+++ b/datasources/apitoken/testdata/terraform/example.tf
@@ -1,0 +1,18 @@
+locals {
+  token_name = "#name#"
+}
+
+data "dynatrace_api_token" "example" {
+  name = local.token_name
+}
+
+data "dynatrace_api_tokens" "example" {
+}
+
+output "auth_token" {
+  value = data.dynatrace_api_token.example.creation_date
+}
+
+output "filtered_api_token" {
+  value = [for token in data.dynatrace_api_tokens.example.api_tokens : token if token.name == local.token_name][0].name
+}

--- a/datasources/deployment/lambdaagent/data_source_test.go
+++ b/datasources/deployment/lambdaagent/data_source_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lambdaagent_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccLambdaAgentVersion(t *testing.T) {
+	api.TestAccClassicHybrid(t)
+}

--- a/datasources/deployment/lambdaagent/testdata/terraform/example.tf
+++ b/datasources/deployment/lambdaagent/testdata/terraform/example.tf
@@ -1,0 +1,6 @@
+data "dynatrace_lambda_agent_version" "example" {
+}
+
+output "latest" {
+  value = data.dynatrace_lambda_agent_version.example.collector
+}

--- a/dynatrace/api/builtin/davis/anomalydetectors/service_test.go
+++ b/dynatrace/api/builtin/davis/anomalydetectors/service_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 func TestAccDavisAnomalyDetectors(t *testing.T) {
@@ -31,7 +32,7 @@ func TestAccDavisAnomalyDetectors(t *testing.T) {
 
 // TestAccDavisAnomalyDetectorsWithPreferToken tests the token => OAuth fallback logic
 func TestAccDavisAnomalyDetectorsWithPreferToken(t *testing.T) {
-	t.Setenv("DYNATRACE_HTTP_OAUTH_PREFERENCE", "false")
+	t.Setenv(envutils.DynatraceHTTPOAuthPreference.Key, "false")
 	api.TestAcc(t)
 }
 

--- a/dynatrace/api/v1/config/customservices/order/service.go
+++ b/dynatrace/api/v1/config/customservices/order/service.go
@@ -34,7 +34,7 @@ const StaticName = "custom_service_order"
 const BasePath = "/api/config/v1/service/customServices/%s"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*order.Settings], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.ClassicHybridClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/customservices/order/service_test.go
+++ b/dynatrace/api/v1/config/customservices/order/service_test.go
@@ -1,0 +1,29 @@
+//go:build sequential_integration
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customservices_order_test
+
+import (
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing/api"
+)
+
+func TestAccCustomServices(t *testing.T) {
+	api.TestAccClassicHybrid(t)
+}

--- a/dynatrace/api/v1/config/customservices/order/testdata/terraform/example.tf
+++ b/dynatrace/api/v1/config/customservices/order/testdata/terraform/example.tf
@@ -1,0 +1,62 @@
+resource "dynatrace_custom_service_order" "this" {
+  dotnet = [
+    dynatrace_custom_service.dotnet[0].id,
+    dynatrace_custom_service.dotnet[1].id,
+  ]
+  java = [
+    dynatrace_custom_service.java[0].id,
+    dynatrace_custom_service.java[1].id,
+  ]
+}
+
+resource "dynatrace_custom_service" "java" {
+  count      = 2
+  name       = "java-#name#-${count.index}"
+  technology = "java"
+  enabled    = true
+  rule {
+    enabled = true
+    class {
+      name  = "com.example.Prefix"
+      match = "EQUALS"
+    }
+    method {
+      name      = "methodA"
+      arguments = ["java.lang.String", "java.lang.String"]
+      returns   = "java.lang.String"
+    }
+    method {
+      name      = "methodB"
+      arguments = []
+      returns   = "void"
+    }
+    annotations = ["com.example.ExampleAnnotation"]
+  }
+  queue_entry_point = false
+}
+
+resource "dynatrace_custom_service" "dotnet" {
+  count      = 2
+  name       = "dotnet-#name#-${count.index}"
+  technology = "dotNet"
+  enabled    = true
+  rule {
+    enabled = true
+    class {
+      name  = "com.example.Prefix"
+      match = "EQUALS"
+    }
+    method {
+      name      = "methodA"
+      arguments = ["java.lang.String", "java.lang.String"]
+      returns   = "java.lang.String"
+    }
+    method {
+      name      = "methodB"
+      arguments = []
+      returns   = "void"
+    }
+    annotations = ["com.example.ExampleAnnotation"]
+  }
+  queue_entry_point = false
+}

--- a/dynatrace/api/v1/config/customservices/service.go
+++ b/dynatrace/api/v1/config/customservices/service.go
@@ -37,7 +37,7 @@ type service struct {
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*customservices.CustomService], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.ClassicHybridClient(clientSet)}, nil
 }
 
 func (me *service) Get(ctx context.Context, id string, v *customservices.CustomService) error {

--- a/dynatrace/api/v1/config/customservices/service_test.go
+++ b/dynatrace/api/v1/config/customservices/service_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestAccCustomServices(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAccClassicHybrid(t)
 }

--- a/dynatrace/api/v1/config/deployment/lambdaagent/service.go
+++ b/dynatrace/api/v1/config/deployment/lambdaagent/service.go
@@ -30,7 +30,7 @@ const SchemaID = "v1:deployment:lambdaagent"
 const BasePath = "/api/v1/deployment/lambda/agent/latest"
 
 func Service(clientSet rest.ClientSet) (settings.RService[*lambdaagent.Latest], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.ClassicHybridClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/requestattributes/service.go
+++ b/dynatrace/api/v1/config/requestattributes/service.go
@@ -32,7 +32,7 @@ const BasePath = "/api/config/v1/service/requestAttributes"
 var mu sync.Mutex
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*requestattributes.RequestAttribute], error) {
-	return settings.NewAPITokenService(
+	return settings.NewClassicHybridService(
 		clientSet,
 		SchemaID,
 		&settings.ServiceOptions[*requestattributes.RequestAttribute]{

--- a/dynatrace/api/v1/config/requestattributes/service_test.go
+++ b/dynatrace/api/v1/config/requestattributes/service_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestAccRequestAttributes(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAccClassicHybrid(t)
 }

--- a/dynatrace/api/v1/config/requestnaming/order/service.go
+++ b/dynatrace/api/v1/config/requestnaming/order/service.go
@@ -30,7 +30,7 @@ import (
 const SchemaID = "v1:config:service:request-naming:order"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*order.Order], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.ClassicHybridClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/requestnaming/order/service_test.go
+++ b/dynatrace/api/v1/config/requestnaming/order/service_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build sequential_integration
 
 /**
 * @license
@@ -26,5 +26,5 @@ import (
 )
 
 func TestAccRequestNamingOrder(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAccClassicHybrid(t)
 }

--- a/dynatrace/api/v1/config/requestnaming/order/testdata/terraform/example.tf
+++ b/dynatrace/api/v1/config/requestnaming/order/testdata/terraform/example.tf
@@ -1,0 +1,25 @@
+resource "dynatrace_request_namings" "order" {
+  ids = [
+    dynatrace_request_naming.terraform-request-naming-global[0].id,
+    dynatrace_request_naming.terraform-request-naming-global[1].id
+  ]
+}
+
+resource "dynatrace_request_naming" "terraform-request-naming-global" {
+  enabled        = true
+  count          = 2
+  naming_pattern = "terraform-request-naming-global-#name#-${count.index}"
+  conditions {
+    condition {
+      attribute = "ONE_AGENT_ATTRIBUTE"
+      comparison {
+        string_one_agent_attribute {
+          case_sensitive          = false
+          operator                = "CONTAINS"
+          one_agent_attribute_key = "http.route"
+          value                   = "/services/*"
+        }
+      }
+    }
+  }
+}

--- a/dynatrace/api/v1/config/requestnaming/service.go
+++ b/dynatrace/api/v1/config/requestnaming/service.go
@@ -33,7 +33,7 @@ const SchemaID = "v1:config:service:request-naming"
 const BasePath = "/api/config/v1/service/requestNaming"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*requestnaming.RequestNaming], error) {
-	svc, err := settings.NewAPITokenService(
+	svc, err := settings.NewClassicHybridService(
 		clientSet,
 		SchemaID,
 		settings.DefaultServiceOptions[*requestnaming.RequestNaming](BasePath),
@@ -42,7 +42,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*requestnaming.Requ
 		return nil, err
 	}
 
-	return &service{service: svc, client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{service: svc, client: rest.ClassicHybridClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/requestnaming/service_test.go
+++ b/dynatrace/api/v1/config/requestnaming/service_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestAccRequestNaming(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAccClassicHybrid(t)
 }

--- a/dynatrace/api/v2/activegatetokens/service.go
+++ b/dynatrace/api/v2/activegatetokens/service.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*activegatetokens.Settings], error) {
-	return &service{clientSet}, nil
+	return &service{client: rest.ClassicHybridClient(clientSet)}, nil
 }
 
 type TokenCreateResponse struct {
@@ -44,19 +44,18 @@ type TenantTokenResponse struct {
 }
 
 type service struct {
-	clientSet rest.ClientSet
+	client rest.Client
 }
 
 func (me *service) Get(ctx context.Context, id string, v *activegatetokens.Settings) error {
 	var err error
 
-	client := rest.APITokenClient(me.clientSet.Credentials())
-	req := client.Get(ctx, fmt.Sprintf("/api/v2/activeGateTokens/%s", url.PathEscape(id))).Expect(200)
+	req := me.client.Get(ctx, fmt.Sprintf("/api/v2/activeGateTokens/%s", url.PathEscape(id))).Expect(200)
 	if err = req.Finish(v); err != nil {
 		return err
 	}
 	var ttr TenantTokenResponse
-	req = client.Get(ctx, "/api/v1/deployment/installer/agent/connectioninfo").Expect(200)
+	req = me.client.Get(ctx, "/api/v1/deployment/installer/agent/connectioninfo").Expect(200)
 	if err = req.Finish(&ttr); err == nil {
 		v.TenantToken = &ttr.TenantToken
 	}
@@ -80,15 +79,14 @@ func (me *service) Create(ctx context.Context, v *activegatetokens.Settings) (*a
 	var err error
 
 	response := TokenCreateResponse{}
-	client := rest.APITokenClient(me.clientSet.Credentials())
-	if err = client.Post(ctx, "/api/v2/activeGateTokens", v, 201).Finish(&response); err != nil {
+	if err = me.client.Post(ctx, "/api/v2/activeGateTokens", v, 201).Finish(&response); err != nil {
 		return nil, err
 	}
 	v.ExpirationDate = response.ExpirationDate
 	v.Token = response.Token
 
 	var ttr TenantTokenResponse
-	req := client.Get(ctx, "/api/v1/deployment/installer/agent/connectioninfo").Expect(200)
+	req := me.client.Get(ctx, "/api/v1/deployment/installer/agent/connectioninfo").Expect(200)
 	if err = req.Finish(&ttr); err == nil {
 		v.TenantToken = &ttr.TenantToken
 	}
@@ -101,7 +99,7 @@ func (me *service) Update(ctx context.Context, id string, v *activegatetokens.Se
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return rest.APITokenClient(me.clientSet.Credentials()).Delete(ctx, fmt.Sprintf("/api/v2/activeGateTokens/%s", url.PathEscape(id)), 204).Finish()
+	return me.client.Delete(ctx, fmt.Sprintf("/api/v2/activeGateTokens/%s", url.PathEscape(id)), 204).Finish()
 }
 
 func (me *service) New() *activegatetokens.Settings {

--- a/dynatrace/api/v2/activegatetokens/service_test.go
+++ b/dynatrace/api/v2/activegatetokens/service_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestAccAGTokens(t *testing.T) {
-	api.TestAcc(t)
+	api.TestAccClassicHybrid(t)
 }

--- a/dynatrace/api/v2/apitokens/service.go
+++ b/dynatrace/api/v2/apitokens/service.go
@@ -29,18 +29,21 @@ import (
 )
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*apitokens.APIToken], error) {
-	return &service{clientSet}, nil
+	return ServiceWithClient(rest.APITokenClient(clientSet.Credentials()))
+}
+
+func ServiceWithClient(client rest.Client) (settings.CRUDService[*apitokens.APIToken], error) {
+	return &service{client}, nil
 }
 
 type service struct {
-	clientSet rest.ClientSet
+	client rest.Client
 }
 
 func (me *service) Get(ctx context.Context, id string, v *apitokens.APIToken) error {
 	var err error
 
-	client := rest.APITokenClient(me.clientSet.Credentials())
-	req := client.Get(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id)).Expect(200)
+	req := me.client.Get(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id)).Expect(200)
 	if err = req.Finish(v); err != nil {
 		return err
 	}
@@ -55,8 +58,7 @@ func (me *service) SchemaID() string {
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 
-	client := rest.APITokenClient(me.clientSet.Credentials())
-	req := client.Get(ctx, "/api/v2/apiTokens?pageSize=10000&fields=%2Bscopes%2C%2BexpirationDate%2C%2BpersonalAccessToken&sort=-creationDate").Expect(200)
+	req := me.client.Get(ctx, "/api/v2/apiTokens?pageSize=10000&fields=%2Bscopes%2C%2BexpirationDate%2C%2BpersonalAccessToken&sort=-creationDate").Expect(200)
 	var tokenlist apitokens.TokenList
 	if err = req.Finish(&tokenlist); err != nil {
 		return nil, err
@@ -77,14 +79,13 @@ func (me *service) Create(ctx context.Context, v *apitokens.APIToken) (*api.Stub
 	var err error
 
 	resultToken := apitokens.APIToken{}
-	client := rest.APITokenClient(me.clientSet.Credentials())
-	if err = client.Post(ctx, "/api/v2/apiTokens", v, 201).Finish(&resultToken); err != nil {
+	if err = me.client.Post(ctx, "/api/v2/apiTokens", v, 201).Finish(&resultToken); err != nil {
 		return nil, err
 	}
 	item := v
 	if item.Enabled == nil || !*item.Enabled {
 		item.Enabled = new(false)
-		if err = client.Put(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", *resultToken.ID), item, 204).Finish(); err != nil {
+		if err = me.client.Put(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", *resultToken.ID), item, 204).Finish(); err != nil {
 			return nil, err
 		}
 		resultToken.Enabled = item.Enabled
@@ -96,11 +97,11 @@ func (me *service) Create(ctx context.Context, v *apitokens.APIToken) (*api.Stub
 }
 
 func (me *service) Update(ctx context.Context, id string, v *apitokens.APIToken) error {
-	return rest.APITokenClient(me.clientSet.Credentials()).Put(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id), v, 204).Finish()
+	return me.client.Put(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id), v, 204).Finish()
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return rest.APITokenClient(me.clientSet.Credentials()).Delete(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id), 204).Finish()
+	return me.client.Delete(ctx, fmt.Sprintf("/api/v2/apiTokens/%s", id), 204).Finish()
 }
 
 func (me *service) New() *apitokens.APIToken {

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -151,7 +151,7 @@ func (me *classic_request) Finish(optionalTarget ...any) error {
 	if len(optionalTarget) > 0 {
 		target = optionalTarget[0]
 	}
-	classicURL := evalClassicURL(me.client.Credentials().URL)
+	classicURL := EvalClassicURL(me.client.Credentials().URL)
 
 	client, err := createClassicClient(classicURL, me.client.Credentials().Token)
 	if err != nil {
@@ -169,7 +169,7 @@ func (me *classic_request) Finish(optionalTarget ...any) error {
 	return request(*me).HandleResponse(client, pathURL, target)
 }
 
-func evalClassicURL(envURL string) string {
+func EvalClassicURL(envURL string) string {
 	envURL = strings.TrimSuffix(strings.TrimSpace(envURL), "/")
 	if len(envURL) == 0 {
 		return envURL

--- a/dynatrace/rest/classic_hybrid_client.go
+++ b/dynatrace/rest/classic_hybrid_client.go
@@ -19,6 +19,8 @@ package rest
 
 import (
 	"context"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 )
 
 // ClassicHybridClient prefers classic over platform requests and doesn't consider the DYNATRACE_HTTP_OAUTH_PREFERENCE env variable.
@@ -53,5 +55,5 @@ func (me *classic_hybrid_client) Delete(ctx context.Context, url string, expecte
 }
 
 func newDisableOAuthPreferenceContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, "DYNATRACE_HTTP_OAUTH_PREFERENCE", false)
+	return context.WithValue(ctx, envutils.DynatraceHTTPOAuthPreference.Key, false)
 }

--- a/dynatrace/rest/classic_hybrid_client.go
+++ b/dynatrace/rest/classic_hybrid_client.go
@@ -1,0 +1,57 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package rest
+
+import (
+	"context"
+)
+
+// ClassicHybridClient prefers classic over platform requests and doesn't consider the DYNATRACE_HTTP_OAUTH_PREFERENCE env variable.
+func ClassicHybridClient(clientSet ClientSet) Client {
+	credentials := clientSet.Credentials()
+	return &classic_hybrid_client{client: HybridClient(credentials), credentials: credentials}
+}
+
+type classic_hybrid_client struct {
+	client      Client
+	credentials *Credentials
+}
+
+func (me *classic_hybrid_client) Credentials() *Credentials {
+	return me.credentials
+}
+
+func (me *classic_hybrid_client) Get(ctx context.Context, url string, expectedStatusCodes ...int) Request {
+	return me.client.Get(newDisableOAuthPreferenceContext(ctx), url, expectedStatusCodes...)
+}
+
+func (me *classic_hybrid_client) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
+	return me.client.Post(newDisableOAuthPreferenceContext(ctx), url, payload, expectedStatusCodes...)
+}
+
+func (me *classic_hybrid_client) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
+	return me.client.Put(newDisableOAuthPreferenceContext(ctx), url, payload, expectedStatusCodes...)
+}
+
+func (me *classic_hybrid_client) Delete(ctx context.Context, url string, expectedStatusCodes ...int) Request {
+	return me.client.Delete(newDisableOAuthPreferenceContext(ctx), url, expectedStatusCodes...)
+}
+
+func newDisableOAuthPreferenceContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, "DYNATRACE_HTTP_OAUTH_PREFERENCE", false)
+}

--- a/dynatrace/rest/hybrid_client.go
+++ b/dynatrace/rest/hybrid_client.go
@@ -73,7 +73,7 @@ func (me *hybrid_client) Delete(ctx context.Context, url string, expectedStatusC
 
 func (me *hybrid_request) Finish(optionalTarget ...any) error {
 	isOAuthPreferred := envutils.DynatraceHTTPOAuthPreference.Get()
-	if v := me.ctx.Value("DYNATRACE_HTTP_OAUTH_PREFERENCE"); v != nil {
+	if v := me.ctx.Value(envutils.DynatraceHTTPOAuthPreference.Key); v != nil {
 		if bv, ok := v.(bool); ok {
 			isOAuthPreferred = bv
 		}
@@ -133,5 +133,5 @@ func (me *hybrid_request) SetHeader(name string, value string) {
 }
 
 func NewPreferOAuthContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, "DYNATRACE_HTTP_OAUTH_PREFERENCE", true)
+	return context.WithValue(ctx, envutils.DynatraceHTTPOAuthPreference.Key, true)
 }

--- a/dynatrace/rest/hybrid_client_test.go
+++ b/dynatrace/rest/hybrid_client_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -161,7 +162,7 @@ func TestHybridClient(t *testing.T) {
 		}
 		t.Run(testCaseName, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.WithValue(t.Context(), "DYNATRACE_HTTP_OAUTH_PREFERENCE", testcase.IsOAuthPreferred)
+			ctx := context.WithValue(t.Context(), envutils.DynatraceHTTPOAuthPreference.Key, testcase.IsOAuthPreferred)
 			expect(t, testcase.Expected, HybridClient(testcase.Credentials()).Get(ctx, "").Finish())
 		})
 	}

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -32,8 +32,8 @@ import (
 )
 
 var eligiblePlatformRequests = map[string]string{
-	"/api/v2/settings/objects": "/platform/classic/environment-api/v2/settings/objects",
-	"/api/v2/settings/schemas": "/platform/classic/environment-api/v2/settings/schemas",
+	"/api/v2/": "/platform/classic/environment-api/v2/",
+	"/api/v1/": "/platform/classic/environment-api/v1/",
 }
 
 type platform_request request
@@ -74,7 +74,13 @@ func (me *platform_request) Finish(optionalTarget ...any) error {
 		target = optionalTarget[0]
 	}
 
-	platformURL := me.evalPlatformURL(me.client.Credentials().URL)
+	var platformURL string
+	// config v1 are not reachable on platform, so we need to use the classic URL for those requests
+	if strings.Contains(me.url, "/api/config/v1/") {
+		platformURL = EvalClassicURL(me.client.Credentials().URL)
+	} else {
+		platformURL = me.evalPlatformURL(me.client.Credentials().URL)
+	}
 
 	client, err := CreatePlatformClient(me.ctx, platformURL, me.client.Credentials())
 	if err != nil {

--- a/dynatrace/settings/default_service.go
+++ b/dynatrace/settings/default_service.go
@@ -33,7 +33,15 @@ import (
 var ExportRunning = false
 
 func NewAPITokenService[T Settings](clientSet rest.ClientSet, schemaID string, options *ServiceOptions[T]) (CRUDService[T], error) {
-	return &defaultService[T]{schemaID: schemaID, client: rest.APITokenClient(clientSet.Credentials()), options: options}, nil
+	return newServiceWithClient[T](rest.APITokenClient(clientSet.Credentials()), schemaID, options)
+}
+
+func NewClassicHybridService[T Settings](clientSet rest.ClientSet, schemaID string, options *ServiceOptions[T]) (CRUDService[T], error) {
+	return newServiceWithClient[T](rest.ClassicHybridClient(clientSet), schemaID, options)
+}
+
+func newServiceWithClient[T Settings](client rest.Client, schemaID string, options *ServiceOptions[T]) (CRUDService[T], error) {
+	return &defaultService[T]{schemaID: schemaID, client: client, options: options}, nil
 }
 
 type defaultService[T Settings] struct {

--- a/dynatrace/testing/api/settingstest.go
+++ b/dynatrace/testing/api/settingstest.go
@@ -42,6 +42,8 @@ type TestCaseAccOptions struct {
 type TestAccOptions struct {
 	ExpectNonEmptyPlan bool
 	ExternalProviders  map[string]resource.ExternalProvider
+	// preset identifier to replace "#name#" and "${randomize}" in the config, if empty a random string will be generated
+	Identifier string
 }
 
 func AccEnvsGiven(t *testing.T) bool {
@@ -126,12 +128,33 @@ func TestAcc(t *testing.T, opts ...TestAccOptions) {
 		t.Run(subTestName, func(t *testing.T) {
 			t.Helper()
 
-			config, _ := ReadTfConfig(t, file)
+			var config string
+			if len(opts) > 0 && opts[0].Identifier != "" {
+				// if an identifier is provided, use it to replace "#name#" and "${randomize}"
+				config = ReadTfConfigWithIdentifier(t, file, opts[0].Identifier)
+			} else {
+				// otherwise, generate a random identifier
+				config, _ = ReadTfConfig(t, file)
+			}
 
 			testCase := createTestCaseWithOptions(t, config, opts)
 			resource.Test(t, testCase)
 		})
 	}
+}
+
+// TestAccClassicHybrid executes all test files in the `testdata` with classic credentials and platform credentials.
+// Disables the envs set in the GitHub pipeline to ensure that the tests are executed with both credentials.
+func TestAccClassicHybrid(t *testing.T, opts ...TestAccOptions) {
+	t.Run("Classic", func(t *testing.T) {
+		t.Setenv("DT_CLIENT_SECRET", "")
+		TestAcc(t, opts...)
+	})
+
+	t.Run("Platform", func(t *testing.T) {
+		t.Setenv("DYNATRACE_API_TOKEN", "")
+		TestAcc(t, opts...)
+	})
 }
 
 // TestAccSingle executes a single test/example file.  e.g., "testdata/terraform/example.tf"

--- a/templates/data-sources/api_token.md.tmpl
+++ b/templates/data-sources/api_token.md.tmpl
@@ -9,7 +9,6 @@ description: |-
 # dynatrace_api_token (Data Source)
 
 -> This data source requires the API token scope **Read API tokens** (`apiTokens.read`)
-or the OAuth scope `api-tokens:tokens:read`
 
 The API token data source allows a single access token to be retrieved by its name, note the token value is not included in the response.
 

--- a/templates/data-sources/api_token.md.tmpl
+++ b/templates/data-sources/api_token.md.tmpl
@@ -8,6 +8,9 @@ description: |-
 
 # dynatrace_api_token (Data Source)
 
+-> This data source requires the API token scope **Read API tokens** (`apiTokens.read`)
+or the OAuth scope `api-tokens:tokens:read`
+
 The API token data source allows a single access token to be retrieved by its name, note the token value is not included in the response.
 
 If multiple tokens match the given name, the first result will be retrieved. To retrieve multiple tokens of the same name, please utilize the `dynatrace_api_tokens` data source.

--- a/templates/data-sources/api_tokens.md.tmpl
+++ b/templates/data-sources/api_tokens.md.tmpl
@@ -8,6 +8,9 @@ description: |-
 
 # dynatrace_api_tokens (Data Source)
 
+-> This data source requires the API token scope **Read API tokens** (`apiTokens.read`)
+or the OAuth scope `api-tokens:tokens:read`
+
 The API tokens data source allows all access tokens to be retrieved, note the token value is not included in the response.
 
 ## Example Usage

--- a/templates/data-sources/api_tokens.md.tmpl
+++ b/templates/data-sources/api_tokens.md.tmpl
@@ -9,7 +9,6 @@ description: |-
 # dynatrace_api_tokens (Data Source)
 
 -> This data source requires the API token scope **Read API tokens** (`apiTokens.read`)
-or the OAuth scope `api-tokens:tokens:read`
 
 The API tokens data source allows all access tokens to be retrieved, note the token value is not included in the response.
 

--- a/templates/data-sources/lambda_agent_version.md.tmpl
+++ b/templates/data-sources/lambda_agent_version.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 # dynatrace_lambda_agent_version (Data Source)
 
 -> This data source requires the API token scope **Installer download** (`InstallerDownload`)
-or the OAuth scope `fleet-management:oneagents:download`
+or the OAuth scope `fleet-management:oneagents:download` (`environment-api:deployment:download`)
 
 The AWS Lambda agent version data source retrieves the latest version names of OneAgent code modules for the Java, Node.js, and Python runtimes, also including names for layers that are combined with the log collector, as well as for the standalone log collector layer.
 

--- a/templates/data-sources/lambda_agent_version.md.tmpl
+++ b/templates/data-sources/lambda_agent_version.md.tmpl
@@ -8,6 +8,9 @@ description: |-
 
 # dynatrace_lambda_agent_version (Data Source)
 
+-> This data source requires the API token scope **Installer download** (`InstallerDownload`)
+or the OAuth scope `fleet-management:oneagents:download`
+
 The AWS Lambda agent version data source retrieves the latest version names of OneAgent code modules for the Java, Node.js, and Python runtimes, also including names for layers that are combined with the log collector, as well as for the standalone log collector layer.
 
 ## Example Usage

--- a/templates/data-sources/request_attribute.md.tmpl
+++ b/templates/data-sources/request_attribute.md.tmpl
@@ -8,6 +8,9 @@ description: |-
 
 # dynatrace_request_attribute (Data Source)
 
+-> This data source requires the API token scope **Read configuration** (`ReadConfig`)
+or the OAuth scope `settings:objects:read`
+
 The `dynatrace_request_attribute` data source allows the request attribute ID to be retrieved by its name.
 
 - `name` (String) - The name of the request attribute

--- a/templates/data-sources/request_naming.md.tmpl
+++ b/templates/data-sources/request_naming.md.tmpl
@@ -8,6 +8,9 @@ description: |-
 
 # dynatrace_request_naming (Data Source)
 
+-> This data source requires the API token scope **Read configuration** (`ReadConfig`)
+or the OAuth scope `settings:objects:read`
+
 The `dynatrace_request_naming` data source allows the request naming rule ID to be retrieved by its name.
 
 - `name` (String) - The name to be assigned to matching requests.

--- a/templates/resources/ag_token.md.tmpl
+++ b/templates/resources/ag_token.md.tmpl
@@ -13,6 +13,7 @@ description: |-
 -> The token value can be retrieved with `dynatrace_ag_token.<#name#>.token` after apply.
 
 -> This resource requires the API token scopes **Create ActiveGate tokens** (`activeGateTokenManagement.create`), **Read ActiveGate tokens** (`activeGateTokenManagement.read`) and **Write ActiveGate tokens** (`activeGateTokenManagement.write`)
+or the OAuth scopes `fleet-management:activegate.tokens:create`, `fleet-management:activegate.tokens:read`, `fleet-management:activegate.tokens:write` and `fleet-management:oneagent.connection-info:read`
 
 ## Dynatrace Documentation
 
@@ -25,4 +26,3 @@ description: |-
 {{ tffile "dynatrace/api/v2/activegatetokens/testdata/terraform/example-a.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
- 

--- a/templates/resources/ag_token.md.tmpl
+++ b/templates/resources/ag_token.md.tmpl
@@ -13,7 +13,7 @@ description: |-
 -> The token value can be retrieved with `dynatrace_ag_token.<#name#>.token` after apply.
 
 -> This resource requires the API token scopes **Create ActiveGate tokens** (`activeGateTokenManagement.create`), **Read ActiveGate tokens** (`activeGateTokenManagement.read`) and **Write ActiveGate tokens** (`activeGateTokenManagement.write`)
-or the OAuth scopes `fleet-management:activegate.tokens:create`, `fleet-management:activegate.tokens:read`, `fleet-management:activegate.tokens:write` and `fleet-management:oneagent.connection-info:read`
+or the OAuth scopes `fleet-management:activegate.tokens:create`, `fleet-management:activegate.tokens:read`, `fleet-management:activegate.tokens:write` and `fleet-management:oneagent.connection-info:read` (`environment-api:activegate-tokens:create`, `environment-api:activegate-tokens:read`, `environment-api:activegate-tokens:write`, `environment-api:deployment:download`)
 
 ## Dynatrace Documentation
 

--- a/templates/resources/custom_service.md.tmpl
+++ b/templates/resources/custom_service.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 # dynatrace_custom_service (Resource)
 
 -> This resource requires the API token scopes **Read configuration** (`ReadConfig`) and **Write configuration** (`WriteConfig`)
+or the OAuth scopes `settings:objects:read` and `settings:objects:write`
 
 ## Dynatrace Documentation
 
@@ -27,4 +28,3 @@ The full documentation of the export feature is available [here](https://dt-url.
 {{ tffile "dynatrace/api/v1/config/customservices/testdata/terraform/example_a.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
- 

--- a/templates/resources/custom_service_order.md.tmpl
+++ b/templates/resources/custom_service_order.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 # dynatrace_custom_service_order (Resource)
 
 -> This resource requires the API token scopes **Read configuration** (`ReadConfig`) and **Write configuration** (`WriteConfig`)
+or the OAuth scopes `settings:objects:read` and `settings:objects:write`
 
 ## Dynatrace Documentation
 
@@ -91,4 +92,3 @@ resource "dynatrace_custom_service" "dotnet-second" {
 ```
 
 {{ .SchemaMarkdown | trimspace }}
- 

--- a/templates/resources/request_attribute.md.tmpl
+++ b/templates/resources/request_attribute.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 # dynatrace_request_attribute (Resource)
 
 -> This resource requires the API token scopes **Read configuration** (`ReadConfig`) and **Capture request data** (`CaptureRequestData`)
+or the OAuth scopes `settings:objects:read` and `settings:objects:write`
 
 ## Dynatrace Documentation
 
@@ -27,4 +28,3 @@ The full documentation of the export feature is available [here](https://dt-url.
 {{ tffile "dynatrace/api/v1/config/requestattributes/testdata/terraform/example_a.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
- 

--- a/templates/resources/request_naming.md.tmpl
+++ b/templates/resources/request_naming.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 # dynatrace_request_naming (Resource)
 
 -> This resource requires the API token scopes **Read configuration** (`ReadConfig`) and **Write configuration** (`WriteConfig`)
+or the OAuth scopes `settings:objects:read` and `settings:objects:write`
 
 ## Dynatrace Documentation
 
@@ -23,4 +24,3 @@ description: |-
 The full documentation of the export feature is available [here](https://dt-url.net/h203qmc).
 
 {{ .SchemaMarkdown | trimspace }}
- 

--- a/templates/resources/request_namings.md.tmpl
+++ b/templates/resources/request_namings.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 # dynatrace_request_namings (Resource)
 
 -> This resource requires the API token scopes **Read configuration** (`ReadConfig`) and **Write configuration** (`WriteConfig`)
+or the OAuth scopes `settings:objects:read` and `settings:objects:write`
 
 ## Dynatrace Documentation
 
@@ -17,4 +18,3 @@ description: |-
 - Request naming API - https://www.dynatrace.com/support/help/dynatrace-api/configuration-api/service-api/request-naming-api
 
 {{ .SchemaMarkdown | trimspace }}
- 


### PR DESCRIPTION
#### **Why** this PR?
Some resources on config V1 and environment API V1 support OAuth and platform tokens. We should support that.

#### **What** has changed?
Adds OAuth and platform token support for the following resources
- dynatrace_ag_token
- dynatrace_custom_service, dynatrace_custom_service_order
- dynatrace_request_naming, dynatrace_request_namings
- dynatrace_request_attribute

and data sources
- ~~dynatrace_api_token / dynatrace_api_tokens~~ support not added for now
- dynatrace_lambda_agent_version
- dynatrace_request_attribute
- dynatrace_request_naming

#### **How** does it do it?
By making use of the hybrid client but by disabling the environment variable `DYNATRACE_HTTP_OAUTH_PREFERENCE`, so that previous configurations are working as before.

#### How is it **tested**?
New integration tests added that test the affected resources with platform and classic credentials.

#### How does it affect **users**?
They can use platform credentials to manage the mentioned resources

**Issue:** PS-49501