### PR TITLE
Retry transient settings requests safely

### DIFF
--- a/dynatrace/api/builtin/generic/service.go
+++ b/dynatrace/api/builtin/generic/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
+	"github.com/google/uuid"
 )
 
 const settingsObjectEndpoint = "/api/v2/settings/objects"
@@ -154,26 +155,29 @@ func (me *service) Validate(v *generic.Settings) error {
 }
 
 func (me *service) Create(ctx context.Context, v *generic.Settings) (*api.Stub, error) {
-	stubs, err := me.create(ctx, v)
+	// Reuse one external ID when the initial classic request falls back to OAuth.
+	externalID := uuid.NewString()
+	stubs, err := me.create(ctx, v, externalID)
 	if err == nil {
 		return stubs, nil
 	}
 	if rest.IsRequiresOAuthError(err) && me.clientSet.Credentials().ContainsOAuthOrPlatformToken() {
 		ctx := rest.NewPreferOAuthContext(ctx)
-		return me.create(ctx, v)
+		return me.create(ctx, v, externalID)
 	}
 	return nil, err
 }
 
-func (me *service) create(ctx context.Context, v *generic.Settings) (*api.Stub, error) {
+func (me *service) create(ctx context.Context, v *generic.Settings, externalID string) (*api.Stub, error) {
 	scope := "environment"
 	if len(v.Scope) > 0 {
 		scope = v.Scope
 	}
 	obj := []settings20.SettingsObjectCreate{{
-		SchemaID: v.SchemaID,
-		Scope:    scope,
-		Value:    json.RawMessage(v.Value),
+		ExternalID: externalID,
+		SchemaID:   v.SchemaID,
+		Scope:      scope,
+		Value:      json.RawMessage(v.Value),
 	}}
 
 	var response []settings20.SettingsObjectCreateResponse

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -20,6 +20,7 @@ package rest
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -51,7 +52,7 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 		return factory.
 			WithHTTPListener(logging.HTTPListener("plat/tok")).
 			WithPlatformToken(credentials.Platform.PlatformToken).
-			CreatePlatformClient(ctx)
+			CreatePlatformClient(NewContextWithOAuthRetryClient(ctx))
 	}
 
 	if credentials.ContainsOAuth() {
@@ -96,7 +97,11 @@ func (me *platform_request) Finish(optionalTarget ...any) error {
 	if err != nil {
 		return err
 	}
-	return request(*me).HandleResponse(client, fullURL, target)
+	platformRequest := request(*me)
+	if me.method == http.MethodPost && (me.url == "/api/v2/settings/objects" || strings.HasPrefix(me.url, "/api/v2/settings/objects?")) {
+		platformRequest.ctx = withNonIdempotentRetry(platformRequest.ctx)
+	}
+	return platformRequest.HandleResponse(client, fullURL, target)
 }
 
 func (me *platform_request) evalPlatformURL(envURL string) string {

--- a/dynatrace/rest/retry_transport.go
+++ b/dynatrace/rest/retry_transport.go
@@ -19,11 +19,14 @@ package rest
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"math"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
@@ -37,7 +40,8 @@ const (
 )
 
 // RetryTransport is an http.RoundTripper that automatically retries requests
-// when the server returns HTTP 429 (Too Many Requests) or HTTP 503 (Service Unavailable).
+// when the server returns HTTP 429 (Too Many Requests) or HTTP 503 (Service Unavailable),
+// or when the underlying transport returns a transient EOF or connection reset error.
 // MaxRetries, BaseBackoff, and MaxBackoff can be set to non-zero values to override the
 // defaults, which is useful in tests to keep execution time short.
 type RetryTransport struct {
@@ -46,6 +50,8 @@ type RetryTransport struct {
 	BaseBackoff time.Duration
 	MaxBackoff  time.Duration
 }
+
+type retryNonIdempotentRequestContextKey struct{}
 
 // transport returns the configured RoundTripper, falling back to http.DefaultTransport when nil.
 func (t *RetryTransport) transport() http.RoundTripper {
@@ -78,6 +84,40 @@ func (t *RetryTransport) maxBackoff() time.Duration {
 
 func isRetriableStatus(statusCode int) bool {
 	return statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable
+}
+
+func isRetriableError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNRESET)
+}
+
+func isIdempotentMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPut, http.MethodDelete, http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+func withNonIdempotentRetry(ctx context.Context) context.Context {
+	return context.WithValue(ctx, retryNonIdempotentRequestContextKey{}, true)
+}
+
+func canRetryTransportError(req *http.Request, err error) bool {
+	// Replay non-idempotent requests only when the caller has explicitly opted in.
+	// A transport error does not tell us whether the server applied the request.
+	if !isRetriableError(err) {
+		return false
+	}
+	if isIdempotentMethod(req.Method) {
+		return true
+	}
+	value, _ := req.Context().Value(retryNonIdempotentRequestContextKey{}).(bool)
+	return value
 }
 
 // bufferRequestBody reads and closes req.Body, returning its contents.
@@ -122,7 +162,19 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		resp, err := t.transport().RoundTrip(clone)
 		if err != nil {
-			return nil, err
+			if !canRetryTransportError(clone, err) || attempt >= maxRetries {
+				return nil, err
+			}
+
+			ctx := clone.Context()
+			wait := t.sleepDuration(nil, attempt)
+			logging.Logger.Printf(ctx, "[RetryTransport] Received transport error %v, retrying in %s (attempt %d/%d)", err, wait, attempt+1, maxRetries)
+			select {
+			case <-time.After(wait):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			continue
 		}
 
 		if !isRetriableStatus(resp.StatusCode) || attempt >= maxRetries {
@@ -147,6 +199,9 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // indicated wait duration. Returns 0 if the header is absent,
 // cannot be parsed, or indicates a non-positive delay.
 func getRetryAfterHeaderAsSleepTime(resp *http.Response) time.Duration {
+	if resp == nil {
+		return 0
+	}
 	ra := resp.Header.Get("Retry-After")
 	if ra == "" {
 		return 0

--- a/dynatrace/rest/retry_transport_internal_test.go
+++ b/dynatrace/rest/retry_transport_internal_test.go
@@ -1,0 +1,96 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type internalRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f internalRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func internalEmptyResponse(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+	}
+}
+
+func TestRetryTransport_NonIdempotentTransportErrorOptedIn(t *testing.T) {
+	calls := 0
+	tr := &RetryTransport{
+		Transport: internalRoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return nil, io.ErrUnexpectedEOF
+			}
+			return internalEmptyResponse(http.StatusOK), nil
+		}),
+		BaseBackoff: time.Millisecond,
+	}
+
+	ctx := withNonIdempotentRetry(t.Context())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://dynatrace.com", nil)
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+}
+
+func TestRetryTransport_BodyReplayedAfterNonIdempotentTransportError(t *testing.T) {
+	const payload = "hello-transport-error-retry"
+	var receivedBodies []string
+
+	tr := &RetryTransport{
+		Transport: internalRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Body != nil {
+				data, _ := io.ReadAll(req.Body)
+				receivedBodies = append(receivedBodies, string(data))
+			}
+			if len(receivedBodies) < 2 {
+				return nil, io.ErrUnexpectedEOF
+			}
+			return internalEmptyResponse(http.StatusOK), nil
+		}),
+		BaseBackoff: time.Millisecond,
+	}
+
+	ctx := withNonIdempotentRetry(t.Context())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://dynatrace.com", bytes.NewBufferString(payload))
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, receivedBodies, 2, "body must be delivered on every attempt")
+	assert.Equal(t, payload, receivedBodies[0])
+	assert.Equal(t, payload, receivedBodies[1])
+}

--- a/dynatrace/rest/retry_transport_test.go
+++ b/dynatrace/rest/retry_transport_test.go
@@ -21,9 +21,13 @@ package rest_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"syscall"
 	"testing"
 	"time"
 
@@ -103,20 +107,76 @@ func TestRetryTransport_NonRetriableStatusCodes(t *testing.T) {
 	}
 }
 
-// TestRetryTransport_TransportError verifies that an error from the underlying
-// transport is propagated immediately without retrying.
-func TestRetryTransport_TransportError(t *testing.T) {
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
-			return nil, assert.AnError
-		}),
+// TestRetryTransport_NonRetriableTransportErrors verifies that general errors,
+// timeouts, DNS errors, and authentication errors are propagated immediately.
+func TestRetryTransport_NonRetriableTransportErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "general error", err: assert.AnError},
+		{name: "timeout wrapping EOF", err: timeoutEOFError{}},
+		{name: "DNS error", err: &net.DNSError{Name: "dynatrace.com", Err: "no such host"}},
+		{name: "authentication error", err: errors.New("401 unauthorized")},
 	}
 
-	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
-	resp, err := tr.RoundTrip(req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			tr := &rest.RetryTransport{
+				Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+					calls++
+					return nil, tt.err
+				}),
+				BaseBackoff: time.Millisecond,
+			}
 
-	assert.Nil(t, resp)
-	assert.ErrorIs(t, err, assert.AnError)
+			req, err := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+			require.NoError(t, err)
+			resp, err := tr.RoundTrip(req)
+
+			assert.Nil(t, resp)
+			assert.ErrorIs(t, err, tt.err)
+			assert.Equal(t, 1, calls)
+		})
+	}
+}
+
+// TestRetryTransport_RetriesOnTransientTransportErrors_EventualSuccess verifies that
+// transient transport errors are retried and that a later successful response is returned.
+func TestRetryTransport_RetriesOnTransientTransportErrors_EventualSuccess(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "EOF", err: io.EOF},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF},
+		{name: "wrapped unexpected EOF", err: &url.Error{Op: "GET", URL: "https://dynatrace.com", Err: io.ErrUnexpectedEOF}},
+		{name: "wrapped connection reset", err: fmt.Errorf("read failed: %w", syscall.ECONNRESET)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			tr := &rest.RetryTransport{
+				Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+					calls++
+					if calls < 3 {
+						return nil, tt.err
+					}
+					return emptyResponse(http.StatusOK, nil), nil
+				}),
+				BaseBackoff: 1 * time.Millisecond,
+			}
+
+			req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+			resp, err := tr.RoundTrip(req)
+
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, 3, calls)
+		})
+	}
 }
 
 // TestRetryTransport_NilBody verifies that requests without a body are handled correctly.
@@ -336,6 +396,29 @@ func TestRetryTransport_MaxRetriesExhausted(t *testing.T) {
 	assert.Equal(t, maxRetries+1, calls, "expected MaxRetries+1 = %d total attempts", maxRetries+1)
 }
 
+// TestRetryTransport_TransportErrorMaxRetriesExhausted verifies that a retriable
+// transport error is returned after MaxRetries retries are exhausted.
+func TestRetryTransport_TransportErrorMaxRetriesExhausted(t *testing.T) {
+	const maxRetries = 3
+	transportErr := fmt.Errorf("connection reset: %w", syscall.ECONNRESET)
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			return nil, transportErr
+		}),
+		MaxRetries:  maxRetries,
+		BaseBackoff: 1 * time.Millisecond,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, syscall.ECONNRESET)
+	assert.Equal(t, maxRetries+1, calls, "expected MaxRetries+1 = %d total attempts", maxRetries+1)
+}
+
 // NewContextWithOAuthRetryClient verifies that the context is enriched with an
 // HTTP client whose transport is a *RetryTransport.
 func TestNewContextWithOAuthRetryClient(t *testing.T) {
@@ -508,7 +591,59 @@ func TestRetryTransport_ContextCancelled(t *testing.T) {
 	assert.Equal(t, 1, calls, "should not retry after context is cancelled")
 }
 
+// TestRetryTransport_TransportErrorContextCancelled verifies that context cancellation
+// during a transport error retry wait is honored immediately.
+func TestRetryTransport_TransportErrorContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			cancel()
+			return nil, io.ErrUnexpectedEOF
+		}),
+		BaseBackoff: time.Hour,
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls, "should not retry after context is cancelled")
+}
+
+// TestRetryTransport_NonIdempotentTransportErrorNotRetried verifies that a POST is not
+// retried unless the caller explicitly opts into replaying the request.
+func TestRetryTransport_NonIdempotentTransportErrorNotRetried(t *testing.T) {
+	calls := 0
+	tr := &rest.RetryTransport{
+		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			return nil, io.ErrUnexpectedEOF
+		}),
+		BaseBackoff: 1 * time.Millisecond,
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.Equal(t, 1, calls)
+}
+
 // failReader is an io.Reader that always returns an error.
 type failReader struct{ err error }
 
 func (f *failReader) Read(_ []byte) (int, error) { return 0, f.err }
+
+// timeoutEOFError models a timeout that also wraps EOF. It verifies that the
+// timeout classification takes precedence over the EOF retry classification.
+type timeoutEOFError struct{}
+
+func (timeoutEOFError) Error() string   { return "i/o timeout" }
+func (timeoutEOFError) Timeout() bool   { return true }
+func (timeoutEOFError) Temporary() bool { return true }
+func (timeoutEOFError) Unwrap() error   { return io.EOF }

--- a/dynatrace/settings/services/settings20/service.go
+++ b/dynatrace/settings/services/settings20/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/shutdown"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
+	"github.com/google/uuid"
 )
 
 func Service[T settings.Settings](clientSet rest.ClientSet, schemaID string, schemaVersion string, options ...*ServiceOptions[T]) (settings.ListIDCRUDService[T], error) {
@@ -54,6 +55,7 @@ type SettingsObjectUpdate struct {
 }
 
 type SettingsObjectCreate struct {
+	ExternalID    string `json:"externalId,omitempty"`
 	SchemaVersion string `json:"schemaVersion,omitempty"`
 	SchemaID      string `json:"schemaId"`
 	Scope         string `json:"scope,omitempty"`
@@ -366,7 +368,9 @@ func (me *service[T]) Validate(ctx context.Context, v T) error {
 }
 
 func (me *service[T]) Create(ctx context.Context, v T) (*api.Stub, error) {
-	return me.create(ctx, v, false, false)
+	// Reuse one external ID across retries belonging to this logical create so the
+	// Settings API can upsert instead of creating a duplicate object.
+	return me.create(ctx, v, false, false, uuid.NewString())
 }
 
 type Matcher interface {
@@ -379,7 +383,7 @@ func (me *service[T]) skipRepairInput() bool {
 
 var regexpNeighborWithKey = regexp.MustCompile(`Neighbor\swith\skey\s'[^']*'\snot\sfound\sfor\s'[^']*'`)
 
-func (me *service[T]) create(ctx context.Context, v T, retry bool, noInsertAfter bool) (*api.Stub, error) {
+func (me *service[T]) create(ctx context.Context, v T, retry bool, noInsertAfter bool, externalID string) (*api.Stub, error) {
 
 	if me.options != nil && me.options.Duplicates != nil {
 		dupStub, dupErr := me.options.Duplicates(ctx, me, v)
@@ -422,6 +426,7 @@ func (me *service[T]) create(ctx context.Context, v T, retry bool, noInsertAfter
 		}
 	}
 	soc := SettingsObjectCreate{
+		ExternalID:    externalID,
 		SchemaID:      me.schemaID,
 		SchemaVersion: me.schemaVersion,
 		Scope:         "environment",
@@ -445,12 +450,12 @@ func (me *service[T]) create(ctx context.Context, v T, retry bool, noInsertAfter
 
 	if oerr := req.Finish(&objectID); oerr != nil {
 		if isInvalidInsertAfter(oerr) {
-			return me.create(ctx, v, retry, true)
+			return me.create(ctx, v, retry, true, externalID)
 		}
 
 		if me.options != nil && me.options.CreateRetry != nil && !retry {
 			if modifiedPayload := me.options.CreateRetry(v, oerr); !reflect.ValueOf(modifiedPayload).IsNil() {
-				return me.create(ctx, modifiedPayload, true, noInsertAfter)
+				return me.create(ctx, modifiedPayload, true, noInsertAfter, externalID)
 			}
 		}
 		if me.options != nil && me.options.HijackOnCreate != nil {


### PR DESCRIPTION
#### **Why** this PR?

Creating Settings 2.0 objects can fail intermittently under parallel apply.

When API token authentication is used, the provider first sends the request to the classic Settings API. A `400` response indicating that OAuth is required is expected, so the provider retries the request against the Platform Settings endpoint.

Some Platform POST requests terminate with `unexpected EOF` before an HTTP response is received. The transport currently treats this as a hard failure, although a later retry often succeeds.

#### **What** has changed?

- Retry transient `io.EOF`, `io.ErrUnexpectedEOF`, and connection-reset errors.
- Retry these errors automatically for idempotent HTTP methods.
- Explicitly allow retries for Settings 2.0 object POST requests.
- Buffer and replay request bodies across retry attempts.
- Apply the retry-enabled HTTP client to platform-token clients as well as OAuth clients.
- Reuse the same `externalId` during a logical Settings create and its internal retries.
- Preserve the same `externalId` when the generic Settings service falls back from the classic API to the Platform API.

#### **How** does it do it?

`RetryTransport` classifies EOF and connection-reset errors as transient transport failures while excluding timeout errors and unrelated failures.

Non-idempotent requests are not retried by default. The Platform Settings object endpoint explicitly opts in because its create operation is designed to reuse the same `externalId` when replayed.

The request body is buffered before the first attempt so that every retry sends the same payload.

The existing OAuth fallback behavior remains unchanged: the expected classic API `400` causes the generic Settings service to retry using the Platform endpoint.

#### How is it **tested**?

- `go test -tags=unit ./...`
- `go vet -tags=unit ./dynatrace/rest ./dynatrace/api/builtin/generic ./dynatrace/settings/services/settings20`
- `git diff --check`

Unit tests cover transient transport errors, retry limits, context cancellation, non-idempotent request opt-in, and request body replay.

No live Dynatrace acceptance test was run.

#### How does it affect **users**?

Transient connection failures during Settings 2.0 creation can now recover automatically instead of failing immediately.

Normal POST requests remain non-retriable unless they explicitly opt in, reducing the risk of duplicate side effects.

The generated `externalId` is reused within one logical Create operation but is not persisted across separate Terraform runs. This change also does not introduce a provider-wide HTTP timeout.

The `externalId` behavior follows the Settings API’s caller-provided object replacement model:

- [Dynatrace Settings API key concepts](https://docs.dynatrace.com/docs/dynatrace-api/environment-api/settings/key-concepts)
- [POST Settings object](https://docs.dynatrace.com/docs/dynatrace-api/environment-api/settings/objects/post-object)

**Issue:** N/A