### PR TITLE
refactor: Add remaining clients to clientset

### DIFF
--- a/datasources/tenant/data_source.go
+++ b/datasources/tenant/data_source.go
@@ -44,7 +44,7 @@ func DataSourceRead(d *schema.ResourceData, m any) error {
 		return err
 	}
 
-	envURL := clientSet.Credentials().URL
+	envURL := clientSet.Credentials().ClassicEnvironmentURL
 	if len(envURL) == 0 {
 		d.SetId("")
 		return nil

--- a/dynatrace/api/builtin/generic/service.go
+++ b/dynatrace/api/builtin/generic/service.go
@@ -45,7 +45,7 @@ type service struct {
 }
 
 func (me *service) Client() rest.Client {
-	return rest.HybridClient(me.clientSet.Credentials())
+	return rest.HybridClient(me.clientSet)
 }
 
 func (me *service) Get(ctx context.Context, id string, v *generic.Settings) error {

--- a/dynatrace/api/builtin/host/monitoring/mode/service.go
+++ b/dynatrace/api/builtin/host/monitoring/mode/service.go
@@ -42,7 +42,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*mode.Settings], er
 	}
 	return &service{
 		service: svc,
-		client:  rest.APITokenClient(clientSet.Credentials()),
+		client:  rest.APITokenClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/builtin/hyperscalerauthentication/connections/gcpdynatraceprincipal/validate_test.go
+++ b/dynatrace/api/builtin/hyperscalerauthentication/connections/gcpdynatraceprincipal/validate_test.go
@@ -20,7 +20,6 @@
 package gcpdynatraceprincipal_test
 
 import (
-	"os"
 	"testing"
 
 	gcpservice "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcp"
@@ -28,6 +27,7 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/hyperscalerauthentication/connections/gcpdynatraceprincipal"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,14 +37,8 @@ import (
 // Dynatrace GCP Principal creation as a side effect of submitting ValidConnection to the validate
 // endpoint; if the payload is rejected, no principal will ever be created.
 func TestValidateIsSuccessfulForGcpConnection(t *testing.T) {
-	envURL := os.Getenv("DYNATRACE_ENV_URL")
-	apiToken := os.Getenv("DYNATRACE_API_TOKEN")
-	if envURL == "" || apiToken == "" {
-		t.Skip("Environment Variables DYNATRACE_ENV_URL and DYNATRACE_API_TOKEN must be specified")
-	}
-
-	clientSet := &config.ProviderConfiguration{EnvironmentURL: envURL, APIToken: apiToken}
-	service, err := settings20.Service[*gcpsettings.Settings](clientSet, gcpservice.SchemaID, gcpservice.SchemaVersion)
+	pc := config.ProviderConfigureGeneric(t.Context(), testing2.EnvironmentGetter(t))
+	service, err := settings20.Service[*gcpsettings.Settings](pc, gcpservice.SchemaID, gcpservice.SchemaVersion)
 	require.NoError(t, err)
 
 	validator, ok := service.(settings.Validator[*gcpsettings.Settings])

--- a/dynatrace/api/builtin/logmonitoring/customlogsourcesettings/service.go
+++ b/dynatrace/api/builtin/logmonitoring/customlogsourcesettings/service.go
@@ -39,7 +39,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*customlogsourceset
 	}
 	return &service{
 		service: svc,
-		client:  rest.HybridClient(clientSet.Credentials()),
+		client:  rest.HybridClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/builtin/managementzones/service.go
+++ b/dynatrace/api/builtin/managementzones/service.go
@@ -48,7 +48,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*managementzones.Se
 	return &service{
 		service:    svc,
 		sloService: sloService,
-		client:     rest.HybridClient(clientSet.Credentials()),
+		client:     rest.HybridClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/builtin/monitoring/slo/service.go
+++ b/dynatrace/api/builtin/monitoring/slo/service.go
@@ -41,7 +41,7 @@ const SchemaVersion = "6.0.14"
 const SchemaID = "builtin:monitoring.slo"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*slo.Settings], error) {
-	return &service{clientSet: clientSet, client: rest.HybridClient(clientSet.Credentials())}, nil
+	return &service{clientSet: clientSet, client: rest.HybridClient(clientSet)}, nil
 }
 
 type service struct {
@@ -184,7 +184,7 @@ func (me *service) get(ctx context.Context, id string, v *slo.Settings) error {
 
 	slo := new(sloGet)
 
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(legacyId)), 200)
 	if err := req.Finish(slo); err != nil {
 		return err

--- a/dynatrace/api/builtin/opentelemetrymetrics/service.go
+++ b/dynatrace/api/builtin/opentelemetrymetrics/service.go
@@ -42,7 +42,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*opentelemetrymetri
 	}
 	return &service{
 		service: svc,
-		client:  rest.HybridClient(clientSet.Credentials()),
+		client:  rest.HybridClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/builtin/rum/hostheaders/validate_test.go
+++ b/dynatrace/api/builtin/rum/hostheaders/validate_test.go
@@ -22,13 +22,13 @@ package hostheaders_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	hostheadersvc "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/hostheaders"
 	hostheaders "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/builtin/rum/hostheaders/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/settings/services/settings20"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/stretchr/testify/assert"
@@ -40,17 +40,11 @@ import (
 // builtin:rum.host-headers is used as the test vehicle because it has no custom
 // validators, no side-effects, and a single plain-text field.
 func TestValidateDoesNotCreateObjects(t *testing.T) {
-	envURL := os.Getenv("DYNATRACE_ENV_URL")
-	apiToken := os.Getenv("DYNATRACE_API_TOKEN")
-	if envURL == "" || apiToken == "" {
-		t.Skip("Environment Variables DYNATRACE_ENV_URL and DYNATRACE_API_TOKEN must be specified")
-	}
+	pc := config.ProviderConfigureGeneric(t.Context(), testing2.EnvironmentGetter(t))
+	service, err := settings20.Service[*hostheaders.Settings](pc, hostheadersvc.SchemaID, hostheadersvc.SchemaVersion)
+	require.NoError(t, err)
 
 	headerName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-
-	clientSet := &config.ProviderConfiguration{EnvironmentURL: envURL, APIToken: apiToken}
-	service, err := settings20.Service[*hostheaders.Settings](clientSet, hostheadersvc.SchemaID, hostheadersvc.SchemaVersion)
-	require.NoError(t, err)
 
 	// If Validate accidentally creates an object, clean it up so subsequent
 	// test runs are not polluted.

--- a/dynatrace/api/builtin/rum/web/appdetection/service.go
+++ b/dynatrace/api/builtin/rum/web/appdetection/service.go
@@ -41,7 +41,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*appdetection.Setti
 	}
 	return &service{
 		service: svc,
-		client:  rest.HybridClient(clientSet.Credentials()),
+		client:  rest.HybridClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/builtin/settings/keyrequests/service.go
+++ b/dynatrace/api/builtin/settings/keyrequests/service.go
@@ -60,7 +60,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*keyrequests.Settin
 	return &service{
 		service:   svc,
 		clientSet: clientSet,
-		client:    rest.HybridClient(clientSet.Credentials()),
+		client:    rest.HybridClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/builtin/span/attribute/service.go
+++ b/dynatrace/api/builtin/span/attribute/service.go
@@ -45,7 +45,7 @@ const SchemaVersion = "0.0.42"
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*attribute.Settings], error) {
 	return &service{
 		clientSet: clientSet,
-		client:    rest.HybridClient(clientSet.Credentials()),
+		client:    rest.HybridClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/builtin/span/eventattribute/service.go
+++ b/dynatrace/api/builtin/span/eventattribute/service.go
@@ -43,7 +43,7 @@ const SchemaID = "builtin:span-event-attribute"
 const SchemaVersion = "1.0.17"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*eventattribute.Settings], error) {
-	return &service{clientSet: clientSet, client: rest.HybridClient(clientSet.Credentials())}, nil
+	return &service{clientSet: clientSet, client: rest.HybridClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/cluster/v1/backup/service.go
+++ b/dynatrace/api/cluster/v1/backup/service.go
@@ -33,7 +33,7 @@ type ServiceClient struct {
 // baseURL should look like this: "https://siz65484.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV1Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV1Client(clientSet)}, nil
 }
 
 // Create TODO: documentation

--- a/dynatrace/api/cluster/v1/bindings/service.go
+++ b/dynatrace/api/cluster/v1/bindings/service.go
@@ -66,7 +66,7 @@ func (me *service) SchemaID() string {
 }
 
 func NewPolicyService(clientSet rest.ClientSet) *BindingServiceClient {
-	return &BindingServiceClient{client: rest.ClusterV2Client(clientSet.Credentials())}
+	return &BindingServiceClient{client: rest.ClusterV2Client(clientSet)}
 }
 
 type service struct {

--- a/dynatrace/api/cluster/v1/groups/service.go
+++ b/dynatrace/api/cluster/v1/groups/service.go
@@ -49,7 +49,7 @@ type ServiceClient struct {
 // baseURL should look like this: "https://#######.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV1Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV1Client(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/cluster/v1/internetproxy/service.go
+++ b/dynatrace/api/cluster/v1/internetproxy/service.go
@@ -33,7 +33,7 @@ type ServiceClient struct {
 // baseURL should look like this: "https://siz65484.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV1Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV1Client(clientSet)}, nil
 }
 
 // Create TODO: documentation

--- a/dynatrace/api/cluster/v1/permissions/mgmz/service.go
+++ b/dynatrace/api/cluster/v1/permissions/mgmz/service.go
@@ -79,7 +79,7 @@ func (cs *ServiceClient) SchemaID() string {
 // baseURL should look like this: "https://#######.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV1Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV1Client(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/cluster/v1/policies/service.go
+++ b/dynatrace/api/cluster/v1/policies/service.go
@@ -33,7 +33,7 @@ type PolicyServiceClient struct {
 }
 
 func NewPolicyService(clientSet rest.ClientSet) *PolicyServiceClient {
-	return &PolicyServiceClient{client: rest.ClusterV2Client(clientSet.Credentials())}
+	return &PolicyServiceClient{client: rest.ClusterV2Client(clientSet)}
 }
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*policies.Policy], error) {

--- a/dynatrace/api/cluster/v1/preferences/service.go
+++ b/dynatrace/api/cluster/v1/preferences/service.go
@@ -33,7 +33,7 @@ type ServiceClient struct {
 // baseURL should look like this: "https://siz65484.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV1Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV1Client(clientSet)}, nil
 }
 
 // Create TODO: documentation

--- a/dynatrace/api/cluster/v1/publicendpoints/service.go
+++ b/dynatrace/api/cluster/v1/publicendpoints/service.go
@@ -33,7 +33,7 @@ type ServiceClient struct {
 // baseURL should look like this: "https://siz65484.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV1Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV1Client(clientSet)}, nil
 }
 
 type AddressSettings struct {

--- a/dynatrace/api/cluster/v1/smtp/service.go
+++ b/dynatrace/api/cluster/v1/smtp/service.go
@@ -33,7 +33,7 @@ type ServiceClient struct {
 // baseURL should look like this: "https://siz65484.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV1Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV1Client(clientSet)}, nil
 }
 
 // Create TODO: documentation

--- a/dynatrace/api/cluster/v1/users/service.go
+++ b/dynatrace/api/cluster/v1/users/service.go
@@ -79,7 +79,7 @@ func (cs *ServiceClient) SchemaID() string {
 // baseURL should look like this: "https://siz65484.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV1Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV1Client(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/cluster/v2/envs/service_client.go
+++ b/dynatrace/api/cluster/v2/envs/service_client.go
@@ -36,7 +36,7 @@ type ServiceClient struct {
 // baseURL should look like this: "https://siz65484.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV2Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV2Client(clientSet)}, nil
 }
 
 func evalRetry(rerr *rest.Error, environment *Environment) bool {

--- a/dynatrace/api/cluster/v2/networkzones/service.go
+++ b/dynatrace/api/cluster/v2/networkzones/service.go
@@ -75,7 +75,7 @@ func (cs *ServiceClient) SchemaID() string {
 }
 
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV2Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV2Client(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/cluster/v2/remoteaccess/service.go
+++ b/dynatrace/api/cluster/v2/remoteaccess/service.go
@@ -35,7 +35,7 @@ type ServiceClient struct {
 // baseURL should look like this: "https://siz65484.live.dynatrace.com/api/config/v1"
 // token is an API Token
 func NewService(clientSet rest.ClientSet) (*ServiceClient, error) {
-	return &ServiceClient{client: rest.ClusterV2Client(clientSet.Credentials())}, nil
+	return &ServiceClient{client: rest.ClusterV2Client(clientSet)}, nil
 }
 
 // Create TODO: documentation

--- a/dynatrace/api/v1/config/anomalies/processgroups/service.go
+++ b/dynatrace/api/v1/config/anomalies/processgroups/service.go
@@ -35,7 +35,7 @@ const SchemaID = "v1:config:anomaly-detection:process-groups"
 const BasePath = "/api/config/v1/anomalyDetection/processGroups"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*processgroups.AnomalyDetection], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials()), clientSet: clientSet}, nil
+	return &service{client: rest.APITokenClient(clientSet), clientSet: clientSet}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/applications/web/dataprivacy/service.go
+++ b/dynatrace/api/v1/config/applications/web/dataprivacy/service.go
@@ -41,7 +41,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*dataprivacy.Applic
 	}
 	return &service{
 		schemaID:      SchemaID,
-		client:        rest.APITokenClient(clientSet.Credentials()),
+		client:        rest.APITokenClient(clientSet),
 		webAppService: webAppService}, nil
 }
 

--- a/dynatrace/api/v1/config/applications/web/errors/service.go
+++ b/dynatrace/api/v1/config/applications/web/errors/service.go
@@ -40,7 +40,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*errors.Rules], err
 		return nil, err
 	}
 	return &service{
-		client:        rest.APITokenClient(clientSet.Credentials()),
+		client:        rest.APITokenClient(clientSet),
 		webAppService: webAppService}, nil
 }
 

--- a/dynatrace/api/v1/config/applications/web/keyuseractions/service.go
+++ b/dynatrace/api/v1/config/applications/web/keyuseractions/service.go
@@ -41,7 +41,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*keyuseractions.Set
 		return nil, err
 	}
 	return &service{
-		client:        rest.APITokenClient(clientSet.Credentials()),
+		client:        rest.APITokenClient(clientSet),
 		webAppService: webAppService}, nil
 }
 

--- a/dynatrace/api/v1/config/applications/web/service.go
+++ b/dynatrace/api/v1/config/applications/web/service.go
@@ -50,7 +50,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*web.Application], 
 
 	return &service{
 		service: svc,
-		client:  rest.APITokenClient(clientSet.Credentials()),
+		client:  rest.APITokenClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/v1/config/credentials/aws/iam/service.go
+++ b/dynatrace/api/v1/config/credentials/aws/iam/service.go
@@ -47,5 +47,5 @@ func (me *service) SchemaID() string {
 }
 
 func Service(clientSet rest.ClientSet) (settings.RService[*iam.Settings], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }

--- a/dynatrace/api/v1/config/credentials/aws/service.go
+++ b/dynatrace/api/v1/config/credentials/aws/service.go
@@ -90,7 +90,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*aws.AWSCredentials
 
 	return &service{
 		service: svc,
-		client:  rest.APITokenClient(clientSet.Credentials()),
+		client:  rest.APITokenClient(clientSet),
 	}, nil
 }
 

--- a/dynatrace/api/v1/config/credentials/aws/services/service.go
+++ b/dynatrace/api/v1/config/credentials/aws/services/service.go
@@ -37,7 +37,7 @@ var smu sync.Mutex
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*services.Settings], error) {
 	return &service{
-		client:     rest.APITokenClient(clientSet.Credentials()),
+		client:     rest.APITokenClient(clientSet),
 		supService: NewSupportedServicesService(clientSet),
 	}, nil
 }

--- a/dynatrace/api/v1/config/credentials/aws/services/services_service.go
+++ b/dynatrace/api/v1/config/credentials/aws/services/services_service.go
@@ -42,7 +42,7 @@ var supportedServicesRepo = map[string]map[string]*SupportedService{}
 func NewSupportedServicesService(clientSet rest.ClientSet) *SupportedServicesService {
 	return &SupportedServicesService{
 		url:    clientSet.Credentials().ClassicEnvironmentURL,
-		client: rest.APITokenClient(clientSet.Credentials()),
+		client: rest.APITokenClient(clientSet),
 	}
 }
 

--- a/dynatrace/api/v1/config/credentials/aws/services/services_service.go
+++ b/dynatrace/api/v1/config/credentials/aws/services/services_service.go
@@ -41,7 +41,7 @@ var supportedServicesRepo = map[string]map[string]*SupportedService{}
 
 func NewSupportedServicesService(clientSet rest.ClientSet) *SupportedServicesService {
 	return &SupportedServicesService{
-		url:    clientSet.Credentials().URL,
+		url:    clientSet.Credentials().ClassicEnvironmentURL,
 		client: rest.APITokenClient(clientSet.Credentials()),
 	}
 }

--- a/dynatrace/api/v1/config/credentials/azure/service.go
+++ b/dynatrace/api/v1/config/credentials/azure/service.go
@@ -45,7 +45,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*azure.AzureCredent
 		return nil, err
 	}
 
-	return &service{service: svc, client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{service: svc, client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/credentials/azure/services/service.go
+++ b/dynatrace/api/v1/config/credentials/azure/services/service.go
@@ -37,7 +37,7 @@ var smu sync.Mutex
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*services.Settings], error) {
 	return &service{
-		client:     rest.APITokenClient(clientSet.Credentials()),
+		client:     rest.APITokenClient(clientSet),
 		supService: NewSupportedServicesService(clientSet),
 	}, nil
 }

--- a/dynatrace/api/v1/config/credentials/azure/services/services_service.go
+++ b/dynatrace/api/v1/config/credentials/azure/services/services_service.go
@@ -42,7 +42,7 @@ var supportedServicesRepo = map[string]map[string]*SupportedService{}
 func NewSupportedServicesService(clientSet rest.ClientSet) *SupportedServicesService {
 	return &SupportedServicesService{
 		url:    clientSet.Credentials().ClassicEnvironmentURL,
-		client: rest.APITokenClient(clientSet.Credentials()),
+		client: rest.APITokenClient(clientSet),
 	}
 }
 

--- a/dynatrace/api/v1/config/credentials/azure/services/services_service.go
+++ b/dynatrace/api/v1/config/credentials/azure/services/services_service.go
@@ -41,7 +41,7 @@ var supportedServicesRepo = map[string]map[string]*SupportedService{}
 
 func NewSupportedServicesService(clientSet rest.ClientSet) *SupportedServicesService {
 	return &SupportedServicesService{
-		url:    clientSet.Credentials().URL,
+		url:    clientSet.Credentials().ClassicEnvironmentURL,
 		client: rest.APITokenClient(clientSet.Credentials()),
 	}
 }

--- a/dynatrace/api/v1/config/customtags/list/list_test.go
+++ b/dynatrace/api/v1/config/customtags/list/list_test.go
@@ -165,10 +165,6 @@ func (request *Request) OnResponse(onresponse func(resp *http.Response)) rest.Re
 	panic("unsupported operation")
 }
 
-func (me *Request) SetHeader(name string, value string) {
-	panic("unsupported operation")
-}
-
 func TestCustomTagExport(t *testing.T) {
 	client := NewTestClient(time.Millisecond * 2)
 	_, err := List(t.Context(), client)

--- a/dynatrace/api/v1/config/customtags/list/list_test.go
+++ b/dynatrace/api/v1/config/customtags/list/list_test.go
@@ -60,7 +60,7 @@ func (client *TestClient) Put(ctx context.Context, url string, payload any, expe
 func (client *TestClient) Delete(ctx context.Context, url string, expectedStatusCodes ...int) rest.Request {
 	panic("unsupported operation")
 }
-func (client *TestClient) Credentials() *rest.Credentials {
+func (client *TestClient) ClientSet() rest.ClientSet {
 	panic("unsupported operation")
 }
 

--- a/dynatrace/api/v1/config/customtags/service.go
+++ b/dynatrace/api/v1/config/customtags/service.go
@@ -44,7 +44,7 @@ type service struct {
 var entityIdSelectorRegexp = regexp.MustCompile("entityId\\((.*)\\)")
 
 func (me *service) Get(ctx context.Context, selector string, v *customtags.Settings) (err error) {
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	if err = client.Get(ctx, fmt.Sprintf("/api/v2/tags?entitySelector=%s&from=now-3y&to=now", url.QueryEscape(selector)), 200).Finish(v); err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (me *service) SchemaID() string {
 }
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
-	return list.List(ctx, rest.APITokenClient(me.clientSet.Credentials()))
+	return list.List(ctx, rest.APITokenClient(me.clientSet))
 }
 
 func (me *service) Validate(ctx context.Context, v *customtags.Settings) error {
@@ -88,7 +88,7 @@ func (me *service) Update(ctx context.Context, id string, v *customtags.Settings
 	var err error
 
 	var settingsObj customtags.Settings
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	if err = client.Post(ctx, fmt.Sprintf("/api/v2/tags?entitySelector=%s&from=now-3y&to=now", url.QueryEscape(v.EntitySelector)), v, 200).Finish(&settingsObj); err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (me *service) Delete(ctx context.Context, id string) error {
 }
 
 func (me *service) DeleteValue(ctx context.Context, v *customtags.Settings) error {
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	for _, tag := range v.Tags {
 		if tag.Value == nil || len(*tag.Value) == 0 {
 			if err := client.Delete(ctx, fmt.Sprintf("/api/v2/tags?key=%s&entitySelector=%s", url.QueryEscape(tag.Key), url.QueryEscape(v.EntitySelector)), 200).Finish(); err != nil {

--- a/dynatrace/api/v1/config/dashboards/sharing/service.go
+++ b/dynatrace/api/v1/config/dashboards/sharing/service.go
@@ -41,7 +41,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*sharing.DashboardS
 		return nil, err
 	}
 	return &service{
-		client:           rest.APITokenClient(clientSet.Credentials()),
+		client:           rest.APITokenClient(clientSet),
 		dashboardService: dashboardService,
 	}, nil
 }

--- a/dynatrace/api/v1/config/metrics/calculated/mobile/service.go
+++ b/dynatrace/api/v1/config/metrics/calculated/mobile/service.go
@@ -33,7 +33,7 @@ import (
 const SchemaID = "v1:config:calculated-metrics-mobile"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*mysettings.CalculatedMobileMetric], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/metrics/calculated/service/service.go
+++ b/dynatrace/api/v1/config/metrics/calculated/service/service.go
@@ -33,7 +33,7 @@ import (
 const SchemaID = "v1:config:calculated-metrics-service"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*mysettings.CalculatedServiceMetric], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/metrics/calculated/synthetic/service.go
+++ b/dynatrace/api/v1/config/metrics/calculated/synthetic/service.go
@@ -40,7 +40,7 @@ func Service(clientSet rest.ClientSet) (settings.CRUDService[*mysettings.Calcula
 		return nil, err
 	}
 
-	return &service{service: svc, client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{service: svc, client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/metrics/calculated/web/service.go
+++ b/dynatrace/api/v1/config/metrics/calculated/web/service.go
@@ -47,7 +47,7 @@ const (
 var createErrs = []string{"Unable to create", "already exists"}
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*mysettings.CalculatedWebMetric], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/naming/order/service.go
+++ b/dynatrace/api/v1/config/naming/order/service.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Service(clientSet rest.ClientSet, schemaID string, staticID string, staticName string, basePath string) (settings.CRUDService[*order.Settings], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials()), schemaID: schemaID, StaticID: staticID, StaticName: staticName, BasePath: basePath}, nil
+	return &service{client: rest.APITokenClient(clientSet), schemaID: schemaID, StaticID: staticID, StaticName: staticName, BasePath: basePath}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/synthetic/locations/service.go
+++ b/dynatrace/api/v1/config/synthetic/locations/service.go
@@ -30,7 +30,7 @@ import (
 const SchemaID = "v1:synthetic:locations:all"
 
 func Service(clientSet rest.ClientSet) (settings.RService[*locations.SyntheticLocation], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v1/config/synthetic/locations/service_test.go
+++ b/dynatrace/api/v1/config/synthetic/locations/service_test.go
@@ -23,33 +23,29 @@ import (
 	"context"
 	"encoding/json"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/synthetic/locations"
 	locsettings "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/api/v1/config/synthetic/locations/settings"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 )
 
 func TestSyntheticLocations(t *testing.T) {
-	envURL := os.Getenv("DYNATRACE_ENV_URL")
-	apiToken := os.Getenv("DYNATRACE_API_TOKEN")
-	if envURL == "" || apiToken == "" {
-		t.Skip("Environment Variables DYNATRACE_ENV_URL and DYNATRACE_API_TOKEN must be specified")
-		return
-	}
-	clientSet := &config.ProviderConfiguration{EnvironmentURL: envURL, APIToken: apiToken}
-	service, err := locations.Service(clientSet)
+	pc := config.ProviderConfigureGeneric(t.Context(), testing2.EnvironmentGetter(t))
+	service, err := locations.Service(pc)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+
 	var stubs api.Stubs
 	if stubs, err = service.List(context.Background()); err != nil {
 		t.Error(err)
 		return
 	}
+
 	foundPublic := false
 	foundPrivate := false
 	for _, stub := range stubs {
@@ -74,10 +70,12 @@ func TestSyntheticLocations(t *testing.T) {
 			return
 		}
 	}
+
 	if !foundPublic {
 		t.Error("Expected to find public synthetic locations - found none")
 		return
 	}
+
 	if !foundPrivate {
 		t.Error("Expected to find private synthetic locations - found none")
 		return

--- a/dynatrace/api/v1/config/synthetic/nodes/service.go
+++ b/dynatrace/api/v1/config/synthetic/nodes/service.go
@@ -31,7 +31,7 @@ import (
 const SchemaID = "v1:synthetic:nodes:all"
 
 func Service(clientSet rest.ClientSet) (settings.RService[*nodes.Settings], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v2/apitokens/service.go
+++ b/dynatrace/api/v2/apitokens/service.go
@@ -29,7 +29,7 @@ import (
 )
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*apitokens.APIToken], error) {
-	return ServiceWithClient(rest.APITokenClient(clientSet.Credentials()))
+	return ServiceWithClient(rest.APITokenClient(clientSet))
 }
 
 func ServiceWithClient(client rest.Client) (settings.CRUDService[*apitokens.APIToken], error) {

--- a/dynatrace/api/v2/customdevice/service.go
+++ b/dynatrace/api/v2/customdevice/service.go
@@ -47,7 +47,7 @@ func (me *service) Get(ctx context.Context, id string, v *customdevice.CustomDev
 	stateConfig, stateConfigFound := cfg.(*customdevice.CustomDevice)
 
 	var err error
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	entitySelector := `detectedName("` + id + `"),type("CUSTOM_DEVICE")`
 	var CustomDeviceGetResponse customdevice.CustomDeviceGetResponse
 
@@ -119,7 +119,7 @@ func (me *service) Get(ctx context.Context, id string, v *customdevice.CustomDev
 
 func (me *service) CheckGet(ctx context.Context, id string, v *customdevice.CustomDevice) error {
 	var err error
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	entitySelector := `detectedName("` + id + `"),type("CUSTOM_DEVICE")`
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/entities?from=now-3y&entitySelector=%s&fields=properties", url.QueryEscape(entitySelector))).Expect(200)
 	var CustomDeviceGetResponse customdevice.CustomDeviceGetResponse
@@ -166,7 +166,7 @@ type lresponse struct {
 
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var err error
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	entitySelector := `type("CUSTOM_DEVICE")`
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/entities?from=now-3y&entitySelector=%s&fields=properties,fromRelationships&pageSize=500", url.QueryEscape(entitySelector))).Expect(200)
 	listResponse := lresponse{}
@@ -214,7 +214,7 @@ func (me *service) Create(ctx context.Context, v *customdevice.CustomDevice) (*a
 	if v.CustomDeviceID == "" {
 		v.CustomDeviceID = uuid.NewString()
 	}
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	uiBasedQuery := ""
 	if v.UIBased != nil && *v.UIBased {
 		uiBasedQuery = "?uiBased=true"
@@ -241,7 +241,7 @@ func (me *service) Update(ctx context.Context, id string, v *customdevice.Custom
 	var err error
 	v.CustomDeviceID = id
 	v.EntityId = ""
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	if err = client.Post(ctx, "/api/v2/entities/custom", v, 201, 204).Finish(); err != nil {
 		return err
 	}

--- a/dynatrace/api/v2/entities/service.go
+++ b/dynatrace/api/v2/entities/service.go
@@ -34,7 +34,7 @@ import (
 const SchemaID = "v2:environment:entities"
 
 func Service(entityType string, entityName string, entitySelector string, from string, to string, clientSet rest.ClientSet) (settings.RService[*entities.Settings], error) {
-	return &service{entityType: entityType, entityName: entityName, entitySelector: entitySelector, from: from, to: to, client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{entityType: entityType, entityName: entityName, entitySelector: entitySelector, from: from, to: to, client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v2/entity/service.go
+++ b/dynatrace/api/v2/entity/service.go
@@ -35,7 +35,7 @@ import (
 const SchemaID = "v2:environment:entity"
 
 func Service(clientSet rest.ClientSet) (settings.RService[*entity.Entity], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {
@@ -55,7 +55,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 }
 
 func DataSourceService(clientSet rest.ClientSet) settings.RService[*entity.Entity] {
-	return &dataSourceService{client: rest.APITokenClient(clientSet.Credentials())}
+	return &dataSourceService{client: rest.APITokenClient(clientSet)}
 }
 
 type dataSourceService struct {

--- a/dynatrace/api/v2/geographicregions/cities/service.go
+++ b/dynatrace/api/v2/geographicregions/cities/service.go
@@ -32,7 +32,7 @@ import (
 const SchemaID = "v2:geographicregions:cities"
 
 func Service(clientSet rest.ClientSet) (settings.RService[*cities.Settings], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v2/geographicregions/countries/service.go
+++ b/dynatrace/api/v2/geographicregions/countries/service.go
@@ -30,7 +30,7 @@ import (
 const SchemaID = "v2:geographicregions:countries"
 
 func Service(clientSet rest.ClientSet) (settings.RService[*countries.Settings], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v2/geographicregions/regions/service.go
+++ b/dynatrace/api/v2/geographicregions/regions/service.go
@@ -31,7 +31,7 @@ import (
 const SchemaID = "v2:geographicregions:regions"
 
 func Service(clientSet rest.ClientSet) (settings.RService[*regions.Settings], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials())}, nil
+	return &service{client: rest.APITokenClient(clientSet)}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v2/hub/extension/active_version/service.go
+++ b/dynatrace/api/v2/hub/extension/active_version/service.go
@@ -45,7 +45,7 @@ type service struct {
 
 func (me *service) Get(ctx context.Context, id string, v *active_version.Settings) error {
 	var response GetActiveEnvironmentConfigurationResponse
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	if err := client.Get(ctx, fmt.Sprintf("/api/v2/extensions/%s/environmentConfiguration", url.PathEscape(id)), 200).Finish(&response); err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (me *service) Create(ctx context.Context, v *active_version.Settings) (*api
 	if err := me.ensureInstalled(ctx, name, version); err != nil {
 		return nil, err
 	}
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	createResponse := SetActiveEnvironmentConfigurationResponse{}
 	retry := 10
 	for retry > 0 {
@@ -95,7 +95,7 @@ func (me *service) Create(ctx context.Context, v *active_version.Settings) (*api
 }
 
 func (me *service) ensureInstalled(ctx context.Context, name string, version string) error {
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	response := struct {
 		Name    string `json:"extensionName"`
 		Version string `json:"extensionVersion"`

--- a/dynatrace/api/v2/hub/extension/config/service.go
+++ b/dynatrace/api/v2/hub/extension/config/service.go
@@ -48,7 +48,7 @@ func (me *service) Get(ctx context.Context, id string, v *extension_config.Setti
 	name, configurationID := splitID(id)
 
 	var response GetMonitoringConfigurationResponse
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 
 	urlPath := fmt.Sprintf(
 		"/api/v2/extensions/%s/monitoringConfigurations/%s",
@@ -95,7 +95,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var stubs api.Stubs
 
 	var extensionsList ExtensionsList
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 
 	nextPageKey := "first"
 	for len(nextPageKey) > 0 {
@@ -143,7 +143,7 @@ func (me *service) Create(ctx context.Context, v *extension_config.Settings) (*a
 	if err := me.ensureInstalled(ctx, name, version); err != nil {
 		return nil, err
 	}
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	createResponse := []CreateMonitoringConfigResponse{}
 	retry := 10
 	for retry > 0 {
@@ -166,7 +166,7 @@ func (me *service) Create(ctx context.Context, v *extension_config.Settings) (*a
 }
 
 func (me *service) ensureInstalled(ctx context.Context, name string, version string) error {
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	if strings.HasPrefix(name, "custom:") {
 		return client.Get(ctx, fmt.Sprintf("/api/v2/extensions/%s/%s", url.PathEscape(name), url.QueryEscape(version)), 200).Finish()
 	}
@@ -195,7 +195,7 @@ func (me *service) Update(ctx context.Context, id string, v *extension_config.Se
 	if err := me.ensureInstalled(ctx, name, version); err != nil {
 		return err
 	}
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	createResponse := CreateMonitoringConfigResponse{}
 	payload := MonitoringConfigCreateDto{Value: []byte(v.Value)}
 	if err := client.Put(ctx, fmt.Sprintf("/api/v2/extensions/%s/monitoringConfigurations/%s", url.PathEscape(name), url.PathEscape(configID)), &payload, 200).Finish(&createResponse); err != nil {
@@ -209,7 +209,7 @@ func (me *service) Update(ctx context.Context, id string, v *extension_config.Se
 
 func (me *service) Delete(ctx context.Context, id string) error {
 	name, configID := splitID(id)
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	if err := client.Delete(ctx, fmt.Sprintf("/api/v2/extensions/%s/monitoringConfigurations/%s", url.PathEscape(name), url.PathEscape(configID)), 200).Finish(nil); err != nil {
 		// Potential response when the configuration contains
 		//    import {

--- a/dynatrace/api/v2/hub/extension/config/service.go
+++ b/dynatrace/api/v2/hub/extension/config/service.go
@@ -168,9 +168,7 @@ func (me *service) Create(ctx context.Context, v *extension_config.Settings) (*a
 func (me *service) ensureInstalled(ctx context.Context, name string, version string) error {
 	client := rest.APITokenClient(me.clientSet.Credentials())
 	if strings.HasPrefix(name, "custom:") {
-		request := client.Get(ctx, fmt.Sprintf("/api/v2/extensions/%s/%s", url.PathEscape(name), url.QueryEscape(version)), 200)
-		request.SetHeader("Accept", "application/json; charset=utf-8")
-		return request.Finish()
+		return client.Get(ctx, fmt.Sprintf("/api/v2/extensions/%s/%s", url.PathEscape(name), url.QueryEscape(version)), 200).Finish()
 	}
 	response := struct {
 		Name    string `json:"extensionName"`

--- a/dynatrace/api/v2/hub/items/service.go
+++ b/dynatrace/api/v2/hub/items/service.go
@@ -35,7 +35,7 @@ type Options struct {
 }
 
 func Service(clientSet rest.ClientSet, opts Options) (settings.RService[*items.HubItemList], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials()), opts: opts}, nil
+	return &service{client: rest.APITokenClient(clientSet), opts: opts}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v2/networkzones/service.go
+++ b/dynatrace/api/v2/networkzones/service.go
@@ -36,7 +36,7 @@ import (
 const SchemaID = "v2:environment:network-zones"
 
 func Service(clientSet rest.ClientSet) (settings.CRUDService[*networkzones.NetworkZone], error) {
-	return &service{client: rest.APITokenClient(clientSet.Credentials()), clientSet: clientSet}, nil
+	return &service{client: rest.APITokenClient(clientSet), clientSet: clientSet}, nil
 }
 
 type service struct {

--- a/dynatrace/api/v2/slo/service.go
+++ b/dynatrace/api/v2/slo/service.go
@@ -56,7 +56,7 @@ func (me *service) Get(ctx context.Context, id string, v *slo.SLO) error {
 func (me *service) get(ctx context.Context, id string, v *slo.SLO) error {
 	var err error
 
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	req := client.Get(ctx, fmt.Sprintf("/api/v2/slo/%s?evaluate=false", url.PathEscape(id)), 200)
 	if err = req.Finish(v); err != nil {
 		return err
@@ -83,7 +83,7 @@ type sloListEntry struct {
 func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	req := client.Get(ctx, "/api/v2/slo?pageSize=4000&sort=name&timeFrame=CURRENT&pageIdx=1&demo=false&evaluate=false", 200)
 	var slos sloList
 	if err = req.Finish(&slos); err != nil {
@@ -109,7 +109,7 @@ func (me *service) Create(ctx context.Context, v *slo.SLO) (*api.Stub, error) {
 
 	var id string
 
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	req := client.Post(ctx, "/api/v2/slo", v, 201).OnResponse(func(resp *http.Response) {
 		if resp == nil {
 			return
@@ -190,11 +190,11 @@ func (me *service) Create(ctx context.Context, v *slo.SLO) (*api.Stub, error) {
 }
 
 func (me *service) Update(ctx context.Context, id string, v *slo.SLO) error {
-	return rest.APITokenClient(me.clientSet.Credentials()).Put(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(id)), v, 200).Finish()
+	return rest.APITokenClient(me.clientSet).Put(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(id)), v, 200).Finish()
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return rest.APITokenClient(me.clientSet.Credentials()).Delete(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(id)), 204).Finish()
+	return rest.APITokenClient(me.clientSet).Delete(ctx, fmt.Sprintf("/api/v2/slo/%s", url.PathEscape(id)), 204).Finish()
 }
 
 func (me *service) New() *slo.SLO {

--- a/dynatrace/api/v2/synthetic/monitors/service.go
+++ b/dynatrace/api/v2/synthetic/monitors/service.go
@@ -47,7 +47,7 @@ func (me *service) Create(ctx context.Context, v *monitors.Settings) (*api.Stub,
 	resp := struct {
 		EntityId string `json:"entityId"`
 	}{}
-	client := rest.APITokenClient(me.clientSet.Credentials())
+	client := rest.APITokenClient(me.clientSet)
 	if err = client.Post(ctx, BasePath, v, 201).Finish(&resp); err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (me *service) Create(ctx context.Context, v *monitors.Settings) (*api.Stub,
 }
 
 func (me *service) Get(ctx context.Context, id string, v *monitors.Settings) error {
-	if err := rest.APITokenClient(me.clientSet.Credentials()).Get(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), 200).Finish(v); err != nil {
+	if err := rest.APITokenClient(me.clientSet).Get(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), 200).Finish(v); err != nil {
 		return err
 	}
 
@@ -111,7 +111,7 @@ func (me *service) List(ctx context.Context) (api.Stubs, error) {
 	var err error
 	var monitors monitorList
 
-	if err = rest.APITokenClient(me.clientSet.Credentials()).Get(ctx, BasePath, 200).Finish(&monitors); err != nil {
+	if err = rest.APITokenClient(me.clientSet).Get(ctx, BasePath, 200).Finish(&monitors); err != nil {
 		return nil, err
 	}
 	stubs := api.Stubs{}
@@ -126,7 +126,7 @@ func (me *service) Validate(v *monitors.Settings) error {
 }
 
 func (me *service) Update(ctx context.Context, id string, v *monitors.Settings) error {
-	err := rest.APITokenClient(me.clientSet.Credentials()).Put(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), v, 200).Finish()
+	err := rest.APITokenClient(me.clientSet).Put(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), v, 200).Finish()
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (me *service) Update(ctx context.Context, id string, v *monitors.Settings) 
 }
 
 func (me *service) Delete(ctx context.Context, id string) error {
-	return rest.APITokenClient(me.clientSet.Credentials()).Delete(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), 204).Finish()
+	return rest.APITokenClient(me.clientSet).Delete(ctx, fmt.Sprintf("%s/%s", BasePath, url.PathEscape(id)), 204).Finish()
 }
 
 func (me *service) New() *monitors.Settings {

--- a/dynatrace/export/environment.go
+++ b/dynatrace/export/environment.go
@@ -64,7 +64,7 @@ type Environment struct {
 }
 
 func (me *Environment) TenantID() string {
-	envURL := me.ClientSet.Credentials().URL
+	envURL := me.ClientSet.Credentials().ClassicEnvironmentURL
 
 	var tenant string
 	if strings.Contains(envURL, "/e/") {

--- a/dynatrace/export/resource_descriptor_test.go
+++ b/dynatrace/export/resource_descriptor_test.go
@@ -101,6 +101,18 @@ func (m *mockService[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
+// emptyGetter is a mock implementation of config.Getter that returns empty values for any key
+type emptyGetter struct {
+}
+
+func (e emptyGetter) Get(key string) any {
+	return ""
+}
+
+func getEmptyProviderConfiguration(t *testing.T) *config.ProviderConfiguration {
+	return config.ProviderConfigureGeneric(t.Context(), &emptyGetter{})
+}
+
 func TestAddInsertAfterWeakIDDependencies(t *testing.T) {
 	t.Run("adds weak ID dependency for Settings 2.0 with insert after", func(t *testing.T) {
 		// Create a resource with Settings 2.0 schema that has InsertAfter
@@ -118,7 +130,7 @@ func TestAddInsertAfterWeakIDDependencies(t *testing.T) {
 		}
 
 		// Execute
-		AddInsertAfterWeakIDDependencies(resources, &config.ProviderConfiguration{})
+		AddInsertAfterWeakIDDependencies(resources, getEmptyProviderConfiguration(t))
 
 		// Verify
 		descriptor := resources[testResType]
@@ -142,7 +154,7 @@ func TestAddInsertAfterWeakIDDependencies(t *testing.T) {
 		}
 
 		// Execute
-		AddInsertAfterWeakIDDependencies(resources, &config.ProviderConfiguration{})
+		AddInsertAfterWeakIDDependencies(resources, getEmptyProviderConfiguration(t))
 
 		// Verify
 		descriptor := resources[testResType]
@@ -166,7 +178,7 @@ func TestAddInsertAfterWeakIDDependencies(t *testing.T) {
 		}
 
 		// Execute
-		AddInsertAfterWeakIDDependencies(resources, &config.ProviderConfiguration{})
+		AddInsertAfterWeakIDDependencies(resources, getEmptyProviderConfiguration(t))
 
 		// Verify - no dependency should be added for non-Settings 2.0 schema
 		descriptor := resources[testResType]
@@ -189,7 +201,7 @@ func TestAddInsertAfterWeakIDDependencies(t *testing.T) {
 		}
 
 		// Execute
-		AddInsertAfterWeakIDDependencies(resources, &config.ProviderConfiguration{})
+		AddInsertAfterWeakIDDependencies(resources, getEmptyProviderConfiguration(t))
 
 		// Verify - no dependency should be added for schema without InsertAfter
 		descriptor := resources[testResType]
@@ -213,7 +225,7 @@ func TestAddInsertAfterWeakIDDependencies(t *testing.T) {
 		}
 
 		// Execute
-		AddInsertAfterWeakIDDependencies(resources, &config.ProviderConfiguration{})
+		AddInsertAfterWeakIDDependencies(resources, getEmptyProviderConfiguration(t))
 
 		// Verify - should still have only one dependency
 		descriptor := resources[testResType]
@@ -257,7 +269,7 @@ func TestAddInsertAfterWeakIDDependencies(t *testing.T) {
 		}
 
 		// Execute
-		AddInsertAfterWeakIDDependencies(resources, &config.ProviderConfiguration{})
+		AddInsertAfterWeakIDDependencies(resources, getEmptyProviderConfiguration(t))
 
 		// Verify each resource was processed correctly
 		assert.True(t, resources[resTypeWithInsertAfter].HasWeakIDDependencyTo(resTypeWithInsertAfter),
@@ -287,7 +299,7 @@ func TestAddInsertAfterWeakIDDependencies(t *testing.T) {
 		}
 
 		// Execute
-		AddInsertAfterWeakIDDependencies(resources, &config.ProviderConfiguration{})
+		AddInsertAfterWeakIDDependencies(resources, getEmptyProviderConfiguration(t))
 
 		// Verify - should have both the existing dep and the new weak ID dep
 		descriptor := resources[testResType]

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
@@ -56,7 +55,7 @@ func (me *api_token_client) Get(ctx context.Context, url string, expectedStatusC
 }
 
 func (me *api_token_client) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &api_token_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: map[string]string{"Content-Type": "application/json"}}
+	req := &api_token_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -64,7 +63,7 @@ func (me *api_token_client) Post(ctx context.Context, url string, payload any, e
 }
 
 func (me *api_token_client) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &api_token_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: map[string]string{"Content-Type": "application/json"}}
+	req := &api_token_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -79,16 +78,28 @@ func (me *api_token_client) Delete(ctx context.Context, url string, expectedStat
 	return req
 }
 
-func (me *api_token_request) Finish(vs ...any) error {
+func (me *api_token_request) Finish(optionalTarget ...any) error {
 	credentials := me.client.Credentials()
 	if !credentials.ContainsAPIToken() {
 		return NoAPITokenError
 	}
-	classicRequest := classic_request(*me)
-	if credentials.URL == TestCaseEnvURL {
-		return errors.New("classic")
+
+	var target any
+	if len(optionalTarget) > 0 {
+		target = optionalTarget[0]
 	}
-	return classicRequest.Finish(vs...)
+
+	client, err := createAPITokenClient(me.client.Credentials().ClassicEnvironmentURL, me.client.Credentials().Token)
+	if err != nil {
+		return err
+	}
+
+	pathURL, err := url.Parse(me.url)
+	if err != nil {
+		return err
+	}
+
+	return request(*me).HandleResponse(client, pathURL, target)
 }
 
 type api_token_request request
@@ -103,29 +114,20 @@ func (me *api_token_request) OnResponse(onResponse func(resp *http.Response)) Re
 	return me
 }
 
-func (me *api_token_request) SetHeader(name string, value string) {
-	if me.headers == nil {
-		me.headers = map[string]string{}
-	}
-	me.headers[name] = value
-}
+var apiTokenClientCache = map[string]*rest.Client{}
 
-type classic_request request
+var apiTokenClientCacheMutex sync.Mutex
 
-var classicClientCache = map[string]*rest.Client{}
-
-var classicClientCacheMutex sync.Mutex
-
-func createClassicClient(classicURL string, apiToken string) (*rest.Client, error) {
+func createAPITokenClient(classicURL string, apiToken string) (*rest.Client, error) {
 	if classicURL == "" {
 		// sanity check - this should not be empty anymore at this point
 		return nil, NoClassicURLDefinedErr
 	}
 
-	classicClientCacheMutex.Lock()
-	defer classicClientCacheMutex.Unlock()
+	apiTokenClientCacheMutex.Lock()
+	defer apiTokenClientCacheMutex.Unlock()
 
-	if client, found := classicClientCache[classicURL]; found {
+	if client, found := apiTokenClientCache[classicURL]; found {
 		return client, nil
 	}
 
@@ -141,41 +143,7 @@ func createClassicClient(classicURL string, apiToken string) (*rest.Client, erro
 		return nil, err
 	}
 
-	classicClientCache[classicURL] = client
+	apiTokenClientCache[classicURL] = client
 
 	return client, nil
-}
-
-func (me *classic_request) Finish(optionalTarget ...any) error {
-	var target any
-	if len(optionalTarget) > 0 {
-		target = optionalTarget[0]
-	}
-	classicURL := EvalClassicURL(me.client.Credentials().URL)
-
-	client, err := createClassicClient(classicURL, me.client.Credentials().Token)
-	if err != nil {
-		return err
-	}
-	for headername, headervalue := range me.headers {
-		client.SetHeader(headername, headervalue)
-	}
-
-	pathURL, err := url.Parse(me.url)
-	if err != nil {
-		return err
-	}
-
-	return request(*me).HandleResponse(client, pathURL, target)
-}
-
-func EvalClassicURL(envURL string) string {
-	envURL = strings.TrimSuffix(strings.TrimSpace(envURL), "/")
-	if len(envURL) == 0 {
-		return envURL
-	}
-	envURL = strings.ReplaceAll(envURL, ".dev.apps.dynatracelabs.", ".dev.dynatracelabs.")
-	envURL = strings.ReplaceAll(envURL, ".sprint.apps.dynatracelabs.", ".sprint.dynatracelabs.")
-	envURL = strings.ReplaceAll(envURL, ".apps.dynatrace.", ".live.dynatrace.")
-	return envURL
 }

--- a/dynatrace/rest/api_token_client.go
+++ b/dynatrace/rest/api_token_client.go
@@ -19,10 +19,8 @@ package rest
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/url"
-	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
@@ -32,18 +30,16 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 )
 
-var NoClassicURLDefinedErr = errors.New("no Environment URL has been specified. Use either the environment variable `DYNATRACE_ENV_URL` or the configuration attribute `dt_env_url` of the provider for that")
-
-func APITokenClient(credentials *Credentials) Client {
-	return &api_token_client{credentials: credentials}
+func APITokenClient(clientSet ClientSet) Client {
+	return &api_token_client{clientSet: clientSet}
 }
 
 type api_token_client struct {
-	credentials *Credentials
+	clientSet ClientSet
 }
 
-func (me *api_token_client) Credentials() *Credentials {
-	return me.credentials
+func (me *api_token_client) ClientSet() ClientSet {
+	return me.clientSet
 }
 
 func (me *api_token_client) Get(ctx context.Context, url string, expectedStatusCodes ...int) Request {
@@ -79,17 +75,7 @@ func (me *api_token_client) Delete(ctx context.Context, url string, expectedStat
 }
 
 func (me *api_token_request) Finish(optionalTarget ...any) error {
-	credentials := me.client.Credentials()
-	if !credentials.ContainsAPIToken() {
-		return NoAPITokenError
-	}
-
-	var target any
-	if len(optionalTarget) > 0 {
-		target = optionalTarget[0]
-	}
-
-	client, err := createAPITokenClient(me.client.Credentials().ClassicEnvironmentURL, me.client.Credentials().Token)
+	client, err := me.client.ClientSet().APITokenClient()
 	if err != nil {
 		return err
 	}
@@ -99,6 +85,10 @@ func (me *api_token_request) Finish(optionalTarget ...any) error {
 		return err
 	}
 
+	var target any
+	if len(optionalTarget) > 0 {
+		target = optionalTarget[0]
+	}
 	return request(*me).HandleResponse(client, pathURL, target)
 }
 
@@ -114,36 +104,12 @@ func (me *api_token_request) OnResponse(onResponse func(resp *http.Response)) Re
 	return me
 }
 
-var apiTokenClientCache = map[string]*rest.Client{}
-
-var apiTokenClientCacheMutex sync.Mutex
-
-func createAPITokenClient(classicURL string, apiToken string) (*rest.Client, error) {
-	if classicURL == "" {
-		// sanity check - this should not be empty anymore at this point
-		return nil, NoClassicURLDefinedErr
-	}
-
-	apiTokenClientCacheMutex.Lock()
-	defer apiTokenClientCacheMutex.Unlock()
-
-	if client, found := apiTokenClientCache[classicURL]; found {
-		return client, nil
-	}
-
-	client, err := clients.Factory().
+func CreateAPITokenClient(ctx context.Context, classicURL string, apiToken string) (*rest.Client, error) {
+	return clients.Factory().
 		WithUserAgent(version.UserAgent()).
 		WithClassicURL(classicURL).
 		WithAccessToken(apiToken).
 		WithHTTPListener(logging.HTTPListener("classic")).
 		WithRetryOptions(defaultRetryOptions).
-		CreateClassicClient()
-
-	if err != nil {
-		return nil, err
-	}
-
-	apiTokenClientCache[classicURL] = client
-
-	return client, nil
+		CreateClassicClientWithContext(ctx)
 }

--- a/dynatrace/rest/classic_hybrid_client.go
+++ b/dynatrace/rest/classic_hybrid_client.go
@@ -25,17 +25,16 @@ import (
 
 // ClassicHybridClient prefers classic over platform requests and doesn't consider the DYNATRACE_HTTP_OAUTH_PREFERENCE env variable.
 func ClassicHybridClient(clientSet ClientSet) Client {
-	credentials := clientSet.Credentials()
-	return &classic_hybrid_client{client: HybridClient(credentials), credentials: credentials}
+	return &classic_hybrid_client{client: HybridClient(clientSet), clientSet: clientSet}
 }
 
 type classic_hybrid_client struct {
-	client      Client
-	credentials *Credentials
+	client    Client
+	clientSet ClientSet
 }
 
-func (me *classic_hybrid_client) Credentials() *Credentials {
-	return me.credentials
+func (me *classic_hybrid_client) ClientSet() ClientSet {
+	return me.clientSet
 }
 
 func (me *classic_hybrid_client) Get(ctx context.Context, url string, expectedStatusCodes ...int) Request {

--- a/dynatrace/rest/client.go
+++ b/dynatrace/rest/client.go
@@ -26,5 +26,5 @@ type Client interface {
 	Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request
 	Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request
 	Delete(ctx context.Context, url string, expectedStatusCodes ...int) Request
-	Credentials() *Credentials
+	ClientSet() ClientSet
 }

--- a/dynatrace/rest/client_set.go
+++ b/dynatrace/rest/client_set.go
@@ -28,4 +28,11 @@ type ClientSet interface {
 	Credentials() *Credentials
 	IAMClient() (IAMClient, error)
 	PlatformClient() (*rest2.Client, error)
+
+	// ClassicPlatformClient returns a client that uses OAuth or platform token authentication to make requests on classic URLs.
+	ClassicPlatformClient() (*rest2.Client, error)
+
+	APITokenClient() (*rest2.Client, error)
+	ClusterV1Client() (*rest2.Client, error)
+	ClusterV2Client() (*rest2.Client, error)
 }

--- a/dynatrace/rest/cluster_v1_client.go
+++ b/dynatrace/rest/cluster_v1_client.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 
 	restlogging "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
@@ -32,19 +31,16 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 )
 
-func ClusterV1Client(credentials *Credentials) Client {
-	creds := *credentials
-	creds.ClassicEnvironmentURL = strings.TrimSuffix(credentials.Cluster.URL, "/") + "/api/v1.0/onpremise"
-	creds.Token = credentials.Cluster.Token
-	return &cluster_v1_client{credentials: &creds}
+func ClusterV1Client(clientSet ClientSet) Client {
+	return &cluster_v1_client{clientSet: clientSet}
 }
 
 type cluster_v1_client struct {
-	credentials *Credentials
+	clientSet ClientSet
 }
 
-func (me *cluster_v1_client) Credentials() *Credentials {
-	return me.credentials
+func (me *cluster_v1_client) ClientSet() ClientSet {
+	return me.clientSet
 }
 
 func (me *cluster_v1_client) Get(ctx context.Context, url string, expectedStatusCodes ...int) Request {
@@ -81,41 +77,20 @@ func (me *cluster_v1_client) Delete(ctx context.Context, url string, expectedSta
 
 type cluster_v1_request request
 
-var clusterV1ClientCache = map[string]*rest.Client{}
+func CreateClusterV1Client(ctx context.Context, baseURL string, apiToken string) (*rest.Client, error) {
+	clusterURL := strings.TrimSuffix(baseURL, "/") + "/api/v1.0/onpremise"
 
-var clusterV1ClientCacheMutex sync.Mutex
-
-func createClusterV1Client(baseURL string, apiToken string) (*rest.Client, error) {
-	clusterV1ClientCacheMutex.Lock()
-	defer clusterV1ClientCacheMutex.Unlock()
-
-	if client, found := clusterV1ClientCache[baseURL]; found {
-		return client, nil
-	}
-
-	client, err := clients.Factory().
+	return clients.Factory().
 		WithUserAgent(version.UserAgent()).
-		WithClassicURL(baseURL).
+		WithClassicURL(clusterURL).
 		WithAccessToken(apiToken).
 		WithRetryOptions(defaultRetryOptions).
 		WithHTTPListener(restlogging.HTTPListener("clustv1 ")).
-		CreateClassicClient()
-
-	if client != nil && err == nil {
-		clusterV1ClientCache[baseURL] = client
-	}
-
-	return client, err
+		CreateClassicClientWithContext(ctx)
 }
 
 func (me *cluster_v1_request) Finish(optionalTarget ...any) error {
-	var target any
-	if len(optionalTarget) > 0 {
-		target = optionalTarget[0]
-	}
-	clusterURL := strings.TrimSuffix(me.client.Credentials().Cluster.URL, "/") + "/api/v1.0/onpremise"
-
-	client, err := createClusterV1Client(clusterURL, me.client.Credentials().Cluster.Token)
+	client, err := me.client.ClientSet().ClusterV1Client()
 	if err != nil {
 		return err
 	}
@@ -123,6 +98,11 @@ func (me *cluster_v1_request) Finish(optionalTarget ...any) error {
 	fullURL, err := url.Parse(me.url)
 	if err != nil {
 		return err
+	}
+
+	var target any
+	if len(optionalTarget) > 0 {
+		target = optionalTarget[0]
 	}
 	return request(*me).HandleResponse(client, fullURL, target)
 }

--- a/dynatrace/rest/cluster_v1_client.go
+++ b/dynatrace/rest/cluster_v1_client.go
@@ -34,7 +34,7 @@ import (
 
 func ClusterV1Client(credentials *Credentials) Client {
 	creds := *credentials
-	creds.URL = strings.TrimSuffix(credentials.Cluster.URL, "/") + "/api/v1.0/onpremise"
+	creds.ClassicEnvironmentURL = strings.TrimSuffix(credentials.Cluster.URL, "/") + "/api/v1.0/onpremise"
 	creds.Token = credentials.Cluster.Token
 	return &cluster_v1_client{credentials: &creds}
 }
@@ -56,7 +56,7 @@ func (me *cluster_v1_client) Get(ctx context.Context, url string, expectedStatus
 }
 
 func (me *cluster_v1_client) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &cluster_v1_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: headers.ContentType.ApplicationJSON}
+	req := &cluster_v1_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -64,7 +64,7 @@ func (me *cluster_v1_client) Post(ctx context.Context, url string, payload any, 
 }
 
 func (me *cluster_v1_client) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &cluster_v1_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: headers.ContentType.ApplicationJSON}
+	req := &cluster_v1_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -135,11 +135,4 @@ func (me *cluster_v1_request) Expect(codes ...int) Request {
 func (me *cluster_v1_request) OnResponse(onResponse func(resp *http.Response)) Request {
 	me.onResponse = onResponse
 	return me
-}
-
-func (me *cluster_v1_request) SetHeader(name string, value string) {
-	if me.headers == nil {
-		me.headers = map[string]string{}
-	}
-	me.headers[name] = value
 }

--- a/dynatrace/rest/cluster_v2_client.go
+++ b/dynatrace/rest/cluster_v2_client.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/version"
@@ -32,19 +31,16 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients"
 )
 
-func ClusterV2Client(credentials *Credentials) Client {
-	creds := *credentials
-	creds.ClassicEnvironmentURL = strings.TrimSuffix(credentials.Cluster.URL, "/") + "/api/cluster/v2"
-	creds.Token = credentials.Cluster.Token
-	return &cluster_v2_client{credentials: &creds}
+func ClusterV2Client(clientSet ClientSet) Client {
+	return &cluster_v2_client{clientSet: clientSet}
 }
 
 type cluster_v2_client struct {
-	credentials *Credentials
+	clientSet ClientSet
 }
 
-func (me *cluster_v2_client) Credentials() *Credentials {
-	return me.credentials
+func (me *cluster_v2_client) ClientSet() ClientSet {
+	return me.clientSet
 }
 
 func (me *cluster_v2_client) Get(ctx context.Context, url string, expectedStatusCodes ...int) Request {
@@ -81,41 +77,20 @@ func (me *cluster_v2_client) Delete(ctx context.Context, url string, expectedSta
 
 type cluster_v2_request request
 
-var clusterV2ClientCache = map[string]*rest.Client{}
-
-var clusterV2ClientCacheMutex sync.Mutex
-
-func createClusterV2Client(baseURL string, apiToken string) (*rest.Client, error) {
-	clusterV2ClientCacheMutex.Lock()
-	defer clusterV2ClientCacheMutex.Unlock()
-
-	if client, found := clusterV2ClientCache[baseURL]; found {
-		return client, nil
-	}
-
-	client, err := clients.Factory().
+func CreateClusterV2Client(ctx context.Context, baseURL string, apiToken string) (*rest.Client, error) {
+	clusterV2URL := strings.TrimSuffix(baseURL, "/") + "/api/cluster/v2"
+	return clients.Factory().
 		WithUserAgent(version.UserAgent()).
-		WithClassicURL(baseURL).
+		WithClassicURL(clusterV2URL).
 		WithAccessToken(apiToken).
 		WithRetryOptions(defaultRetryOptions).
 		WithHTTPListener(logging.HTTPListener("clustv2 ")).
-		CreateClassicClient()
-
-	if client != nil && err == nil {
-		clusterV2ClientCache[baseURL] = client
-	}
-
-	return client, err
+		CreateClassicClientWithContext(ctx)
 }
 
 func (me *cluster_v2_request) Finish(optionalTarget ...any) error {
-	var target any
-	if len(optionalTarget) > 0 {
-		target = optionalTarget[0]
-	}
-	clusterV2URL := strings.TrimSuffix(me.client.Credentials().Cluster.URL, "/") + "/api/cluster/v2"
 
-	client, err := createClusterV2Client(clusterV2URL, me.client.Credentials().Cluster.Token)
+	client, err := me.client.ClientSet().ClusterV2Client()
 	if err != nil {
 		return err
 	}
@@ -123,6 +98,11 @@ func (me *cluster_v2_request) Finish(optionalTarget ...any) error {
 	fullURL, err := url.Parse(me.url)
 	if err != nil {
 		return err
+	}
+
+	var target any
+	if len(optionalTarget) > 0 {
+		target = optionalTarget[0]
 	}
 
 	return request(*me).HandleResponse(client, fullURL, target)

--- a/dynatrace/rest/cluster_v2_client.go
+++ b/dynatrace/rest/cluster_v2_client.go
@@ -34,7 +34,7 @@ import (
 
 func ClusterV2Client(credentials *Credentials) Client {
 	creds := *credentials
-	creds.URL = strings.TrimSuffix(credentials.Cluster.URL, "/") + "/api/cluster/v2"
+	creds.ClassicEnvironmentURL = strings.TrimSuffix(credentials.Cluster.URL, "/") + "/api/cluster/v2"
 	creds.Token = credentials.Cluster.Token
 	return &cluster_v2_client{credentials: &creds}
 }
@@ -56,7 +56,7 @@ func (me *cluster_v2_client) Get(ctx context.Context, url string, expectedStatus
 }
 
 func (me *cluster_v2_client) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &cluster_v2_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: headers.ContentType.ApplicationJSON}
+	req := &cluster_v2_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -64,7 +64,7 @@ func (me *cluster_v2_client) Post(ctx context.Context, url string, payload any, 
 }
 
 func (me *cluster_v2_client) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &cluster_v2_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: headers.ContentType.ApplicationJSON}
+	req := &cluster_v2_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -136,11 +136,4 @@ func (me *cluster_v2_request) Expect(codes ...int) Request {
 func (me *cluster_v2_request) OnResponse(onResponse func(resp *http.Response)) Request {
 	me.onResponse = onResponse
 	return me
-}
-
-func (me *cluster_v2_request) SetHeader(name string, value string) {
-	if me.headers == nil {
-		me.headers = map[string]string{}
-	}
-	me.headers[name] = value
 }

--- a/dynatrace/rest/credentials.go
+++ b/dynatrace/rest/credentials.go
@@ -17,8 +17,6 @@
 
 package rest
 
-const TestCaseEnvURL = "go-test"
-
 type IAMCredentials struct {
 	ClientID     string
 	AccountID    string
@@ -41,11 +39,11 @@ type ClusterCredentials struct {
 }
 
 type Credentials struct {
-	URL      string
-	Token    string
-	IAM      IAMCredentials
-	Platform PlatformCredentials
-	Cluster  ClusterCredentials
+	ClassicEnvironmentURL string
+	Token                 string
+	IAM                   IAMCredentials
+	Platform              PlatformCredentials
+	Cluster               ClusterCredentials
 }
 
 func (c *Credentials) ContainsOAuth() bool {

--- a/dynatrace/rest/hybrid_client.go
+++ b/dynatrace/rest/hybrid_client.go
@@ -26,16 +26,16 @@ import (
 	"github.com/google/uuid"
 )
 
-func HybridClient(credentials *Credentials) Client {
-	return &hybrid_client{credentials: credentials}
+func HybridClient(clientSet ClientSet) Client {
+	return &hybrid_client{clientSet: clientSet}
 }
 
 type hybrid_client struct {
-	credentials *Credentials
+	clientSet ClientSet
 }
 
-func (me *hybrid_client) Credentials() *Credentials {
-	return me.credentials
+func (me *hybrid_client) ClientSet() ClientSet {
+	return me.clientSet
 }
 
 func (me *hybrid_client) Get(ctx context.Context, url string, expectedStatusCodes ...int) Request {
@@ -78,7 +78,7 @@ func (me *hybrid_request) Finish(optionalTarget ...any) error {
 		}
 	}
 
-	credentials := me.client.Credentials()
+	credentials := me.client.ClientSet().Credentials()
 
 	if !credentials.ContainsAPIToken() && !credentials.ContainsOAuthOrPlatformToken() {
 		if isOAuthPreferred {

--- a/dynatrace/rest/hybrid_client.go
+++ b/dynatrace/rest/hybrid_client.go
@@ -19,7 +19,6 @@ package rest
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
@@ -48,7 +47,7 @@ func (me *hybrid_client) Get(ctx context.Context, url string, expectedStatusCode
 }
 
 func (me *hybrid_client) Post(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &hybrid_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload, headers: headers.ContentType.ApplicationJSON}
+	req := &hybrid_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPost, payload: payload}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -56,7 +55,7 @@ func (me *hybrid_client) Post(ctx context.Context, url string, payload any, expe
 }
 
 func (me *hybrid_client) Put(ctx context.Context, url string, payload any, expectedStatusCodes ...int) Request {
-	req := &hybrid_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload, headers: headers.ContentType.ApplicationJSON}
+	req := &hybrid_request{id: uuid.NewString(), ctx: ctx, client: me, url: url, method: http.MethodPut, payload: payload}
 	if len(expectedStatusCodes) > 0 {
 		req.expect = statuscodes(expectedStatusCodes)
 	}
@@ -95,11 +94,8 @@ func (me *hybrid_request) Finish(optionalTarget ...any) error {
 		if !credentials.ContainsAPIToken() {
 			return NoAPITokenError
 		}
-		classicRequest := classic_request(*me)
-		if credentials.URL == TestCaseEnvURL {
-			return errors.New("classic")
-		}
-		return classicRequest.Finish(optionalTarget...)
+		apiTokenRequest := api_token_request(*me)
+		return apiTokenRequest.Finish(optionalTarget...)
 	}
 
 	if !credentials.ContainsOAuthOrPlatformToken() {
@@ -107,9 +103,6 @@ func (me *hybrid_request) Finish(optionalTarget ...any) error {
 	}
 
 	platformRequest := platform_request(*me)
-	if credentials.URL == TestCaseEnvURL {
-		return errors.New("platform")
-	}
 	return platformRequest.Finish(optionalTarget...)
 }
 
@@ -123,13 +116,6 @@ func (me *hybrid_request) Expect(codes ...int) Request {
 func (me *hybrid_request) OnResponse(onResponse func(resp *http.Response)) Request {
 	me.onResponse = onResponse
 	return me
-}
-
-func (me *hybrid_request) SetHeader(name string, value string) {
-	if me.headers == nil {
-		me.headers = map[string]string{}
-	}
-	me.headers[name] = value
 }
 
 func NewPreferOAuthContext(ctx context.Context) context.Context {

--- a/dynatrace/rest/hybrid_client_test.go
+++ b/dynatrace/rest/hybrid_client_test.go
@@ -17,18 +17,17 @@
 * limitations under the License.
  */
 
-package rest
+package rest_test
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,136 +35,91 @@ import (
 
 const mockToken = "########"
 
-var credential_repo = map[string]Credentials{
-	"unconfigured":                           {URL: TestCaseEnvURL},
-	"api-token":                              {URL: TestCaseEnvURL, Token: mockToken},
-	"oauth":                                  {URL: TestCaseEnvURL, Platform: PlatformCredentials{ClientID: mockToken, ClientSecret: mockToken}},
-	"platform-token":                         {URL: TestCaseEnvURL, Platform: PlatformCredentials{PlatformToken: mockToken}},
-	"api-token-and-oauth":                    {URL: TestCaseEnvURL, Token: mockToken, Platform: PlatformCredentials{ClientID: mockToken, ClientSecret: mockToken}},
-	"api-token-and-platform-token":           {URL: TestCaseEnvURL, Token: mockToken, Platform: PlatformCredentials{PlatformToken: mockToken}},
-	"oauth-and-platform-token":               {URL: TestCaseEnvURL, Platform: PlatformCredentials{ClientID: mockToken, ClientSecret: mockToken, PlatformToken: mockToken}},
-	"api-token-and-oauth-and-platform-token": {URL: TestCaseEnvURL, Token: mockToken, Platform: PlatformCredentials{PlatformToken: mockToken, ClientID: mockToken, ClientSecret: mockToken}},
-}
-
-type testcase struct {
-	credentials      creds_with_name
-	IsOAuthPreferred bool
-	Expected         error
-}
-
-func (t testcase) Credentials() *Credentials {
-	return &t.credentials.Credentials
-}
-
-var expectedAPITokenError = errors.New("No API Token has been specified")
-var expectedOAuthCredsError = errors.New("Neither OAuth Credentials nor Platform Token have been specified")
-var classicChosen = errors.New("classic")
-var platformChosen = errors.New("platform")
-
-type creds_with_name struct {
-	Name        string
-	Credentials Credentials
-}
-
-func credentials(name string) creds_with_name {
-	return creds_with_name{Name: name, Credentials: credential_repo[name]}
-}
-
-var testcases = []testcase{
-	{
-		credentials:      credentials("unconfigured"),
-		IsOAuthPreferred: false,
-		Expected:         expectedAPITokenError,
-	},
-	{
-		credentials:      credentials("unconfigured"),
-		IsOAuthPreferred: true,
-		Expected:         expectedOAuthCredsError,
-	},
-	{
-		credentials:      credentials("api-token"),
-		IsOAuthPreferred: false,
-		Expected:         classicChosen,
-	},
-	{
-		credentials:      credentials("api-token"),
-		IsOAuthPreferred: true,
-		Expected:         classicChosen,
-	},
-	{
-		credentials:      credentials("oauth"),
-		IsOAuthPreferred: false,
-		Expected:         platformChosen,
-	},
-	{
-		credentials:      credentials("oauth"),
-		IsOAuthPreferred: true,
-		Expected:         platformChosen,
-	},
-	{
-		credentials:      credentials("platform-token"),
-		IsOAuthPreferred: false,
-		Expected:         platformChosen,
-	},
-	{
-		credentials:      credentials("platform-token"),
-		IsOAuthPreferred: true,
-		Expected:         platformChosen,
-	},
-	{
-		credentials:      credentials("oauth-and-platform-token"),
-		IsOAuthPreferred: false,
-		Expected:         platformChosen,
-	},
-	{
-		credentials:      credentials("oauth-and-platform-token"),
-		IsOAuthPreferred: true,
-		Expected:         platformChosen,
-	},
-	{
-		credentials:      credentials("api-token-and-oauth"),
-		IsOAuthPreferred: false,
-		Expected:         classicChosen,
-	},
-	{
-		credentials:      credentials("api-token-and-oauth"),
-		IsOAuthPreferred: true,
-		Expected:         platformChosen,
-	},
-	{
-		credentials:      credentials("api-token-and-platform-token"),
-		IsOAuthPreferred: false,
-		Expected:         classicChosen,
-	},
-	{
-		credentials:      credentials("api-token-and-platform-token"),
-		IsOAuthPreferred: true,
-		Expected:         platformChosen,
-	},
-	{
-		credentials:      credentials("api-token-and-oauth-and-platform-token"),
-		IsOAuthPreferred: false,
-		Expected:         classicChosen,
-	},
-	{
-		credentials:      credentials("api-token-and-oauth-and-platform-token"),
-		IsOAuthPreferred: true,
-		Expected:         platformChosen,
-	},
-}
-
 func TestHybridClient(t *testing.T) {
-	for _, testcase := range testcases {
-		testCaseName := testcase.credentials.Name
-		if testcase.IsOAuthPreferred {
-			testCaseName = testCaseName + "/oauth-pref"
-		}
-		t.Run(testCaseName, func(t *testing.T) {
-			t.Parallel()
-			ctx := context.WithValue(t.Context(), envutils.DynatraceHTTPOAuthPreference.Key, testcase.IsOAuthPreferred)
-			expect(t, testcase.Expected, HybridClient(testcase.Credentials()).Get(ctx, "").Finish())
+	baseURL, tokenURL := newHybridTestServer(t)
+
+	oauth := rest.PlatformCredentials{EnvironmentURL: baseURL, ClientID: mockToken, ClientSecret: mockToken, TokenURL: tokenURL}
+	oauthAndPlatformToken := rest.PlatformCredentials{EnvironmentURL: baseURL, ClientID: mockToken, ClientSecret: mockToken, TokenURL: tokenURL, PlatformToken: mockToken}
+	platformToken := rest.PlatformCredentials{EnvironmentURL: baseURL, PlatformToken: mockToken}
+
+	tests := []struct {
+		name           string
+		creds          *rest.Credentials
+		oauthPreferred bool
+		wantErr        error
+		wantClassic    bool
+		wantPlatform   bool
+	}{
+		{name: "unconfigured", creds: &rest.Credentials{}, wantErr: rest.NoAPITokenError},
+		{name: "unconfigured, oauth preferred", creds: &rest.Credentials{}, oauthPreferred: true, wantErr: rest.NoOAuthCredentialsError},
+
+		{name: "api token", creds: &rest.Credentials{ClassicEnvironmentURL: baseURL, Token: mockToken}, wantClassic: true},
+		{name: "api token, oauth preferred", creds: &rest.Credentials{ClassicEnvironmentURL: baseURL, Token: mockToken}, oauthPreferred: true, wantClassic: true},
+		{name: "oauth", creds: &rest.Credentials{Platform: oauth}, wantPlatform: true},
+		{name: "oauth, oauth preferred", creds: &rest.Credentials{Platform: oauth}, oauthPreferred: true, wantPlatform: true},
+
+		{name: "oauth and platform token", creds: &rest.Credentials{Platform: oauthAndPlatformToken}, wantPlatform: true},
+		{name: "oauth and platform token, oauth preferred", creds: &rest.Credentials{Platform: oauthAndPlatformToken}, oauthPreferred: true, wantPlatform: true},
+
+		{name: "api token and oauth", creds: &rest.Credentials{ClassicEnvironmentURL: baseURL, Token: mockToken, Platform: oauth}, wantClassic: true},
+		{name: "api token and oauth, oauth preferred", creds: &rest.Credentials{ClassicEnvironmentURL: baseURL, Token: mockToken, Platform: oauth}, oauthPreferred: true, wantPlatform: true},
+
+		{name: "api token and platform token", creds: &rest.Credentials{ClassicEnvironmentURL: baseURL, Token: mockToken, Platform: platformToken}, wantClassic: true},
+		{name: "api token and platform token, oauth preferred", creds: &rest.Credentials{ClassicEnvironmentURL: baseURL, Token: mockToken, Platform: platformToken}, oauthPreferred: true, wantPlatform: true},
+
+		{name: "api token, oauth and platform token", creds: &rest.Credentials{ClassicEnvironmentURL: baseURL, Token: mockToken, Platform: oauthAndPlatformToken}, wantClassic: true},
+		{name: "api token, oauth and platform token, oauth preferred", creds: &rest.Credentials{ClassicEnvironmentURL: baseURL, Token: mockToken, Platform: oauthAndPlatformToken}, oauthPreferred: true, wantPlatform: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.oauthPreferred {
+				ctx = context.WithValue(ctx, envutils.DynatraceHTTPOAuthPreference.Key, true)
+			}
+
+			var v struct {
+				Classic  bool `json:"classic"`
+				Platform bool `json:"platform"`
+			}
+			err := rest.HybridClient(tt.creds).Get(ctx, "").Finish(&v)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantClassic, v.Classic)
+			assert.Equal(t, tt.wantPlatform, v.Platform)
 		})
 	}
+}
+
+func newHybridTestServer(t *testing.T) (baseURL, tokenURL string) {
+	tokenPath := "/sso/oauth2/token"
+
+	writeJSON := func(w http.ResponseWriter, body string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenPath, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, `{"access_token": "tok","token_type":"Bearer","expires_in":3600}`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.Header.Get("Authorization"), "Api-Token") {
+			writeJSON(w, `{"classic": true}`)
+			return
+		}
+		writeJSON(w, `{"platform": true}`)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL, srv.URL + tokenPath
 }
 
 func TestApiTokenClient(t *testing.T) {
@@ -179,15 +133,14 @@ func TestApiTokenClient(t *testing.T) {
 			expectedURL, err := url.JoinPath(activeGatePostfix, endpoint)
 			require.NoError(t, err)
 			require.Equal(t, expectedURL, r.URL.Path)
-			require.Equal(t, expectedURL, r.URL.Path)
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("{}"))
 		}))
 		activeGateURL, err := url.JoinPath(server.URL, activeGatePostfix)
 		require.NoError(t, err)
 
-		cred := Credentials{URL: activeGateURL, Token: mockToken}
-		client := HybridClient(&cred)
+		cred := rest.Credentials{ClassicEnvironmentURL: activeGateURL, Token: mockToken}
+		client := rest.HybridClient(&cred)
 
 		req := client.Get(t.Context(), endpoint)
 		err = req.Finish()
@@ -195,72 +148,21 @@ func TestApiTokenClient(t *testing.T) {
 	})
 
 	t.Run("Errors on empty env URL", func(t *testing.T) {
-		cred := Credentials{URL: "", Token: mockToken}
-		client := HybridClient(&cred)
+		cred := rest.Credentials{ClassicEnvironmentURL: "", Token: mockToken}
+		client := rest.HybridClient(&cred)
 
 		req := client.Get(t.Context(), endpoint)
 		err := req.Finish()
-		assert.ErrorIs(t, err, NoClassicURLDefinedErr)
+		assert.ErrorIs(t, err, rest.NoClassicURLDefinedErr)
 	})
 
 	t.Run("Errors on invalid path", func(t *testing.T) {
-		cred := Credentials{URL: "my-url", Token: mockToken}
-		client := HybridClient(&cred)
+		cred := rest.Credentials{ClassicEnvironmentURL: "my-url", Token: mockToken}
+		client := rest.HybridClient(&cred)
 
 		req := client.Get(t.Context(), ":/invalid-url")
 		err := req.Finish()
 		expectedErr := &url.Error{}
 		assert.ErrorAs(t, err, &expectedErr)
 	})
-
-	t.Run("Sets correct headers", func(t *testing.T) {
-		customHeaderName := "my-header"
-		customHeaderValue := "my-value"
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expectedURL, err := url.JoinPath(activeGatePostfix, endpoint)
-			require.NoError(t, err)
-			require.Equal(t, expectedURL, r.URL.Path)
-			require.Equal(t, fmt.Sprintf("Api-Token %s", mockToken), r.Header.Get("Authorization"))
-			require.Equal(t, customHeaderValue, r.Header.Get(customHeaderName))
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("{}"))
-		}))
-		activeGateURL, err := url.JoinPath(server.URL, activeGatePostfix)
-		require.NoError(t, err)
-
-		cred := Credentials{URL: activeGateURL, Token: mockToken}
-		client := HybridClient(&cred)
-
-		req := client.Get(t.Context(), endpoint)
-		req.SetHeader(customHeaderName, customHeaderValue)
-		err = req.Finish()
-		assert.NoError(t, err)
-	})
-}
-
-func expect(t *testing.T, expected error, actual error) {
-	if expected == nil {
-		if actual == nil {
-			return
-		}
-		actualError := actual.Error()
-		if idx := strings.Index(actualError, "."); idx >= 0 {
-			actualError = actualError[:idx]
-		}
-		t.Errorf("expected no error, actual: %s", actualError)
-		t.FailNow()
-	}
-	if actual == nil {
-		t.Errorf("expected: '%s...', but no error", expected.Error())
-		t.FailNow()
-	}
-	if strings.HasPrefix(actual.Error(), expected.Error()) {
-		return
-	}
-	actualError := actual.Error()
-	if idx := strings.Index(actualError, "."); idx >= 0 {
-		actualError = actualError[:idx]
-	}
-	t.Errorf("expected: '%s...', actual: '%s'", expected.Error(), actualError)
-	t.FailNow()
 }

--- a/dynatrace/rest/hybrid_client_test.go
+++ b/dynatrace/rest/hybrid_client_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,7 +83,7 @@ func TestHybridClient(t *testing.T) {
 				Classic  bool `json:"classic"`
 				Platform bool `json:"platform"`
 			}
-			err := rest.HybridClient(tt.creds).Get(ctx, "").Finish(&v)
+			err := rest.HybridClient(createMockClientSet(t, tt.creds)).Get(ctx, "").Finish(&v)
 
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
@@ -139,8 +140,8 @@ func TestApiTokenClient(t *testing.T) {
 		activeGateURL, err := url.JoinPath(server.URL, activeGatePostfix)
 		require.NoError(t, err)
 
-		cred := rest.Credentials{ClassicEnvironmentURL: activeGateURL, Token: mockToken}
-		client := rest.HybridClient(&cred)
+		cred := &rest.Credentials{ClassicEnvironmentURL: activeGateURL, Token: mockToken}
+		client := rest.HybridClient(createMockClientSet(t, cred))
 
 		req := client.Get(t.Context(), endpoint)
 		err = req.Finish()
@@ -148,21 +149,28 @@ func TestApiTokenClient(t *testing.T) {
 	})
 
 	t.Run("Errors on empty env URL", func(t *testing.T) {
-		cred := rest.Credentials{ClassicEnvironmentURL: "", Token: mockToken}
-		client := rest.HybridClient(&cred)
+		cred := &rest.Credentials{ClassicEnvironmentURL: "", Token: mockToken}
+		client := rest.HybridClient(createMockClientSet(t, cred))
 
 		req := client.Get(t.Context(), endpoint)
 		err := req.Finish()
-		assert.ErrorIs(t, err, rest.NoClassicURLDefinedErr)
+		assert.ErrorContains(t, err, "no classic API URL provided")
 	})
 
 	t.Run("Errors on invalid path", func(t *testing.T) {
-		cred := rest.Credentials{ClassicEnvironmentURL: "my-url", Token: mockToken}
-		client := rest.HybridClient(&cred)
+		cred := &rest.Credentials{ClassicEnvironmentURL: "my-url", Token: mockToken}
+		client := rest.HybridClient(createMockClientSet(t, cred))
 
 		req := client.Get(t.Context(), ":/invalid-url")
 		err := req.Finish()
 		expectedErr := &url.Error{}
 		assert.ErrorAs(t, err, &expectedErr)
 	})
+}
+
+func createMockClientSet(t *testing.T, creds *rest.Credentials) *testing2.MockClientSet {
+	clientSet := &testing2.MockClientSet{CredentialsValue: creds}
+	clientSet.PlatformClientValue, clientSet.PlatformClientErr = rest.CreatePlatformClient(t.Context(), creds.Platform.EnvironmentURL, creds)
+	clientSet.APITokenClientValue, clientSet.APITokenClientErr = rest.CreateAPITokenClient(t.Context(), creds.ClassicEnvironmentURL, creds.Token)
+	return clientSet
 }

--- a/dynatrace/rest/logging/logger_test.go
+++ b/dynatrace/rest/logging/logger_test.go
@@ -74,6 +74,7 @@ func TestProviderLogging(t *testing.T) {
 			},
 		}
 		clientSet := &testing2.MockClientSet{CredentialsValue: creds}
+		clientSet.PlatformClientValue, clientSet.PlatformClientErr = rest.CreatePlatformClient(t.Context(), creds.Platform.EnvironmentURL, creds)
 
 		service, err := connection.Service(clientSet)
 		require.NoError(t, err)
@@ -100,6 +101,7 @@ func TestProviderLogging(t *testing.T) {
 			Token:                 "my-token",
 		}
 		clientSet := &testing2.MockClientSet{CredentialsValue: creds}
+		clientSet.APITokenClientValue, clientSet.APITokenClientErr = rest.CreateAPITokenClient(t.Context(), creds.ClassicEnvironmentURL, creds.Token)
 
 		service, err := connection.Service(clientSet)
 		require.NoError(t, err)

--- a/dynatrace/rest/logging/logger_test.go
+++ b/dynatrace/rest/logging/logger_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
 	testing2 "github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/testing"
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -57,50 +56,59 @@ func TestProviderLogging(t *testing.T) {
 	t.Setenv("DYNATRACE_LOG_HTTP", "true")
 	t.Setenv("DYNATRACE_HTTP_RESPONSE", "true")
 
-	connectionTests := []struct {
-		name      string
-		clientSet func(url string) rest.ClientSet
-	}{
-		{
-			name: "log HTTP requests and responses only once for platform token",
-			clientSet: func(url string) rest.ClientSet {
-				return &config.ProviderConfiguration{
-					EnvironmentURL: url,
-					Platform: rest.PlatformCredentials{
-						PlatformToken: "my-token",
-					},
-				}
-			},
-		},
-		{
-			name: "log HTTP requests and responses only once for classic",
-			clientSet: func(url string) rest.ClientSet {
-				return &config.ProviderConfiguration{
-					EnvironmentURL: url,
-					APIToken:       "my-token",
-				}
-			},
-		},
-	}
-	for _, tc := range connectionTests {
-		t.Run(tc.name, func(t *testing.T) {
-			builder := newTestLogger(t)
-			mux := http.ServeMux{}
-			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, err := w.Write([]byte(`{"objectId": "test-id", "value": {}}`))
-				require.NoError(t, err)
-			})
-			httpServer := httptest.NewServer(&mux)
-			defer httpServer.Close()
-
-			service, err := connection.Service(tc.clientSet(httpServer.URL))
+	t.Run("log HTTP requests and responses only once for platform token", func(t *testing.T) {
+		builder := newTestLogger(t)
+		mux := http.ServeMux{}
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"objectId": "test-id", "value": {}}`))
 			require.NoError(t, err)
-			err = service.Get(t.Context(), "test-id", new(set.Settings))
-			require.NoError(t, err)
-			assertLoggedOnce(t, builder.String())
 		})
-	}
+		httpServer := httptest.NewServer(&mux)
+		defer httpServer.Close()
+
+		creds := &rest.Credentials{
+			Platform: rest.PlatformCredentials{
+				EnvironmentURL: httpServer.URL,
+				PlatformToken:  "my-token",
+			},
+		}
+		clientSet := &testing2.MockClientSet{CredentialsValue: creds}
+
+		service, err := connection.Service(clientSet)
+		require.NoError(t, err)
+
+		err = service.Get(t.Context(), "test-id", new(set.Settings))
+		require.NoError(t, err)
+
+		assertLoggedOnce(t, builder.String())
+	})
+
+	t.Run("log HTTP requests and responses only once for classic", func(t *testing.T) {
+		builder := newTestLogger(t)
+		mux := http.ServeMux{}
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"objectId": "test-id", "value": {}}`))
+			require.NoError(t, err)
+		})
+		httpServer := httptest.NewServer(&mux)
+		defer httpServer.Close()
+
+		creds := &rest.Credentials{
+			ClassicEnvironmentURL: httpServer.URL,
+			Token:                 "my-token",
+		}
+		clientSet := &testing2.MockClientSet{CredentialsValue: creds}
+
+		service, err := connection.Service(clientSet)
+		require.NoError(t, err)
+
+		err = service.Get(t.Context(), "test-id", new(set.Settings))
+		require.NoError(t, err)
+
+		assertLoggedOnce(t, builder.String())
+	})
 
 	t.Run("log HTTP requests and responses only once for IAM", func(t *testing.T) {
 		builder := newTestLogger(t)
@@ -136,8 +144,10 @@ func TestProviderLogging(t *testing.T) {
 
 		service, err := boundaries.Service(clientSet)
 		require.NoError(t, err)
+
 		err = service.Get(t.Context(), "test-id", new(setboundaries.PolicyBoundary))
 		require.NoError(t, err)
+
 		assertLoggedOnce(t, builder.String())
 	})
 }

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -77,9 +77,9 @@ func (me *platform_request) Finish(optionalTarget ...any) error {
 	var platformURL string
 	// config v1 are not reachable on platform, so we need to use the classic URL for those requests
 	if strings.Contains(me.url, "/api/config/v1/") {
-		platformURL = EvalClassicURL(me.client.Credentials().URL)
+		platformURL = me.client.Credentials().ClassicEnvironmentURL
 	} else {
-		platformURL = me.evalPlatformURL(me.client.Credentials().URL)
+		platformURL = me.client.Credentials().Platform.EnvironmentURL
 	}
 
 	client, err := CreatePlatformClient(me.ctx, platformURL, me.client.Credentials())
@@ -103,16 +103,4 @@ func (me *platform_request) Finish(optionalTarget ...any) error {
 		return err
 	}
 	return request(*me).HandleResponse(client, fullURL, target)
-}
-
-func (me *platform_request) evalPlatformURL(envURL string) string {
-	envURL = strings.TrimSuffix(strings.TrimSpace(envURL), "/")
-	if len(envURL) == 0 {
-		return envURL
-	}
-	envURL = strings.ReplaceAll(envURL, ".dev.dynatracelabs.", ".dev.apps.dynatracelabs.")
-	envURL = strings.ReplaceAll(envURL, ".live.dynatrace.", ".apps.dynatrace.")
-	envURL = strings.ReplaceAll(envURL, ".sprint.dynatracelabs.", ".sprint.apps.dynatracelabs.")
-	return envURL
-
 }

--- a/dynatrace/rest/platform_request.go
+++ b/dynatrace/rest/platform_request.go
@@ -69,20 +69,7 @@ func CreatePlatformClient(ctx context.Context, platformURL string, credentials *
 }
 
 func (me *platform_request) Finish(optionalTarget ...any) error {
-	var target any
-	if len(optionalTarget) > 0 {
-		target = optionalTarget[0]
-	}
-
-	var platformURL string
-	// config v1 are not reachable on platform, so we need to use the classic URL for those requests
-	if strings.Contains(me.url, "/api/config/v1/") {
-		platformURL = me.client.Credentials().ClassicEnvironmentURL
-	} else {
-		platformURL = me.client.Credentials().Platform.EnvironmentURL
-	}
-
-	client, err := CreatePlatformClient(me.ctx, platformURL, me.client.Credentials())
+	client, err := selectClient(me.client.ClientSet(), me.url)
 	if err != nil {
 		return err
 	}
@@ -98,9 +85,21 @@ func (me *platform_request) Finish(optionalTarget ...any) error {
 		}
 	}
 
-	fullURL, err := url.Parse(platformURL + meURL)
+	fullURL, err := url.Parse(client.BaseURL().String() + meURL)
 	if err != nil {
 		return err
 	}
+
+	var target any
+	if len(optionalTarget) > 0 {
+		target = optionalTarget[0]
+	}
 	return request(*me).HandleResponse(client, fullURL, target)
+}
+
+func selectClient(clientSet ClientSet, url string) (*rest.Client, error) {
+	if strings.Contains(url, "/api/config/v1/") {
+		return clientSet.ClassicPlatformClient()
+	}
+	return clientSet.PlatformClient()
 }

--- a/dynatrace/rest/request.go
+++ b/dynatrace/rest/request.go
@@ -36,7 +36,6 @@ type Request interface {
 	Finish(v ...any) error
 	Expect(codes ...int) Request
 	OnResponse(func(resp *http.Response)) Request
-	SetHeader(name string, value string)
 }
 
 type statuscodes []int
@@ -50,7 +49,6 @@ type request struct {
 	method     string
 	payload    any
 	fileName   string
-	headers    map[string]string
 	onResponse func(resp *http.Response)
 }
 
@@ -153,10 +151,4 @@ func (me request) HandleResponse(client *rest.Client, u *url.URL, target any) (e
 	}
 
 	return nil
-}
-
-var headers = struct {
-	ContentType struct{ ApplicationJSON map[string]string }
-}{
-	ContentType: struct{ ApplicationJSON map[string]string }{ApplicationJSON: map[string]string{"Content-Type": "application/json"}},
 }

--- a/dynatrace/settings/api_token_static_service.go
+++ b/dynatrace/settings/api_token_static_service.go
@@ -34,7 +34,7 @@ type staticService[T Settings] struct {
 func APITokenStaticService[T Settings](clientSet rest.ClientSet, schemaID string, url string, stub api.Stub) (Service[T], error) {
 	return &staticService[T]{
 		schemaID: schemaID,
-		client:   rest.APITokenClient(clientSet.Credentials()),
+		client:   rest.APITokenClient(clientSet),
 		url:      url,
 		stub:     stub,
 	}, nil

--- a/dynatrace/settings/default_service.go
+++ b/dynatrace/settings/default_service.go
@@ -33,7 +33,7 @@ import (
 var ExportRunning = false
 
 func NewAPITokenService[T Settings](clientSet rest.ClientSet, schemaID string, options *ServiceOptions[T]) (CRUDService[T], error) {
-	return newServiceWithClient[T](rest.APITokenClient(clientSet.Credentials()), schemaID, options)
+	return newServiceWithClient[T](rest.APITokenClient(clientSet), schemaID, options)
 }
 
 func NewClassicHybridService[T Settings](clientSet rest.ClientSet, schemaID string, options *ServiceOptions[T]) (CRUDService[T], error) {

--- a/dynatrace/settings/services/settings20/service.go
+++ b/dynatrace/settings/services/settings20/service.go
@@ -42,7 +42,7 @@ func Service[T settings.Settings](clientSet rest.ClientSet, schemaID string, sch
 	return &service[T]{
 		schemaID: schemaID,
 		// schemaVersion: schemaVersion,
-		client:  rest.HybridClient(clientSet.Credentials()),
+		client:  rest.HybridClient(clientSet),
 		options: opts,
 	}, nil
 }

--- a/dynatrace/testing/environmentgetter.go
+++ b/dynatrace/testing/environmentgetter.go
@@ -1,0 +1,59 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package testing
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/config"
+	"github.com/stretchr/testify/require"
+)
+
+var _ config.Getter = &environmentGetter{}
+
+type environmentGetter struct {
+	envURL   string
+	apiToken string
+}
+
+// EnvironmentGetter returns a config.Getter that retrieves the Dynatrace environment URL and API token from environment variables.
+func EnvironmentGetter(t *testing.T) *environmentGetter {
+	envURL := envutils.DynatraceEnvURL.Get()
+	require.NotEmpty(t, envURL, fmt.Sprintf("Environment variable %s must be specified", envutils.DynatraceEnvURL.Key))
+
+	apiToken := envutils.DynatraceAPIToken.Get()
+	require.NotEmpty(t, apiToken, fmt.Sprintf("Environment variable %s must be specified", envutils.DynatraceAPIToken.Key))
+
+	return &environmentGetter{
+		envURL:   envURL,
+		apiToken: apiToken,
+	}
+}
+
+func (t *environmentGetter) Get(key string) any {
+	switch key {
+	case "dt_env_url":
+		return t.envURL
+	case "dt_api_token":
+		return t.apiToken
+	}
+	return ""
+}

--- a/dynatrace/testing/mockclientset.go
+++ b/dynatrace/testing/mockclientset.go
@@ -24,18 +24,45 @@ import (
 // MockClientSet is a rest.ClientSet whose IAM client and credentials are supplied directly, for
 // injecting a MockIAMClient into IAM services under test.
 type MockClientSet struct {
-	IAMClientValue      rest.IAMClient
-	IAMClientErr        error
-	PlatformClientValue *rest2.Client
-	PlatformClientErr   error
-	CredentialsValue    *rest.Credentials
+	IAMClientValue             rest.IAMClient
+	IAMClientErr               error
+	PlatformClientValue        *rest2.Client
+	PlatformClientErr          error
+	ClassicPlatformClientValue *rest2.Client
+	ClassicPlatformClientErr   error
+	APITokenClientValue        *rest2.Client
+	APITokenClientErr          error
+	ClusterV1ClientValue       *rest2.Client
+	ClusterV1ClientErr         error
+	ClusterV2ClientValue       *rest2.Client
+	ClusterV2ClientErr         error
+	CredentialsValue           *rest.Credentials
 }
 
 func (me *MockClientSet) IAMClient() (rest.IAMClient, error) {
 	return me.IAMClientValue, me.IAMClientErr
 }
+
 func (me *MockClientSet) PlatformClient() (*rest2.Client, error) {
 	return me.PlatformClientValue, me.PlatformClientErr
 }
 
-func (me *MockClientSet) Credentials() *rest.Credentials { return me.CredentialsValue }
+func (me *MockClientSet) ClassicPlatformClient() (*rest2.Client, error) {
+	return me.ClassicPlatformClientValue, me.ClassicPlatformClientErr
+}
+
+func (me *MockClientSet) APITokenClient() (*rest2.Client, error) {
+	return me.APITokenClientValue, me.APITokenClientErr
+}
+
+func (me *MockClientSet) ClusterV1Client() (*rest2.Client, error) {
+	return me.ClusterV1ClientValue, me.ClusterV1ClientErr
+}
+
+func (me *MockClientSet) ClusterV2Client() (*rest2.Client, error) {
+	return me.ClusterV2ClientValue, me.ClusterV2ClientErr
+}
+
+func (me *MockClientSet) Credentials() *rest.Credentials {
+	return me.CredentialsValue
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 /**
 * @license
 * Copyright 2025 Dynatrace LLC
@@ -14,8 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
-//go:build unit
 
 package main_test
 

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -45,6 +45,18 @@ type ProviderConfiguration struct {
 
 	platformClient    *rest2.Client
 	platformClientErr error
+
+	classicPlatformClient    *rest2.Client
+	classicPlatformClientErr error
+
+	apiTokenClient    *rest2.Client
+	apiTokenClientErr error
+
+	clusterV1Client    *rest2.Client
+	clusterV1ClientErr error
+
+	clusterV2Client    *rest2.Client
+	clusterV2ClientErr error
 }
 
 func (c *ProviderConfiguration) Credentials() *rest.Credentials {
@@ -65,6 +77,22 @@ func (c *ProviderConfiguration) IAMClient() (rest.IAMClient, error) {
 
 func (c *ProviderConfiguration) PlatformClient() (*rest2.Client, error) {
 	return c.platformClient, c.platformClientErr
+}
+
+func (c *ProviderConfiguration) APITokenClient() (*rest2.Client, error) {
+	return c.apiTokenClient, c.apiTokenClientErr
+}
+
+func (c *ProviderConfiguration) ClassicPlatformClient() (*rest2.Client, error) {
+	return c.classicPlatformClient, c.classicPlatformClientErr
+}
+
+func (c *ProviderConfiguration) ClusterV1Client() (*rest2.Client, error) {
+	return c.clusterV1Client, c.clusterV1ClientErr
+}
+
+func (c *ProviderConfiguration) ClusterV2Client() (*rest2.Client, error) {
+	return c.clusterV2Client, c.clusterV2ClientErr
 }
 
 type Getter interface {
@@ -137,7 +165,10 @@ func ProviderConfigureGeneric(ctx context.Context, d Getter) *ProviderConfigurat
 
 	pc.iamClient, pc.iamClientErr = rest.NewIAMClient(clientCtx, pc.Credentials())
 	pc.platformClient, pc.platformClientErr = rest.CreatePlatformClient(clientCtx, pc.Platform.EnvironmentURL, pc.Credentials())
-
+	pc.classicPlatformClient, pc.classicPlatformClientErr = rest.CreatePlatformClient(clientCtx, pc.EnvironmentURL, pc.Credentials())
+	pc.apiTokenClient, pc.apiTokenClientErr = rest.CreateAPITokenClient(clientCtx, pc.EnvironmentURL, pc.APIToken)
+	pc.clusterV1Client, pc.clusterV1ClientErr = rest.CreateClusterV1Client(clientCtx, pc.ClusterAPIV2URL, pc.ClusterAPIToken)
+	pc.clusterV2Client, pc.clusterV2ClientErr = rest.CreateClusterV2Client(clientCtx, pc.ClusterAPIV2URL, pc.ClusterAPIToken)
 	return pc
 }
 

--- a/provider/config/config.go
+++ b/provider/config/config.go
@@ -49,10 +49,10 @@ type ProviderConfiguration struct {
 
 func (c *ProviderConfiguration) Credentials() *rest.Credentials {
 	credentials := &rest.Credentials{
-		Token:    c.APIToken,
-		URL:      c.EnvironmentURL,
-		IAM:      c.IAM,
-		Platform: c.Platform,
+		Token:                 c.APIToken,
+		ClassicEnvironmentURL: c.EnvironmentURL,
+		IAM:                   c.IAM,
+		Platform:              c.Platform,
 	}
 	credentials.Cluster.URL = c.ClusterAPIV2URL
 	credentials.Cluster.Token = c.ClusterAPIToken

--- a/resources/generic_test.go
+++ b/resources/generic_test.go
@@ -34,6 +34,20 @@ import (
 	rest2 "github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
+type envURLGetter struct {
+}
+
+func (e envURLGetter) Get(key string) any {
+	if key == "dt_env_url" {
+		return "https://dynatrace.com"
+	}
+	return ""
+}
+
+func getProviderConfigurationWithFixedEnvironmentURL(t *testing.T) *config.ProviderConfiguration {
+	return config.ProviderConfigureGeneric(t.Context(), &envURLGetter{})
+}
+
 func TestGeneric_Read(t *testing.T) {
 	t.Run("resource not found error should set the ID to empty", func(t *testing.T) {
 		gen := resources.Generic{
@@ -41,9 +55,7 @@ func TestGeneric_Read(t *testing.T) {
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
 		d.SetId("test")
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Read(t.Context(), d, m)
 		assert.False(t, diags.HasError())
@@ -56,9 +68,7 @@ func TestGeneric_Read(t *testing.T) {
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
 		d.SetId("test")
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Read(t.Context(), d, m)
 		assert.False(t, diags.HasError())
@@ -71,9 +81,7 @@ func TestGeneric_Read(t *testing.T) {
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
 		d.SetId("test")
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Read(t.Context(), d, m)
 		assert.True(t, diags.HasError())
@@ -91,9 +99,7 @@ func TestGeneric_Delete(t *testing.T) {
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
 		d.SetId("test")
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Delete(t.Context(), d, m)
 		assert.False(t, diags.HasError())
@@ -106,9 +112,7 @@ func TestGeneric_Delete(t *testing.T) {
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
 		d.SetId("test")
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Delete(t.Context(), d, m)
 		assert.False(t, diags.HasError())
@@ -121,9 +125,7 @@ func TestGeneric_Delete(t *testing.T) {
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
 		d.SetId("test")
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Delete(t.Context(), d, m)
 		assert.True(t, diags.HasError())
@@ -145,9 +147,7 @@ func TestGeneric_Create(t *testing.T) {
 			}})),
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Create(t.Context(), d, m)
 		assert.True(t, diags.HasError())
@@ -161,9 +161,7 @@ func TestGeneric_Create(t *testing.T) {
 			Descriptor: export.NewResourceDescriptor(MockService(nil, rest.Error{Code: http.StatusBadRequest, Message: "My message"})),
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Create(t.Context(), d, m)
 		assert.True(t, diags.HasError())
@@ -185,9 +183,7 @@ func TestGeneric_Create(t *testing.T) {
 			Descriptor: export.NewResourceDescriptor(MockService(nil, apiErr)),
 		}
 		d := schema.TestResourceDataRaw(t, new(mockSchema).Schema(), nil)
-		m := &config.ProviderConfiguration{
-			EnvironmentURL: "https://dynatrace.com",
-		}
+		m := getProviderConfigurationWithFixedEnvironmentURL(t)
 
 		diags := gen.Create(t.Context(), d, m)
 		assert.True(t, diags.HasError())

--- a/terraform/confighcl/confighcl.go
+++ b/terraform/confighcl/confighcl.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-
 type bootstrapDecoder struct {
 	Reader schema.FieldReader
 }

--- a/terraform/hcl/diff_suppress.go
+++ b/terraform/hcl/diff_suppress.go
@@ -130,7 +130,6 @@ func SuppressJSONorEOT(k, old, new string, d *schema.ResourceData) bool {
 	return equalLineByLine(old, new)
 }
 
-
 func Println(path string, message string, b ...bool) {
 	if !envutils.DynatraceDashboardTests.Get() {
 		return

--- a/terraform/hclgen/primitive_entry.go
+++ b/terraform/hclgen/primitive_entry.go
@@ -30,7 +30,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-
 type primitiveEntry struct {
 	Indent      string
 	Key         string


### PR DESCRIPTION
#### **Why** this PR?
The provider still had clients being created from raw credentials in many places, and tests were often constructing `config.ProviderConfiguration` directly in incomplete ways. This refactor finishes moving client creation behind the shared `ClientSet`, clarifies which URL is the classic environment URL, and removes request plumbing that only existed to support test-specific behavior.

#### **What** has changed and **how** does it do it?
- `provider/config` and `dynatrace/rest` now build and reuse the full client set through `config.ProviderConfigureGeneric(...)`, so API token, hybrid, classic platform, and cluster requests are all created from `rest.ClientSet` instead of re-deriving clients from credentials.
- `rest.Credentials.URL` was renamed to `ClassicEnvironmentURL`, and callers that depend on the classic base URL were updated accordingly.
- The remaining services that still called `rest.APITokenClient(clientSet.Credentials())`, `rest.HybridClient(clientSet.Credentials())`, `rest.ClusterV1Client(clientSet.Credentials())`, or `rest.ClusterV2Client(clientSet.Credentials())` were migrated to pass the shared `ClientSet` directly.
- Request handling in `dynatrace/rest` was simplified by removing unnecessary header plumbing and test-only behavior, including the old `rest.classic_request` path and explicit header mutation in extension requests.
- Tests and test helpers were aligned with the new configuration path so they use the same provider setup as production code instead of manually instantiating partial provider configs.

#### How is it **tested**?
- Validation and service tests were updated to use `config.ProviderConfigureGeneric(...)`
- Client behavior tests were reworked in `dynatrace/rest/hybrid_client_test.go`

#### How does it affect **users**?
- This PR is mainly refactoring. However, performance will be improved by potentially re-using the platform OAuth client, rather than re-creating it for each operation.

**Issue:** PS-48500