### PR TITLE
feat: resource updates for 345

### DIFF
--- a/dynatrace/api/builtin/appsec/notificationattackalertingprofile/schema.json
+++ b/dynatrace/api/builtin/appsec/notificationattackalertingprofile/schema.json
@@ -28,6 +28,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "EARLY_ADOPTER",
 	"maxObjects": 10,
 	"metadata": {
 		"addItemButton": "Add alerting profile"
@@ -49,6 +50,7 @@
 			"constraints": [
 				{
 					"customValidatorId": "attack-candidate-number-of-attack-states-validator",
+					"skipAsyncValidation": false,
 					"type": "CUSTOM_VALIDATOR_REF"
 				}
 			],
@@ -96,5 +98,5 @@
 	],
 	"schemaId": "builtin:appsec.notification-attack-alerting-profile",
 	"types": {},
-	"version": "0.0.4"
+	"version": "0.0.5"
 }

--- a/dynatrace/api/builtin/appsec/notificationattackalertingprofile/service.go
+++ b/dynatrace/api/builtin/appsec/notificationattackalertingprofile/service.go
@@ -18,15 +18,15 @@
 package notificationattackalertingprofile
 
 import (
-	notificationattackalertingprofile "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/appsec/notificationattackalertingprofile/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/appsec/notificationattackalertingprofile/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.0.4"
+const SchemaVersion = "0.0.5"
 const SchemaID = "builtin:appsec.notification-attack-alerting-profile"
 
-func Service(clientSet rest.ClientSet) (settings.CRUDService[*notificationattackalertingprofile.Settings], error) {
-	return settings20.Service[*notificationattackalertingprofile.Settings](clientSet, SchemaID, SchemaVersion)
+func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {
+	return settings20.Service[*service.Settings](clientSet, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/appsec/notificationattackalertingprofile/settings/settings.go
+++ b/dynatrace/api/builtin/appsec/notificationattackalertingprofile/settings/settings.go
@@ -24,7 +24,7 @@ import (
 
 type Settings struct {
 	Enabled                  bool               `json:"enabled"`                            // This setting is enabled (`true`) or disabled (`false`)
-	EnabledAttackMitigations []AttackMitigation `json:"enabledAttackMitigations,omitempty"` // Attack State
+	EnabledAttackMitigations []AttackMitigation `json:"enabledAttackMitigations,omitempty"` // Attack State. Possible values: `BLOCKED_WITH_EXCEPTION`, `NONE_ALLOWLISTED`, `NONE_BLOCKING_DISABLED`
 	Name                     string             `json:"name"`                               // Name
 }
 
@@ -37,7 +37,7 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		},
 		"enabled_attack_mitigations": {
 			Type:        schema.TypeSet,
-			Description: "Attack State",
+			Description: "Attack State. Possible values: `BLOCKED_WITH_EXCEPTION`, `NONE_ALLOWLISTED`, `NONE_BLOCKING_DISABLED`",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},

--- a/dynatrace/api/builtin/hyperscalerauthentication/awsconnection/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/awsconnection/schema.json
@@ -9,8 +9,8 @@
 			"type": "SECRET_RESUBMISSION"
 		}
 	],
-	"description": "Available connections for [AWS for Workflows](https://dt-url.net/s803q9r). A connection is used to authenticate against your AWS account. The retrieved, temporary AWS credentials are used to execute the AWS workflow actions.",
-	"displayName": "AWS Connections",
+	"description": "This schema has been replaced by `builtin:hyperscaler-authentication.connections.aws`.",
+	"displayName": "AWS Connections (deprecated)",
 	"documentation": "",
 	"dynatrace": "1",
 	"enums": {
@@ -27,6 +27,7 @@
 			"type": "enum"
 		}
 	},
+	"maturity": "EARLY_ADOPTER",
 	"maxObjects": 100,
 	"multiObject": true,
 	"ordered": false,
@@ -159,5 +160,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "0.0.3"
+	"version": "0.0.4"
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/awsconnection/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/awsconnection/service.go
@@ -18,15 +18,15 @@
 package awsconnection
 
 import (
-	awsconnection "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/awsconnection/settings"
+	service "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/awsconnection/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
+const SchemaVersion = "0.0.4"
 const SchemaID = "builtin:hyperscaler-authentication.aws.connection"
-const SchemaVersion = "0.0.3"
 
-func Service(clientSet rest.ClientSet) (settings.CRUDService[*awsconnection.Settings], error) {
-	return settings20.Service[*awsconnection.Settings](clientSet, SchemaID, SchemaVersion)
+func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {
+	return settings20.Service[*service.Settings](clientSet, SchemaID, SchemaVersion)
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/schema.json
@@ -20,10 +20,6 @@
 			"documentation": "",
 			"items": [
 				{
-					"displayName": "(Deprecated) Data Acquisition",
-					"value": "DA"
-				},
-				{
 					"displayName": "Data Acquisition",
 					"value": "SVC:com.dynatrace.da"
 				},
@@ -38,10 +34,6 @@
 				{
 					"displayName": "Grail",
 					"value": "SVC:com.dynatrace.grail"
-				},
-				{
-					"displayName": "None",
-					"value": "NONE"
 				}
 			],
 			"type": "enum"
@@ -272,5 +264,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "0.0.26"
+	"version": "1"
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/service.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.0.26"
+const SchemaVersion = "1"
 const SchemaID = "builtin:hyperscaler-authentication.connections.aws"
 
 type service struct {

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/aws_role_based_authentication_config.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/aws_role_based_authentication_config.go
@@ -23,7 +23,7 @@ import (
 )
 
 type AwsRoleBasedAuthenticationConfig struct {
-	Consumers []ConsumersOfAwsRoleBasedAuthentication `json:"consumers"` // Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
+	Consumers []ConsumersOfAwsRoleBasedAuthentication `json:"consumers"` // Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
 	RoleArn   string                                  `json:"roleArn"`   // The ARN of the AWS role that should be assumed
 }
 
@@ -37,7 +37,7 @@ func (me *AwsRoleBasedAuthenticationConfig) Schema() map[string]*schema.Schema {
 		// },
 		"consumers": {
 			Type:        schema.TypeSet,
-			Description: "Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`",
+			Description: "Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			MinItems:    1,

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/enums.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/aws/settings/enums.go
@@ -20,15 +20,11 @@ package aws
 type ConsumersOfAwsRoleBasedAuthentication string
 
 var ConsumersOfAwsRoleBasedAuthentications = struct {
-	Da                          ConsumersOfAwsRoleBasedAuthentication
-	None                        ConsumersOfAwsRoleBasedAuthentication
 	SvcComDynatraceBo           ConsumersOfAwsRoleBasedAuthentication
 	SvcComDynatraceDa           ConsumersOfAwsRoleBasedAuthentication
 	SvcComDynatraceGrail        ConsumersOfAwsRoleBasedAuthentication
 	SvcComDynatraceOpenpipeline ConsumersOfAwsRoleBasedAuthentication
 }{
-	"DA",
-	"NONE",
 	"SVC:com.dynatrace.bo",
 	"SVC:com.dynatrace.da",
 	"SVC:com.dynatrace.grail",

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/schema.json
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/schema.json
@@ -20,16 +20,8 @@
 			"documentation": "",
 			"items": [
 				{
-					"displayName": "(Deprecated) Data Acquisition",
-					"value": "DA"
-				},
-				{
 					"displayName": "Data Acquisition",
 					"value": "SVC:com.dynatrace.da"
-				},
-				{
-					"displayName": "None",
-					"value": "NONE"
 				}
 			],
 			"type": "enum"
@@ -39,10 +31,6 @@
 			"displayName": "Consumers",
 			"documentation": "",
 			"items": [
-				{
-					"displayName": "(Deprecated) Data Acquisition",
-					"value": "DA"
-				},
 				{
 					"displayName": "Data Acquisition",
 					"value": "SVC:com.dynatrace.da"
@@ -62,10 +50,6 @@
 				{
 					"displayName": "Business Observability",
 					"value": "SVC:com.dynatrace.bo"
-				},
-				{
-					"displayName": "None",
-					"value": "NONE"
 				}
 			],
 			"type": "enum"
@@ -345,5 +329,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "0.0.18"
+	"version": "1"
 }

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/service.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/service.go
@@ -31,7 +31,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.0.18"
+const SchemaVersion = "1"
 const SchemaID = "builtin:hyperscaler-authentication.connections.azure"
 const DefaultTimeout = 2 * time.Minute
 

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/client_secret_config.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/client_secret_config.go
@@ -25,7 +25,7 @@ import (
 type ClientSecretConfig struct {
 	ApplicationID string                    `json:"applicationId"`       // Application (client) ID of your app registered in Microsoft Azure App registrations
 	ClientSecret  string                    `json:"clientSecret"`        // Client secret of your app registered in Microsoft Azure App registrations
-	Consumers     []ConsumersOfClientSecret `json:"consumers,omitempty"` // Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.da`
+	Consumers     []ConsumersOfClientSecret `json:"consumers,omitempty"` // Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.da`
 	DirectoryID   string                    `json:"directoryId"`         // Directory (tenant) ID of Microsoft Entra ID
 }
 
@@ -45,7 +45,7 @@ func (me *ClientSecretConfig) Schema() map[string]*schema.Schema {
 		},
 		"consumers": {
 			Type:        schema.TypeList,
-			Description: "Dynatrace integrations that can use this connection. Possible values: `DA`, `NONE`, `SVC:com.dynatrace.da`",
+			Description: "Dynatrace integrations that can use this connection. Possible values: `SVC:com.dynatrace.da`",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			ForceNew:    true,

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/enums.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/enums.go
@@ -20,12 +20,8 @@ package azure
 type ConsumersOfClientSecret string
 
 var ConsumersOfClientSecrets = struct {
-	Da                ConsumersOfClientSecret
-	None              ConsumersOfClientSecret
 	SvcComDynatraceDa ConsumersOfClientSecret
 }{
-	"DA",
-	"NONE",
 	"SVC:com.dynatrace.da",
 }
 
@@ -33,16 +29,12 @@ type ConsumersOfFederatedIdentityCredential string
 
 var ConsumersOfFederatedIdentityCredentials = struct {
 	AppDynatraceMicrosoftAzureConnector ConsumersOfFederatedIdentityCredential
-	Da                                  ConsumersOfFederatedIdentityCredential
-	None                                ConsumersOfFederatedIdentityCredential
 	SvcComDynatraceBo                   ConsumersOfFederatedIdentityCredential
 	SvcComDynatraceDa                   ConsumersOfFederatedIdentityCredential
 	SvcComDynatraceGrail                ConsumersOfFederatedIdentityCredential
 	SvcComDynatraceOpenpipeline         ConsumersOfFederatedIdentityCredential
 }{
 	"APP:dynatrace.microsoft.azure.connector",
-	"DA",
-	"NONE",
 	"SVC:com.dynatrace.bo",
 	"SVC:com.dynatrace.da",
 	"SVC:com.dynatrace.grail",

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/federated_identity_credential.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/settings/federated_identity_credential.go
@@ -24,7 +24,7 @@ import (
 
 type FederatedIdentityCredential struct {
 	ApplicationID *string                                  `json:"applicationId,omitempty"` // Application (client) ID of your app registered in Microsoft Azure App registrations
-	Consumers     []ConsumersOfFederatedIdentityCredential `json:"consumers,omitempty"`     // Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
+	Consumers     []ConsumersOfFederatedIdentityCredential `json:"consumers,omitempty"`     // Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`
 	DirectoryID   *string                                  `json:"directoryId,omitempty"`   // Directory (tenant) ID of Microsoft Entra ID
 }
 
@@ -32,7 +32,7 @@ func (me *FederatedIdentityCredential) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"consumers": {
 			Type:        schema.TypeList,
-			Description: "Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `DA`, `NONE`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`",
+			Description: "Consumers that can use the connection. Possible values: `APP:dynatrace.microsoft.azure.connector`, `SVC:com.dynatrace.bo`, `SVC:com.dynatrace.da`, `SVC:com.dynatrace.grail`, `SVC:com.dynatrace.openpipeline`",
 			Optional:    true, // minobjects == 0
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			ForceNew:    true,

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/terraform/azure_connector_client_secret.tf
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/azure/testdata/terraform/azure_connector_client_secret.tf
@@ -36,7 +36,7 @@ resource "dynatrace_azure_connection" "example" {
     application_id = azuread_application_registration.example.client_id
     directory_id   = var.azure_tenant_id
     consumers = [
-      "DA"
+      "SVC:com.dynatrace.da"
     ]
   }
 }

--- a/dynatrace/api/builtin/kubernetes/enrichment/schema.json
+++ b/dynatrace/api/builtin/kubernetes/enrichment/schema.json
@@ -3,6 +3,14 @@
 		"KUBERNETES_CLUSTER",
 		"environment"
 	],
+	"constraints": [
+		{
+			"customMessage": "This scope has opted into the new unified enrichment settings (builtin:ingest.enrichment.config). Rules in builtin:kubernetes.generic.metadata.enrichment are inactive; disable the opt-in toggle to edit them.",
+			"customValidatorId": "kubernetes-enrichment-optin-write-block",
+			"skipAsyncValidation": true,
+			"type": "CUSTOM_VALIDATOR_REF"
+		}
+	],
 	"description": "Generic metadata enrichment for Kubernetes.",
 	"displayName": "Kubernetes Telemetry Enrichment",
 	"documentation": "",
@@ -77,6 +85,15 @@
 			"modificationPolicy": "DEFAULT",
 			"nullable": false,
 			"type": "list"
+		},
+		"useIngestEnrichmentConfigSchema": {
+			"description": "Opt-in to experience the new unified enrichment settings view ahead of future rollout.\nEnabling this toggle may trigger migration of rules to the new enrichment settings. Learn more in our [documentation](https://dt-url.net/qm02uk2).",
+			"displayName": "Use new unified enrichment settings",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": "boolean"
 		}
 	},
 	"schemaGroups": [
@@ -167,5 +184,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.5"
+	"version": "1.6.2"
 }

--- a/dynatrace/api/builtin/kubernetes/enrichment/service.go
+++ b/dynatrace/api/builtin/kubernetes/enrichment/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.5"
+const SchemaVersion = "1.6.2"
 const SchemaID = "builtin:kubernetes.generic.metadata.enrichment"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {

--- a/dynatrace/api/builtin/kubernetes/enrichment/settings/settings.go
+++ b/dynatrace/api/builtin/kubernetes/enrichment/settings/settings.go
@@ -23,8 +23,9 @@ import (
 )
 
 type Settings struct {
-	Rules Rules   `json:"rules,omitempty"` // Kubernetes Telemetry Enrichment empowers you to effectively tag your telemetry data using Kubernetes namespace labels and annotations. Additionally, it enables you to tag it for cost allocation and permission purposes.\n\n  Enrichment Options:\n\n  - **Enrich telemetry with label/annotation directly:** Tag your telemetry data with existing Kubernetes namespace labels or annotations. These will be made available as domain-specific fields (e.g., `k8s.namespace.label.your_key`). This allows for flexible pipeline routing, bucket selection, segmentation, and filtering.\n\n  - **Security Context and Cost Allocation:** Leverage existing Kubernetes namespace labels or annotations  as the basis for security context or cost allocation. This provides granular control over permissions and facilitates chargeback functionalities.\n\n  Additional Information:\n\n  - Only namespace-level labels or annotations can be used as source.\n\n  - You can define up to 20 enrichment rules.\n\n  - New rules may take up to 45 minutes to take effect.\n\n  - Pod restarts are required after the 45 mins to ensure the changes take effect.\n\n  To learn more, please refer to our [documentation](https://dt-url.net/pn22sye).
-	Scope *string `json:"-" scope:"scope"` // The scope of this setting (KUBERNETES_CLUSTER). Omit this property if you want to cover the whole environment.
+	Rules                           Rules   `json:"rules,omitempty"`                           // Kubernetes Telemetry Enrichment empowers you to effectively tag your telemetry data using Kubernetes namespace labels and annotations. Additionally, it enables you to tag it for cost allocation and permission purposes.\n\n  Enrichment Options:\n\n  - **Enrich telemetry with label/annotation directly:** Tag your telemetry data with existing Kubernetes namespace labels or annotations. These will be made available as domain-specific fields (e.g., `k8s.namespace.label.your_key`). This allows for flexible pipeline routing, bucket selection, segmentation, and filtering.\n\n  - **Security Context and Cost Allocation:** Leverage existing Kubernetes namespace labels or annotations  as the basis for security context or cost allocation. This provides granular control over permissions and facilitates chargeback functionalities.\n\n  Additional Information:\n\n  - Only namespace-level labels or annotations can be used as source.\n\n  - You can define up to 20 enrichment rules.\n\n  - New rules may take up to 45 minutes to take effect.\n\n  - Pod restarts are required after the 45 mins to ensure the changes take effect.\n\n  To learn more, please refer to our [documentation](https://dt-url.net/pn22sye).
+	Scope                           *string `json:"-" scope:"scope"`                           // The scope of this setting (KUBERNETES_CLUSTER). Omit this property if you want to cover the whole environment.
+	UseIngestEnrichmentConfigSchema *bool   `json:"useIngestEnrichmentConfigSchema,omitempty"` // Opt-in to experience the new unified enrichment settings view ahead of future rollout.\n Enabling this toggle may trigger migration of rules to the new enrichment settings. Learn more in our [documentation](https://dt-url.net/qm02uk2).
 }
 
 func (me *Settings) Name() string {
@@ -44,22 +45,30 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"scope": {
 			Type:        schema.TypeString,
 			Description: "The scope of this setting (KUBERNETES_CLUSTER). Omit this property if you want to cover the whole environment.",
+			ForceNew:    true,
 			Optional:    true,
 			Default:     "environment",
+		},
+		"use_ingest_enrichment_config_schema": {
+			Type:        schema.TypeBool,
+			Description: "Opt-in to experience the new unified enrichment settings view ahead of future rollout.\n Enabling this toggle may trigger migration of rules to the new enrichment settings. Learn more in our [documentation](https://dt-url.net/qm02uk2).",
+			Optional:    true, // nullable
 		},
 	}
 }
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"rules": me.Rules,
-		"scope": me.Scope,
+		"rules":                               me.Rules,
+		"scope":                               me.Scope,
+		"use_ingest_enrichment_config_schema": me.UseIngestEnrichmentConfigSchema,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"rules": &me.Rules,
-		"scope": &me.Scope,
+		"rules":                               &me.Rules,
+		"scope":                               &me.Scope,
+		"use_ingest_enrichment_config_schema": &me.UseIngestEnrichmentConfigSchema,
 	})
 }

--- a/dynatrace/api/builtin/kubernetes/enrichment/testdata/terraform/example_a.tf
+++ b/dynatrace/api/builtin/kubernetes/enrichment/testdata/terraform/example_a.tf
@@ -1,5 +1,6 @@
-resource "dynatrace_kubernetes_enrichment" "#name#" {
+resource "dynatrace_kubernetes_enrichment" "example" {
   scope = "environment"
+  use_ingest_enrichment_config_schema = true
   rules {
     rule {
       type    = "LABEL"

--- a/dynatrace/api/builtin/logmonitoring/logdpprules/schema.json
+++ b/dynatrace/api/builtin/logmonitoring/logdpprules/schema.json
@@ -189,5 +189,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.0.28"
+	"version": "1.0.30"
 }

--- a/dynatrace/api/builtin/logmonitoring/logdpprules/service.go
+++ b/dynatrace/api/builtin/logmonitoring/logdpprules/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.0.28"
+const SchemaVersion = "1.0.30"
 const SchemaID = "builtin:logmonitoring.log-dpp-rules"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {

--- a/dynatrace/api/builtin/logmonitoring/logdpprules/settings/settings.go
+++ b/dynatrace/api/builtin/logmonitoring/logdpprules/settings/settings.go
@@ -27,11 +27,11 @@ import (
 
 type Settings struct {
 	Enabled             bool                 `json:"enabled"`             // This setting is enabled (`true`) or disabled (`false`)
+	InsertAfter         *string              `json:"-"`                   // Because this resource allows for ordering you may specify the ID of the resource instance that comes before this instance regarding order. If not specified when creating the setting will be added to the end of the list. If not specified during update the order will remain untouched
 	ProcessorDefinition *ProcessorDefinition `json:"ProcessorDefinition"` // ## Processor definition
 	Query               string               `json:"query"`               // Matcher
 	RuleName            string               `json:"ruleName"`            // Rule name
-	RuleTesting         *RuleTesting         `json:"RuleTesting"`         // ## Rule testing\n### 1. Paste a log / JSON sample
-	InsertAfter         string               `json:"-"`
+	RuleTesting         *RuleTesting         `json:"RuleTesting"`         // ## Rule testing\n ### 1. Paste a log / JSON sample
 }
 
 func (me *Settings) Name() string {
@@ -44,6 +44,12 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Description: "This setting is enabled (`true`) or disabled (`false`)",
 			Required:    true,
+		},
+		"insert_after": {
+			Type:        schema.TypeString,
+			Description: "Because this resource allows for ordering you may specify the ID of the resource instance that comes before this instance regarding order. If not specified when creating the setting will be added to the end of the list. If not specified during update the order will remain untouched",
+			Computed:    true,
+			Optional:    true,
 		},
 		"processor_definition": {
 			Type:        schema.TypeList,
@@ -72,12 +78,6 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			MinItems:    1,
 			MaxItems:    1,
 		},
-		"insert_after": {
-			Type:        schema.TypeString,
-			Description: "Because this resource allows for ordering you may specify the ID of the resource instance that comes before this instance regarding order. If not specified when creating the setting will be added to the end of the list. If not specified during update the order will remain untouched",
-			Optional:    true,
-			Computed:    true,
-		},
 	}
 }
 
@@ -98,11 +98,11 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		me.Schema(),
 		map[string]any{
 			"enabled":              me.Enabled,
+			"insert_after":         me.InsertAfter,
 			"processor_definition": me.ProcessorDefinition,
 			"query":                me.Query,
 			"rule_name":            me.RuleName,
 			"rule_testing":         me.RuleTesting,
-			"insert_after":         me.InsertAfter,
 		},
 		me.genIgnoreChanges(),
 	))
@@ -111,10 +111,10 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
 		"enabled":              &me.Enabled,
+		"insert_after":         &me.InsertAfter,
 		"processor_definition": &me.ProcessorDefinition,
 		"query":                &me.Query,
 		"rule_name":            &me.RuleName,
 		"rule_testing":         &me.RuleTesting,
-		"insert_after":         &me.InsertAfter,
 	})
 }

--- a/dynatrace/api/builtin/maintenancewindows/schema.json
+++ b/dynatrace/api/builtin/maintenancewindows/schema.json
@@ -104,6 +104,17 @@
 			"nullable": false,
 			"type": "text"
 		},
+		"objectScopes": {
+			"description": "",
+			"displayName": "Object scopes",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": true,
+			"type": {
+				"$ref": "#/types/ObjectScopes"
+			}
+		},
 		"schedule": {
 			"default": {
 				"duration": 60,
@@ -127,6 +138,31 @@
 	},
 	"schemaId": "builtin:maintenance-windows",
 	"types": {
+		"ObjectScopes": {
+			"description": "Scopes controlling which objects are affected by the maintenance window.",
+			"displayName": "Object scopes",
+			"documentation": "",
+			"properties": {
+				"syntheticMonitors": {
+					"default": {
+						"disableSyntheticMonitors": false
+					},
+					"description": "",
+					"displayName": "Synthetic monitors",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": {
+						"$ref": "#/types/SyntheticMonitorSettings"
+					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
 		"OnceTrigger": {
 			"description": "Once trigger definition.",
 			"displayName": "Once Trigger",
@@ -209,6 +245,53 @@
 					"type": {
 						"$ref": "#/types/Trigger"
 					}
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
+		},
+		"SyntheticMonitorSettings": {
+			"description": "Configuration for pausing synthetic monitors during the maintenance window.",
+			"displayName": "Synthetic monitor disablement",
+			"documentation": "",
+			"properties": {
+				"disableSyntheticMonitorFilter": {
+					"constraints": [
+						{
+							"customValidatorId": "filter-validator",
+							"skipAsyncValidation": false,
+							"type": "CUSTOM_VALIDATOR_REF"
+						},
+						{
+							"maxLength": 500,
+							"minLength": 1,
+							"type": "LENGTH"
+						}
+					],
+					"description": "DQL filter selecting which synthetic monitors to pause. Required when synthetic monitors are disabled.",
+					"displayName": "Synthetic monitor filter",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": true,
+					"precondition": {
+						"expectedValue": true,
+						"property": "disableSyntheticMonitors",
+						"type": "EQUALS"
+					},
+					"type": "text"
+				},
+				"disableSyntheticMonitors": {
+					"default": false,
+					"description": "When enabled, synthetic monitors matching the filter are paused during the maintenance window.",
+					"displayName": "Disable synthetic monitors",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
 				}
 			},
 			"summaryPattern": "",
@@ -333,5 +416,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1"
+	"version": "1.1"
 }

--- a/dynatrace/api/builtin/maintenancewindows/service.go
+++ b/dynatrace/api/builtin/maintenancewindows/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1"
+const SchemaVersion = "1.1"
 const SchemaID = "builtin:maintenance-windows"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {

--- a/dynatrace/api/builtin/maintenancewindows/settings/object_scopes.go
+++ b/dynatrace/api/builtin/maintenancewindows/settings/object_scopes.go
@@ -1,0 +1,53 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package maintenancewindows
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Object scopes. Scopes controlling which objects are affected by the maintenance window.
+type ObjectScopes struct {
+	SyntheticMonitors *SyntheticMonitorSettings `json:"syntheticMonitors"` // Synthetic monitors
+}
+
+func (me *ObjectScopes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"synthetic_monitors": {
+			Type:        schema.TypeList,
+			Description: "Synthetic monitors",
+			Required:    true,
+			Elem:        &schema.Resource{Schema: new(SyntheticMonitorSettings).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
+	}
+}
+
+func (me *ObjectScopes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"synthetic_monitors": me.SyntheticMonitors,
+	})
+}
+
+func (me *ObjectScopes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"synthetic_monitors": &me.SyntheticMonitors,
+	})
+}

--- a/dynatrace/api/builtin/maintenancewindows/settings/settings.go
+++ b/dynatrace/api/builtin/maintenancewindows/settings/settings.go
@@ -23,12 +23,13 @@ import (
 )
 
 type Settings struct {
-	AutoDelete  bool                `json:"autoDelete"`            // When enabled, this maintenance window configuration will be automatically deleted 30 days after the end of its last execution.
-	Description *string             `json:"description,omitempty"` // Description
-	Enabled     bool                `json:"enabled"`               // This setting is enabled (`true`) or disabled (`false`)
-	Filter      string              `json:"filter"`                // DQL Filter
-	Name        string              `json:"name"`                  // Name of the maintenance window
-	Schedule    *ScheduleDefinition `json:"schedule"`              // Schedule definition
+	AutoDelete   bool                `json:"autoDelete"`             // When enabled, this maintenance window configuration will be automatically deleted 30 days after the end of its last execution.
+	Description  *string             `json:"description,omitempty"`  // Description
+	Enabled      bool                `json:"enabled"`                // This setting is enabled (`true`) or disabled (`false`)
+	Filter       string              `json:"filter"`                 // DQL Filter
+	Name         string              `json:"name"`                   // Name of the maintenance window
+	ObjectScopes *ObjectScopes       `json:"objectScopes,omitempty"` // Object scopes
+	Schedule     *ScheduleDefinition `json:"schedule"`               // Schedule definition
 }
 
 func (me *Settings) Schema() map[string]*schema.Schema {
@@ -58,6 +59,14 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "Name of the maintenance window",
 			Required:    true,
 		},
+		"object_scopes": {
+			Type:        schema.TypeList,
+			Description: "Object scopes",
+			Optional:    true, // nullable
+			Elem:        &schema.Resource{Schema: new(ObjectScopes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 		"schedule": {
 			Type:        schema.TypeList,
 			Description: "Schedule definition",
@@ -71,22 +80,24 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 
 func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 	return properties.EncodeAll(map[string]any{
-		"auto_delete": me.AutoDelete,
-		"description": me.Description,
-		"enabled":     me.Enabled,
-		"filter":      me.Filter,
-		"name":        me.Name,
-		"schedule":    me.Schedule,
+		"auto_delete":   me.AutoDelete,
+		"description":   me.Description,
+		"enabled":       me.Enabled,
+		"filter":        me.Filter,
+		"name":          me.Name,
+		"object_scopes": me.ObjectScopes,
+		"schedule":      me.Schedule,
 	})
 }
 
 func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 	return decoder.DecodeAll(map[string]any{
-		"auto_delete": &me.AutoDelete,
-		"description": &me.Description,
-		"enabled":     &me.Enabled,
-		"filter":      &me.Filter,
-		"name":        &me.Name,
-		"schedule":    &me.Schedule,
+		"auto_delete":   &me.AutoDelete,
+		"description":   &me.Description,
+		"enabled":       &me.Enabled,
+		"filter":        &me.Filter,
+		"name":          &me.Name,
+		"object_scopes": &me.ObjectScopes,
+		"schedule":      &me.Schedule,
 	})
 }

--- a/dynatrace/api/builtin/maintenancewindows/settings/synthetic_monitor_settings.go
+++ b/dynatrace/api/builtin/maintenancewindows/settings/synthetic_monitor_settings.go
@@ -1,0 +1,67 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package maintenancewindows
+
+import (
+	"fmt"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Synthetic monitor disablement. Configuration for pausing synthetic monitors during the maintenance window.
+type SyntheticMonitorSettings struct {
+	DisableSyntheticMonitorFilter *string `json:"disableSyntheticMonitorFilter,omitempty"` // DQL filter selecting which synthetic monitors to pause. Required when synthetic monitors are disabled.
+	DisableSyntheticMonitors      bool    `json:"disableSyntheticMonitors"`                // When enabled, synthetic monitors matching the filter are paused during the maintenance window.
+}
+
+func (me *SyntheticMonitorSettings) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"disable_synthetic_monitor_filter": {
+			Type:        schema.TypeString,
+			Description: "DQL filter selecting which synthetic monitors to pause. Required when synthetic monitors are disabled.",
+			Optional:    true, // nullable & precondition
+		},
+		"disable_synthetic_monitors": {
+			Type:        schema.TypeBool,
+			Description: "When enabled, synthetic monitors matching the filter are paused during the maintenance window.",
+			Required:    true,
+		},
+	}
+}
+
+func (me *SyntheticMonitorSettings) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"disable_synthetic_monitor_filter": me.DisableSyntheticMonitorFilter,
+		"disable_synthetic_monitors":       me.DisableSyntheticMonitors,
+	})
+}
+
+func (me *SyntheticMonitorSettings) HandlePreconditions() error {
+	if (me.DisableSyntheticMonitorFilter != nil) && (!me.DisableSyntheticMonitors) {
+		return fmt.Errorf("'disable_synthetic_monitor_filter' must not be specified unless 'disable_synthetic_monitors' is set to 'true'; got 'disable_synthetic_monitors'='%v'", me.DisableSyntheticMonitors)
+	}
+	return nil
+}
+
+func (me *SyntheticMonitorSettings) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"disable_synthetic_monitor_filter": &me.DisableSyntheticMonitorFilter,
+		"disable_synthetic_monitors":       &me.DisableSyntheticMonitors,
+	})
+}

--- a/dynatrace/api/builtin/maintenancewindows/testdata/terraform/example.tf
+++ b/dynatrace/api/builtin/maintenancewindows/testdata/terraform/example.tf
@@ -5,6 +5,13 @@ resource "dynatrace_maintenance_windows" "recurring_window" {
   auto_delete = true
   enabled     = true
 
+  object_scopes {
+    synthetic_monitors {
+      disable_synthetic_monitor_filter = "status == \"OPEN\" AND severity == \"HIGH\""
+      disable_synthetic_monitors       = true
+    }
+  }
+
   schedule {
     duration = 60
     timezone = "UTC"

--- a/dynatrace/api/builtin/problem/fields/schema.json
+++ b/dynatrace/api/builtin/problem/fields/schema.json
@@ -8,7 +8,7 @@
 	"dynatrace": "1",
 	"enums": {},
 	"maturity": "EARLY_ADOPTER",
-	"maxObjects": 40,
+	"maxObjects": 43,
 	"multiObject": true,
 	"ordered": false,
 	"properties": {
@@ -90,5 +90,5 @@
 	],
 	"schemaId": "builtin:problem.fields",
 	"types": {},
-	"version": "1.10"
+	"version": "1.11"
 }

--- a/dynatrace/api/builtin/problem/fields/service.go
+++ b/dynatrace/api/builtin/problem/fields/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.10"
+const SchemaVersion = "1.11"
 const SchemaID = "builtin:problem.fields"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {

--- a/dynatrace/api/builtin/rum/mobile/enablement/schema.json
+++ b/dynatrace/api/builtin/rum/mobile/enablement/schema.json
@@ -27,6 +27,18 @@
 			"customValidatorId": "mrumOnGrailEnabledForReplayOnGrailValidator",
 			"skipAsyncValidation": false,
 			"type": "CUSTOM_VALIDATOR_REF"
+		},
+		{
+			"customMessage": "Real User Monitoring Classic and the New Real User Monitoring Experience must be enabled or disabled together.",
+			"customValidatorId": "mrumPhase3RumGrailPairingValidator",
+			"skipAsyncValidation": false,
+			"type": "CUSTOM_VALIDATOR_REF"
+		},
+		{
+			"customMessage": "Session Replay Classic and the New Session Replay Experience must be enabled or disabled together.",
+			"customValidatorId": "mrumPhase3SessionReplayGrailPairingValidator",
+			"skipAsyncValidation": false,
+			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"description": "Turn on Real User Monitoring and Session Replay. Configure cost and traffic control settings.",
@@ -287,5 +299,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "2.7.3"
+	"version": "2.7.4"
 }

--- a/dynatrace/api/builtin/rum/mobile/enablement/service.go
+++ b/dynatrace/api/builtin/rum/mobile/enablement/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "2.7.3"
+const SchemaVersion = "2.7.4"
 const SchemaID = "builtin:rum.mobile.enablement"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {

--- a/dynatrace/api/builtin/rum/mobile/enablement/settings/settings.go
+++ b/dynatrace/api/builtin/rum/mobile/enablement/settings/settings.go
@@ -38,9 +38,9 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"application_id": {
 			Type:        schema.TypeString,
 			Description: "The scope of this settings. If the settings should cover the whole environment, just don't specify any scope.",
+			ForceNew:    true,
 			Optional:    true,
 			Default:     "environment",
-			ForceNew:    true,
 		},
 		"experience_analytics": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/builtin/rum/web/enablement/schema.json
+++ b/dynatrace/api/builtin/rum/web/enablement/schema.json
@@ -21,6 +21,18 @@
 			"customValidatorId": "rumOnGrailEnabledForReplayOnGrailValidator",
 			"skipAsyncValidation": false,
 			"type": "CUSTOM_VALIDATOR_REF"
+		},
+		{
+			"customMessage": "Real User Monitoring Classic and the New Real User Monitoring Experience must be enabled or disabled together.",
+			"customValidatorId": "phase3RumGrailPairingValidator",
+			"skipAsyncValidation": false,
+			"type": "CUSTOM_VALIDATOR_REF"
+		},
+		{
+			"customMessage": "Session Replay Classic and the New Session Replay Experience must be enabled or disabled together.",
+			"customValidatorId": "phase3SessionReplayGrailPairingValidator",
+			"skipAsyncValidation": false,
+			"type": "CUSTOM_VALIDATOR_REF"
 		}
 	],
 	"deletionConstraints": [
@@ -269,5 +281,5 @@
 			"versionInfo": ""
 		}
 	},
-	"version": "1.9.2"
+	"version": "1.9.3"
 }

--- a/dynatrace/api/builtin/rum/web/enablement/service.go
+++ b/dynatrace/api/builtin/rum/web/enablement/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "1.9.2"
+const SchemaVersion = "1.9.3"
 const SchemaID = "builtin:rum.web.enablement"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {

--- a/dynatrace/api/builtin/rum/web/enablement/settings/settings.go
+++ b/dynatrace/api/builtin/rum/web/enablement/settings/settings.go
@@ -38,9 +38,9 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 		"application_id": {
 			Type:        schema.TypeString,
 			Description: "The scope of this settings. If the settings should cover the whole environment, just don't specify any scope.",
+			ForceNew:    true,
 			Optional:    true,
 			Default:     "environment",
-			ForceNew:    true,
 		},
 		"experience_analytics": {
 			Type:        schema.TypeList,

--- a/dynatrace/api/service/daviscopilot/dataminingblocklist/schema.json
+++ b/dynatrace/api/service/daviscopilot/dataminingblocklist/schema.json
@@ -70,7 +70,7 @@
 			"type": "boolean"
 		},
 		"enableCopilot": {
-			"default": false,
+			"default": true,
 			"description": "Please note that once generative AI is enabled, you still need to [assign permissions](https://dt-url.net/rh22idn \"Dynatrace Generative AI permissions\") to the relevant user groups.",
 			"displayName": "Enable generative AI",
 			"documentation": "",
@@ -108,6 +108,32 @@
 				"type": "EQUALS"
 			},
 			"type": "boolean"
+		},
+		"piiBlockingEnabled": {
+			"default": true,
+			"description": "",
+			"displayName": "Enable PII blocking",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"type": "boolean"
+		},
+		"piiBlockingTypes": {
+			"description": "",
+			"displayName": "PII blocking types",
+			"documentation": "",
+			"maxObjects": 1,
+			"modificationPolicy": "DEFAULT",
+			"nullable": false,
+			"precondition": {
+				"expectedValue": true,
+				"property": "piiBlockingEnabled",
+				"type": "EQUALS"
+			},
+			"type": {
+				"$ref": "#/types/PiiBlockingTypes"
+			}
 		}
 	},
 	"schemaGroups": [
@@ -157,7 +183,108 @@
 			"type": "object",
 			"version": "0",
 			"versionInfo": ""
+		},
+		"PiiBlockingTypes": {
+			"description": "",
+			"displayName": "PII blocking types",
+			"documentation": "",
+			"properties": {
+				"canadianSocialInsuranceNumber": {
+					"default": true,
+					"description": "",
+					"displayName": "Canadian social insurance number",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"creditCardNumber": {
+					"default": true,
+					"description": "",
+					"displayName": "Credit card number",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"emailAddress": {
+					"default": true,
+					"description": "",
+					"displayName": "Email address",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"ibanBankAccount": {
+					"default": false,
+					"description": "",
+					"displayName": "IBAN bank account",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"ipAddress": {
+					"default": true,
+					"description": "",
+					"displayName": "IP address",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"phoneNumber": {
+					"default": false,
+					"description": "",
+					"displayName": "Phone number",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"urlQueryParameters": {
+					"default": true,
+					"description": "",
+					"displayName": "URL query parameters",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"usBankNumber": {
+					"default": false,
+					"description": "",
+					"displayName": "US bank number",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				},
+				"usSocialSecurityNumber": {
+					"default": true,
+					"description": "",
+					"displayName": "US social security number",
+					"documentation": "",
+					"maxObjects": 1,
+					"modificationPolicy": "DEFAULT",
+					"nullable": false,
+					"type": "boolean"
+				}
+			},
+			"summaryPattern": "",
+			"type": "object",
+			"version": "0",
+			"versionInfo": ""
 		}
 	},
-	"version": "0.4"
+	"version": "0.5"
 }

--- a/dynatrace/api/service/daviscopilot/dataminingblocklist/service.go
+++ b/dynatrace/api/service/daviscopilot/dataminingblocklist/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
 )
 
-const SchemaVersion = "0.4"
+const SchemaVersion = "0.5"
 const SchemaID = "service:davis.copilot.datamining-blocklist"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*service.Settings], error) {

--- a/dynatrace/api/service/daviscopilot/dataminingblocklist/settings/datamining_blocklist_entry.go
+++ b/dynatrace/api/service/daviscopilot/dataminingblocklist/settings/datamining_blocklist_entry.go
@@ -53,7 +53,7 @@ func (me *DataminingBlocklistEntry) Schema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {
 			Type:        schema.TypeString,
-			Description: "no documentation available",
+			Description: "No documentation available",
 			Required:    true,
 		},
 		"type": {

--- a/dynatrace/api/service/daviscopilot/dataminingblocklist/settings/pii_blocking_types.go
+++ b/dynatrace/api/service/daviscopilot/dataminingblocklist/settings/pii_blocking_types.go
@@ -1,0 +1,112 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataminingblocklist
+
+import (
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type PiiBlockingTypes struct {
+	CanadianSocialInsuranceNumber bool `json:"canadianSocialInsuranceNumber"` // Canadian social insurance number
+	CreditCardNumber              bool `json:"creditCardNumber"`              // Credit card number
+	EmailAddress                  bool `json:"emailAddress"`                  // Email address
+	IbanBankAccount               bool `json:"ibanBankAccount"`               // IBAN bank account
+	IpAddress                     bool `json:"ipAddress"`                     // IP address
+	PhoneNumber                   bool `json:"phoneNumber"`                   // Phone number
+	UrlQueryParameters            bool `json:"urlQueryParameters"`            // URL query parameters
+	UsBankNumber                  bool `json:"usBankNumber"`                  // US bank number
+	UsSocialSecurityNumber        bool `json:"usSocialSecurityNumber"`        // US social security number
+}
+
+func (me *PiiBlockingTypes) Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"canadian_social_insurance_number": {
+			Type:        schema.TypeBool,
+			Description: "Canadian social insurance number",
+			Required:    true,
+		},
+		"credit_card_number": {
+			Type:        schema.TypeBool,
+			Description: "Credit card number",
+			Required:    true,
+		},
+		"email_address": {
+			Type:        schema.TypeBool,
+			Description: "Email address",
+			Required:    true,
+		},
+		"iban_bank_account": {
+			Type:        schema.TypeBool,
+			Description: "IBAN bank account",
+			Required:    true,
+		},
+		"ip_address": {
+			Type:        schema.TypeBool,
+			Description: "IP address",
+			Required:    true,
+		},
+		"phone_number": {
+			Type:        schema.TypeBool,
+			Description: "Phone number",
+			Required:    true,
+		},
+		"url_query_parameters": {
+			Type:        schema.TypeBool,
+			Description: "URL query parameters",
+			Required:    true,
+		},
+		"us_bank_number": {
+			Type:        schema.TypeBool,
+			Description: "US bank number",
+			Required:    true,
+		},
+		"us_social_security_number": {
+			Type:        schema.TypeBool,
+			Description: "US social security number",
+			Required:    true,
+		},
+	}
+}
+
+func (me *PiiBlockingTypes) MarshalHCL(properties hcl.Properties) error {
+	return properties.EncodeAll(map[string]any{
+		"canadian_social_insurance_number": me.CanadianSocialInsuranceNumber,
+		"credit_card_number":               me.CreditCardNumber,
+		"email_address":                    me.EmailAddress,
+		"iban_bank_account":                me.IbanBankAccount,
+		"ip_address":                       me.IpAddress,
+		"phone_number":                     me.PhoneNumber,
+		"url_query_parameters":             me.UrlQueryParameters,
+		"us_bank_number":                   me.UsBankNumber,
+		"us_social_security_number":        me.UsSocialSecurityNumber,
+	})
+}
+
+func (me *PiiBlockingTypes) UnmarshalHCL(decoder hcl.Decoder) error {
+	return decoder.DecodeAll(map[string]any{
+		"canadian_social_insurance_number": &me.CanadianSocialInsuranceNumber,
+		"credit_card_number":               &me.CreditCardNumber,
+		"email_address":                    &me.EmailAddress,
+		"iban_bank_account":                &me.IbanBankAccount,
+		"ip_address":                       &me.IpAddress,
+		"phone_number":                     &me.PhoneNumber,
+		"url_query_parameters":             &me.UrlQueryParameters,
+		"us_bank_number":                   &me.UsBankNumber,
+		"us_social_security_number":        &me.UsSocialSecurityNumber,
+	})
+}

--- a/dynatrace/api/service/daviscopilot/dataminingblocklist/settings/settings.go
+++ b/dynatrace/api/service/daviscopilot/dataminingblocklist/settings/settings.go
@@ -18,6 +18,8 @@
 package dataminingblocklist
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/terraform/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -28,6 +30,8 @@ type Settings struct {
 	EnableCopilot               bool                       `json:"enableCopilot"`                         // Please note that once generative AI is enabled, you still need to [assign permissions](https://dt-url.net/rh22idn \"Dynatrace Generative AI permissions\") to the relevant user groups.
 	EnableDocumentSuggestion    *bool                      `json:"enableDocumentSuggestion,omitempty"`    // By enabling document suggestions, Dynatrace Intelligence can find similarities between Problems and existing Notebooks and Dashboards in order to suggest relevant troubleshooting guides. Learn more about [document suggestions](https://dt-url.net/xy02gpo \"Dynatrace AI document suggestions\").
 	EnableTenantAwareDataMining *bool                      `json:"enableTenantAwareDataMining,omitempty"` // You can enrich Dynatrace generative and agentic AI with your environment data. This lets you generate more accurate queries that identify and reference relevant entities, events, spans, logs, and metrics from your environment. Once enabled, Dynatrace Intelligence periodically scans your Grail data to create its own semantic index. Please note, it can take up to 24 hours to reflect changes. Learn more about [environment-aware queries](https://dt-url.net/4g42iu7 \"Dynatrace Generative AI environment aware queries\").
+	PiiBlockingEnabled          bool                       `json:"piiBlockingEnabled"`                    // Enable PII blocking
+	PiiBlockingTypes            *PiiBlockingTypes          `json:"piiBlockingTypes,omitempty"`            // PII blocking types
 }
 
 func (me *Settings) Name() string {
@@ -64,6 +68,21 @@ func (me *Settings) Schema() map[string]*schema.Schema {
 			Description: "You can enrich Dynatrace generative and agentic AI with your environment data. This lets you generate more accurate queries that identify and reference relevant entities, events, spans, logs, and metrics from your environment. Once enabled, Dynatrace Intelligence periodically scans your Grail data to create its own semantic index. Please note, it can take up to 24 hours to reflect changes. Learn more about [environment-aware queries](https://dt-url.net/4g42iu7 \"Dynatrace Generative AI environment aware queries\").",
 			Optional:    true, // precondition
 		},
+		"pii_blocking_enabled": {
+			Type:        schema.TypeBool,
+			Description: "Enable PII blocking",
+			// New required field. Default to "false" as pii_blocking_types must be provided if this is true
+			Optional: true,
+			Default:  false,
+		},
+		"pii_blocking_types": {
+			Type:        schema.TypeList,
+			Description: "PII blocking types",
+			Optional:    true, // precondition
+			Elem:        &schema.Resource{Schema: new(PiiBlockingTypes).Schema()},
+			MinItems:    1,
+			MaxItems:    1,
+		},
 	}
 }
 
@@ -74,6 +93,8 @@ func (me *Settings) MarshalHCL(properties hcl.Properties) error {
 		"enable_copilot":                  me.EnableCopilot,
 		"enable_document_suggestion":      me.EnableDocumentSuggestion,
 		"enable_tenant_aware_data_mining": me.EnableTenantAwareDataMining,
+		"pii_blocking_enabled":            me.PiiBlockingEnabled,
+		"pii_blocking_types":              me.PiiBlockingTypes,
 	})
 }
 
@@ -87,6 +108,21 @@ func (me *Settings) HandlePreconditions() error {
 	if (me.EnableTenantAwareDataMining == nil) && (me.EnableCopilot) {
 		me.EnableTenantAwareDataMining = new(false)
 	}
+	if (me.EnableAgenticAi != nil) && (!me.EnableCopilot) {
+		return fmt.Errorf("'enable_agentic_ai' must not be specified unless 'enable_copilot' is set to 'true'; got 'enable_copilot'='%v'", me.EnableCopilot)
+	}
+	if (me.EnableDocumentSuggestion != nil) && (!me.EnableCopilot) {
+		return fmt.Errorf("'enable_document_suggestion' must not be specified unless 'enable_copilot' is set to 'true'; got 'enable_copilot'='%v'", me.EnableCopilot)
+	}
+	if (me.EnableTenantAwareDataMining != nil) && (!me.EnableCopilot) {
+		return fmt.Errorf("'enable_tenant_aware_data_mining' must not be specified unless 'enable_copilot' is set to 'true'; got 'enable_copilot'='%v'", me.EnableCopilot)
+	}
+	if (me.PiiBlockingTypes != nil) && (!me.PiiBlockingEnabled) {
+		return fmt.Errorf("'pii_blocking_types' must not be specified unless 'pii_blocking_enabled' is set to 'true'; got 'pii_blocking_enabled'='%v'", me.PiiBlockingEnabled)
+	}
+	if (me.PiiBlockingTypes == nil) && (me.PiiBlockingEnabled) {
+		return fmt.Errorf("'pii_blocking_types' must be specified when 'pii_blocking_enabled' is set to 'true'; got 'pii_blocking_enabled'='%v'", me.PiiBlockingEnabled)
+	}
 	// ---- BlocklistEntries DataminingBlocklistEntries -> {"expectedValue":true,"property":"enableTenantAwareDataMining","type":"EQUALS"}
 	return nil
 }
@@ -98,5 +134,7 @@ func (me *Settings) UnmarshalHCL(decoder hcl.Decoder) error {
 		"enable_copilot":                  &me.EnableCopilot,
 		"enable_document_suggestion":      &me.EnableDocumentSuggestion,
 		"enable_tenant_aware_data_mining": &me.EnableTenantAwareDataMining,
+		"pii_blocking_enabled":            &me.PiiBlockingEnabled,
+		"pii_blocking_types":              &me.PiiBlockingTypes,
 	})
 }

--- a/dynatrace/api/service/daviscopilot/dataminingblocklist/testdata/terraform/example_pii_blocking.tf
+++ b/dynatrace/api/service/daviscopilot/dataminingblocklist/testdata/terraform/example_pii_blocking.tf
@@ -1,0 +1,15 @@
+resource "dynatrace_davis_copilot" "pii_blocking" {
+  enable_copilot       = true
+  pii_blocking_enabled = true
+  pii_blocking_types {
+    canadian_social_insurance_number = true
+    credit_card_number               = true
+    email_address                    = true
+    iban_bank_account                = true
+    ip_address                       = true
+    phone_number                     = true
+    url_query_parameters             = true
+    us_bank_number                   = true
+    us_social_security_number        = true
+  }
+}


### PR DESCRIPTION
#### **Why** this PR?
Some APIs have changed with Dynatrace version 343. Therefore, the Terraform resources also need updating.

#### **What** has changed?
- `dynatrace_davis_copilot`: New fields: `pii_blocking_enabled` (default: false) and `pii_blocking_types` (if `pii_blocking_enabled` is set to `true`)
- `dynatrace_maintenance_windows`: New optional field "object_scopes", which contains settings for pausing specific synthetic monitors during the maintenance window
- `dynatrace_kubernetes_enrichment`: New optional "use_ingest_enrichment_config_schema" field.
- `dynatrace_azure_connection` and `dynatrace_aws_connection`: Remove the deprecated enums for the consumers field: "NONE" and "DA" (Breaking change)


Documentation and fixes for conditional field handling

#### **How** does it do it?
Updating the resources based on the settings schema.

#### How is it **tested**?
Existing tests cover most of the changes.

#### How does it affect **users**?
They can make use of all the new fields that are currently available.

**Issue:** PS-49923
