### PR TITLE
chore: update core lib dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/dynatrace-oss/terraform-provider-dynatrace
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f
+	github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260817092727-9b1e65008abc
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f h1:rhHqP/RvovDcRWVUOSjWTMvsRPxWoBh1cE2pCUhBEuY=
-github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260810104307-a9c67f731f2f/go.mod h1:KhaE60mnB3XYk2dlMnHzvvJ2OYXSiaMXX4BLZkWuwLo=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260817092727-9b1e65008abc h1:lWhl0sH00VlT7vAmpEfOXhGm8Fi1vYikaGNjl2O8rCg=
+github.com/dynatrace/dynatrace-configuration-as-code-core v0.9.1-0.20260817092727-9b1e65008abc/go.mod h1:ahjPUFCbDUsAKjRvmuyDT88mlJV9GA5ZE6T2J1sMxWE=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
#### **Why** this PR, **What** has changed, **How**?
Core lib Go version was updated to 1.26.6 to address vulnerabilities, so in turn the terraform provider updates the core lib dependency.

#### How is it **tested**?
CI pipeline

#### How does it affect **users**?
It shouldn't

**Issue:** N/A
