### PR TITLE
feat: add wif package

### DIFF
--- a/dynatrace/rest/oauth_retry_client.go
+++ b/dynatrace/rest/oauth_retry_client.go
@@ -1,0 +1,31 @@
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/retry"
+	"golang.org/x/oauth2"
+)
+
+func NewContextWithOAuthRetryClient(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: &retry.Transport{},
+	})
+}

--- a/dynatrace/rest/oauth_retry_client_test.go
+++ b/dynatrace/rest/oauth_retry_client_test.go
@@ -1,0 +1,41 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/retry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// NewContextWithOAuthRetryClient verifies that the context is enriched with an
+// HTTP client whose transport is a *retry.Transport.
+func TestNewContextWithOAuthRetryClient(t *testing.T) {
+	ctx := rest.NewContextWithOAuthRetryClient(t.Context())
+
+	client, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+	require.True(t, ok, "context should contain an *http.Client")
+	_, isRetry := client.Transport.(*retry.Transport)
+	assert.True(t, isRetry, "the client's transport should be a *retry.Transport")
+}

--- a/dynatrace/rest/retry/transport.go
+++ b/dynatrace/rest/retry/transport.go
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package rest
+package retry
 
 import (
 	"bytes"
-	"context"
+	"fmt"
 	"io"
 	"math"
 	"math/rand/v2"
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/logging"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -36,48 +35,62 @@ const (
 	defaultMaxBackoff  = 60 * time.Second
 )
 
-// RetryTransport is an http.RoundTripper that automatically retries requests
-// when the server returns HTTP 429 (Too Many Requests) or HTTP 503 (Service Unavailable).
-// MaxRetries, BaseBackoff, and MaxBackoff can be set to non-zero values to override the
-// defaults, which is useful in tests to keep execution time short.
-type RetryTransport struct {
-	Transport   http.RoundTripper
+// Transport is an http.RoundTripper that automatically repeats a request whose outcome ShouldRetry
+// accepts, by default when the server returns HTTP 429 (Too Many Requests) or HTTP 503 (Service
+// Unavailable). MaxRetries, BaseBackoff, and MaxBackoff can be set to non-zero values to override
+// the defaults, which is useful in tests to keep execution time short.
+type Transport struct {
+	Base        http.RoundTripper
 	MaxRetries  int
 	BaseBackoff time.Duration
 	MaxBackoff  time.Duration
+
+	// ShouldRetry decides whether an attempt is worth repeating. It receives the response, or nil
+	// and the error when the round trip itself did not complete. Defaults to
+	// IfTooManyRequestsOrServiceUnavailable.
+	ShouldRetry func(*http.Response, error) bool
 }
 
-// transport returns the configured RoundTripper, falling back to http.DefaultTransport when nil.
-func (t *RetryTransport) transport() http.RoundTripper {
-	if t.Transport != nil {
-		return t.Transport
+// IfTooManyRequestsOrServiceUnavailable repeats a request the server answered with HTTP 429 or 503,
+// and gives up on anything else, including a round trip that failed outright.
+func IfTooManyRequestsOrServiceUnavailable(resp *http.Response, err error) bool {
+	return err == nil && (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable)
+}
+
+// base returns the configured RoundTripper, falling back to http.DefaultTransport when nil.
+func (t *Transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
 	}
 	return http.DefaultTransport
 }
 
-func (t *RetryTransport) maxRetries() int {
+func (t *Transport) shouldRetry(resp *http.Response, err error) bool {
+	if t.ShouldRetry != nil {
+		return t.ShouldRetry(resp, err)
+	}
+	return IfTooManyRequestsOrServiceUnavailable(resp, err)
+}
+
+func (t *Transport) maxRetries() int {
 	if t.MaxRetries > 0 {
 		return t.MaxRetries
 	}
 	return defaultMaxRetries
 }
 
-func (t *RetryTransport) baseBackoff() time.Duration {
+func (t *Transport) baseBackoff() time.Duration {
 	if t.BaseBackoff > 0 {
 		return t.BaseBackoff
 	}
 	return defaultBaseBackoff
 }
 
-func (t *RetryTransport) maxBackoff() time.Duration {
+func (t *Transport) maxBackoff() time.Duration {
 	if t.MaxBackoff > 0 {
 		return t.MaxBackoff
 	}
 	return defaultMaxBackoff
-}
-
-func isRetriableStatus(statusCode int) bool {
-	return statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable
 }
 
 // bufferRequestBody reads and closes req.Body, returning its contents.
@@ -93,8 +106,18 @@ func bufferRequestBody(req *http.Request) ([]byte, error) {
 	return body, err
 }
 
-// drainAndClose drains body into /dev/null and closes it, allowing TCP
-// connection reuse. The drain error takes precedence over the close error.
+// cloneRequestWithBody returns a copy of req that can be sent on its own, with the previously
+// buffered body put back in place of the one the last attempt consumed.
+func cloneRequestWithBody(req *http.Request, body []byte) *http.Request {
+	clone := req.Clone(req.Context())
+	if body != nil {
+		clone.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	return clone
+}
+
+// drainAndClose drains body into /dev/null and closes it, allowing TCP connection reuse. The drain
+// error takes precedence over the close error.
 func drainAndClose(body io.ReadCloser) error {
 	_, copyErr := io.Copy(io.Discard, body)
 	closeErr := body.Close()
@@ -104,7 +127,7 @@ func drainAndClose(body io.ReadCloser) error {
 	return closeErr
 }
 
-func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Buffer the request body so it can be replayed on retries.
 	bodyBytes, err := bufferRequestBody(req)
 	if err != nil {
@@ -114,26 +137,20 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	maxRetries := t.maxRetries()
 
 	for attempt := 0; ; attempt++ {
-		// Clone the request and restore the body for each attempt.
-		clone := req.Clone(req.Context())
-		if bodyBytes != nil {
-			clone.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-		}
+		clone := cloneRequestWithBody(req, bodyBytes)
 
-		resp, err := t.transport().RoundTrip(clone)
-		if err != nil {
-			return nil, err
-		}
-
-		if !isRetriableStatus(resp.StatusCode) || attempt >= maxRetries {
-			return resp, nil
+		resp, err := t.base().RoundTrip(clone)
+		if !t.shouldRetry(resp, err) || attempt >= maxRetries {
+			return resp, err
 		}
 
 		ctx := clone.Context()
 		wait := t.sleepDuration(resp, attempt)
-		logging.Logger.Printf(ctx, "[RetryTransport] Received HTTP %d, retrying in %s (attempt %d/%d)", resp.StatusCode, wait, attempt+1, maxRetries)
-		if err := drainAndClose(resp.Body); err != nil {
-			return nil, err
+		logging.Logger.Printf(ctx, "[RetryTransport] %s, retrying in %s (attempt %d/%d)", retryReason(resp, err), wait, attempt+1, maxRetries)
+		if resp != nil {
+			if err := drainAndClose(resp.Body); err != nil {
+				return nil, err
+			}
 		}
 		select {
 		case <-time.After(wait):
@@ -143,10 +160,21 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 }
 
+// retryReason describes the outcome that ShouldRetry accepted, for the log line.
+func retryReason(resp *http.Response, err error) string {
+	if err != nil {
+		return fmt.Sprintf("Request failed (%s)", err)
+	}
+	return fmt.Sprintf("Received HTTP %d", resp.StatusCode)
+}
+
 // getRetryAfterHeaderAsSleepTime parses the Retry-After response header and returns the
-// indicated wait duration. Returns 0 if the header is absent,
+// indicated wait duration. Returns 0 if there is no response, or if the header is absent,
 // cannot be parsed, or indicates a non-positive delay.
 func getRetryAfterHeaderAsSleepTime(resp *http.Response) time.Duration {
+	if resp == nil {
+		return 0
+	}
 	ra := resp.Header.Get("Retry-After")
 	if ra == "" {
 		return 0
@@ -175,7 +203,7 @@ func computeBackoffSleepTime(base time.Duration, attempt int) time.Duration {
 // sleepDuration determines how long to wait before the next retry attempt.
 // It honours the Retry-After response header when present (capped at maxBackoff);
 // otherwise it falls back to exponential back-off with jitter.
-func (t *RetryTransport) sleepDuration(resp *http.Response, attempt int) time.Duration {
+func (t *Transport) sleepDuration(resp *http.Response, attempt int) time.Duration {
 	d := getRetryAfterHeaderAsSleepTime(resp)
 	if d <= 0 {
 		d = computeBackoffSleepTime(t.baseBackoff(), attempt)
@@ -184,10 +212,4 @@ func (t *RetryTransport) sleepDuration(resp *http.Response, attempt int) time.Du
 		return maxWait
 	}
 	return d
-}
-
-func NewContextWithOAuthRetryClient(ctx context.Context) context.Context {
-	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
-		Transport: &RetryTransport{},
-	})
 }

--- a/dynatrace/rest/retry/transport_test.go
+++ b/dynatrace/rest/retry/transport_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package rest_test
+package retry_test
 
 import (
 	"bytes"
@@ -27,10 +27,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest"
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
 )
 
 // rtFunc lets an ordinary function act as an http.RoundTripper.
@@ -55,8 +54,8 @@ func emptyResponse(status int, headers map[string]string) *http.Response {
 // returned immediately without any retry.
 func TestRetryTransport_SuccessOnFirstAttempt(t *testing.T) {
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			return emptyResponse(http.StatusOK, nil), nil
 		}),
@@ -86,8 +85,8 @@ func TestRetryTransport_NonRetriableStatusCodes(t *testing.T) {
 	for _, status := range nonRetryStatusCodes {
 		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
 			calls := 0
-			tr := &rest.RetryTransport{
-				Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			tr := &retry.Transport{
+				Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 					calls++
 					return emptyResponse(status, nil), nil
 				}),
@@ -106,8 +105,8 @@ func TestRetryTransport_NonRetriableStatusCodes(t *testing.T) {
 // TestRetryTransport_TransportError verifies that an error from the underlying
 // transport is propagated immediately without retrying.
 func TestRetryTransport_TransportError(t *testing.T) {
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			return nil, assert.AnError
 		}),
 	}
@@ -119,10 +118,83 @@ func TestRetryTransport_TransportError(t *testing.T) {
 	assert.ErrorIs(t, err, assert.AnError)
 }
 
+// TestRetryTransport_ShouldRetryOverridesDefaultStatuses verifies that a ShouldRetry accepting a
+// status the default gives up on, HTTP 500, makes the transport retry it.
+func TestRetryTransport_ShouldRetryOverridesDefaultStatuses(t *testing.T) {
+	calls := 0
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return emptyResponse(http.StatusInternalServerError, nil), nil
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: 10 * time.Millisecond,
+		ShouldRetry: func(resp *http.Response, err error) bool {
+			return err == nil && resp.StatusCode == http.StatusInternalServerError
+		},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+}
+
+// TestRetryTransport_ShouldRetryRepeatsFailedRoundTrip verifies that a ShouldRetry accepting a round
+// trip that never produced a response makes the transport retry it, which the default does not.
+func TestRetryTransport_ShouldRetryRepeatsFailedRoundTrip(t *testing.T) {
+	calls := 0
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			if calls < 3 {
+				return nil, assert.AnError
+			}
+			return emptyResponse(http.StatusOK, nil), nil
+		}),
+		BaseBackoff: 10 * time.Millisecond,
+		ShouldRetry: func(_ *http.Response, err error) bool { return err != nil },
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, calls)
+}
+
+// TestRetryTransport_ShouldRetryExhaustedOnFailedRoundTrip verifies that the error of the last
+// failed round trip reaches the caller once the retries are used up.
+func TestRetryTransport_ShouldRetryExhaustedOnFailedRoundTrip(t *testing.T) {
+	const maxRetries = 2
+	calls := 0
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
+			calls++
+			return nil, assert.AnError
+		}),
+		MaxRetries:  maxRetries,
+		BaseBackoff: 10 * time.Millisecond,
+		ShouldRetry: func(_ *http.Response, err error) bool { return err != nil },
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://dynatrace.com", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, maxRetries+1, calls, "expected MaxRetries+1 = %d total attempts", maxRetries+1)
+}
+
 // TestRetryTransport_NilBody verifies that requests without a body are handled correctly.
 func TestRetryTransport_NilBody(t *testing.T) {
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			return emptyResponse(http.StatusOK, nil), nil
 		}),
 	}
@@ -137,8 +209,8 @@ func TestRetryTransport_NilBody(t *testing.T) {
 // TestRetryTransport_BodyReadError verifies that an error while buffering the request
 // body is returned immediately without calling the underlying transport.
 func TestRetryTransport_BodyReadError(t *testing.T) {
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			t.Fatal("transport should not be called when the body cannot be read")
 			return nil, nil
 		}),
@@ -157,8 +229,8 @@ func TestRetryTransport_BodyReplayed(t *testing.T) {
 	const payload = "hello-retry"
 	var receivedBodies []string
 
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(req *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(req *http.Request) (*http.Response, error) {
 			if req.Body != nil {
 				data, _ := io.ReadAll(req.Body)
 				receivedBodies = append(receivedBodies, string(data))
@@ -186,8 +258,8 @@ func TestRetryTransport_BodyReplayed(t *testing.T) {
 // Uses Retry-After: 1 – test duration ~2 seconds.
 func TestRetryTransport_RetriesOn429_EventualSuccess(t *testing.T) {
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls < 3 {
 				return emptyResponse(http.StatusTooManyRequests, nil), nil
@@ -210,8 +282,8 @@ func TestRetryTransport_RetriesOn429_EventualSuccess(t *testing.T) {
 // Uses Retry-After: 1 – test duration ~2 seconds.
 func TestRetryTransport_RetriesOn503_EventualSuccess(t *testing.T) {
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls < 3 {
 				return emptyResponse(http.StatusServiceUnavailable, nil), nil
@@ -234,8 +306,8 @@ func TestRetryTransport_RetriesOn503_EventualSuccess(t *testing.T) {
 // Test duration ~1 second.
 func TestRetryTransport_RetryAfterSeconds(t *testing.T) {
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
 				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": "1"}), nil
@@ -262,8 +334,8 @@ func TestRetryTransport_RetryAfterHTTPDate(t *testing.T) {
 	retryAfterDate := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
 
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
 				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": retryAfterDate}), nil
@@ -288,8 +360,8 @@ func TestRetryTransport_RetryAfterHTTPDate(t *testing.T) {
 func TestRetryTransport_ExponentialBackoff(t *testing.T) {
 	const base = 100 * time.Millisecond
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
 				// No Retry-After header → exponential backoff applies.
@@ -318,8 +390,8 @@ func TestRetryTransport_ExponentialBackoff(t *testing.T) {
 func TestRetryTransport_MaxRetriesExhausted(t *testing.T) {
 	const maxRetries = 3
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			return emptyResponse(http.StatusTooManyRequests, nil), nil
 		}),
@@ -336,24 +408,13 @@ func TestRetryTransport_MaxRetriesExhausted(t *testing.T) {
 	assert.Equal(t, maxRetries+1, calls, "expected MaxRetries+1 = %d total attempts", maxRetries+1)
 }
 
-// NewContextWithOAuthRetryClient verifies that the context is enriched with an
-// HTTP client whose transport is a *RetryTransport.
-func TestNewContextWithOAuthRetryClient(t *testing.T) {
-	ctx := rest.NewContextWithOAuthRetryClient(t.Context())
-
-	client, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
-	require.True(t, ok, "context should contain an *http.Client")
-	_, isRetry := client.Transport.(*rest.RetryTransport)
-	assert.True(t, isRetry, "the client's transport should be a *RetryTransport")
-}
-
 // TestRetryTransport_RetryAfterZero verifies that a Retry-After value of 0 is treated as
 // invalid and the transport falls back to exponential back-off instead.
 func TestRetryTransport_RetryAfterZero_FallsBackToBackoff(t *testing.T) {
 	const base = 30 * time.Millisecond
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
 				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": "0"}), nil
@@ -379,8 +440,8 @@ func TestRetryTransport_RetryAfterZero_FallsBackToBackoff(t *testing.T) {
 func TestRetryTransport_RetryAfterNegative_FallsBackToBackoff(t *testing.T) {
 	const base = 30 * time.Millisecond
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
 				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": "-5"}), nil
@@ -407,8 +468,8 @@ func TestRetryTransport_RetryAfterPastDate_FallsBackToBackoff(t *testing.T) {
 	const base = 30 * time.Millisecond
 	pastDate := time.Now().Add(-10 * time.Second).UTC().Format(http.TimeFormat)
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
 				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": pastDate}), nil
@@ -434,8 +495,8 @@ func TestRetryTransport_RetryAfterPastDate_FallsBackToBackoff(t *testing.T) {
 func TestRetryTransport_RetryAfterCapped(t *testing.T) {
 	const cap = 50 * time.Millisecond
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
 				return emptyResponse(http.StatusTooManyRequests, map[string]string{"Retry-After": "99999"}), nil
@@ -462,8 +523,8 @@ func TestRetryTransport_RetryAfterCapped(t *testing.T) {
 func TestRetryTransport_BackoffCapped(t *testing.T) {
 	const cap = 50 * time.Millisecond
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			return emptyResponse(http.StatusTooManyRequests, nil), nil
 		}),
@@ -490,8 +551,8 @@ func TestRetryTransport_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	calls := 0
-	tr := &rest.RetryTransport{
-		Transport: rtFunc(func(_ *http.Request) (*http.Response, error) {
+	tr := &retry.Transport{
+		Base: rtFunc(func(_ *http.Request) (*http.Response, error) {
 			calls++
 			// Cancel the context so the upcoming retry wait fires the Done branch.
 			cancel()

--- a/dynatrace/rest/wif/config.go
+++ b/dynatrace/rest/wif/config.go
@@ -1,0 +1,82 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package wif
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	errNotConfigured        = errors.New("no Workload Identity Federation has been configured")
+	errVendorAndStaticToken = errors.New("a vendor and a pre-minted OIDC token are mutually exclusive, specify only one of them")
+	errStaticTokenNotAJWT   = errors.New("the pre-minted OIDC token is not a JWT: expected three dot-separated segments")
+	errNoAudience           = errors.New("no audience has been specified")
+)
+
+// Vendor identifies the workload identity provider that issues the OIDC token.
+type Vendor = string
+
+// VendorGitHub obtains tokens from the GitHub Actions OIDC token service.
+const VendorGitHub Vendor = "github"
+
+type Config struct {
+	Vendor      Vendor
+	Audience    string
+	StaticToken string
+}
+
+// Configured reports whether any form of Workload Identity Federation was requested.
+func (config Config) Configured() bool {
+	return len(config.Vendor) > 0 || len(config.StaticToken) > 0
+}
+
+// Validate reports whether the configuration describes a usable setup, as far as that can be judged
+// without contacting a token service. Callers for which Workload Identity Federation is optional have
+// to guard with [Config.Configured] - only they can decide whether its absence is a problem.
+func (config Config) Validate() error {
+	if !config.Configured() {
+		return errNotConfigured
+	}
+
+	if len(config.Vendor) > 0 && len(config.StaticToken) > 0 {
+		return errVendorAndStaticToken
+	}
+
+	if len(config.StaticToken) > 0 {
+		if strings.Count(config.StaticToken, ".") != jwtSegmentCount-1 {
+			return errStaticTokenNotAJWT
+		}
+		return nil
+	}
+
+	if config.Vendor != VendorGitHub {
+		return unsupportedVendorError(config.Vendor)
+	}
+
+	if len(config.Audience) == 0 {
+		return errNoAudience
+	}
+
+	return nil
+}
+
+func unsupportedVendorError(vendor Vendor) error {
+	return fmt.Errorf("`%s` is not a supported vendor, the only supported one is `%s`", vendor, VendorGitHub)
+}

--- a/dynatrace/rest/wif/config_test.go
+++ b/dynatrace/rest/wif/config_test.go
@@ -1,0 +1,64 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wif
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Callers for which federation is optional guard with Configured, so absence is a problem by the time
+// Validate is asked.
+func TestValidateRejectsUnconfigured(t *testing.T) {
+	assert.ErrorIs(t, Config{}.Validate(), errNotConfigured)
+}
+
+func TestValidateAcceptsVendorWithAudience(t *testing.T) {
+	assert.NoError(t, Config{Vendor: VendorGitHub, Audience: "dynatrace"}.Validate())
+}
+
+func TestValidateRejectsVendorWithoutAudience(t *testing.T) {
+	err := Config{Vendor: VendorGitHub}.Validate()
+
+	assert.ErrorIs(t, err, errNoAudience)
+}
+
+func TestValidateRejectsUnsupportedVendor(t *testing.T) {
+	err := Config{Vendor: "aws", Audience: "dynatrace"}.Validate()
+
+	assert.EqualError(t, err, "`aws` is not a supported vendor, the only supported one is `github`")
+}
+
+// The audience belongs to the vendor that mints a token, so a supplied one is complete without it.
+func TestValidateAcceptsStaticTokenWithoutAudience(t *testing.T) {
+	assert.NoError(t, Config{StaticToken: jwtWithPayload(`{"exp":1767225600}`)}.Validate())
+}
+
+func TestValidateRejectsStaticTokenThatIsNotAJWT(t *testing.T) {
+	err := Config{StaticToken: "not-a-jwt"}.Validate()
+
+	assert.ErrorIs(t, err, errStaticTokenNotAJWT)
+}
+
+func TestValidateRejectsVendorAndStaticTokenTogether(t *testing.T) {
+	err := Config{Vendor: VendorGitHub, Audience: "dynatrace", StaticToken: jwtWithPayload(`{"exp":1767225600}`)}.Validate()
+
+	assert.ErrorIs(t, err, errVendorAndStaticToken)
+}

--- a/dynatrace/rest/wif/github.go
+++ b/dynatrace/rest/wif/github.go
@@ -1,0 +1,113 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package wif
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
+)
+
+const maxTokenResponseSize = 1 << 20
+
+var (
+	errMissingCredential    = errors.New("an OIDC token can only be requested from a GitHub Actions job with `permissions: { id-token: write }`")
+	errResponseNotJSON      = errors.New("failed to get ID token: the response of the token service is not valid JSON")
+	errResponseWithoutToken = errors.New("failed to get ID token: the response of the token service does not contain a token")
+)
+
+type githubMinter struct {
+	requestURL   *url.URL
+	requestToken string
+	audience     string
+	httpClient   *http.Client
+}
+
+func missingCredentialError(variableKey string) error {
+	return fmt.Errorf("unable to get %s environment variable: %w", variableKey, errMissingCredential)
+}
+
+// The credentials GitHub injects stay valid for the whole job, which is what lets the provider mint
+// a fresh token whenever it needs one.
+func newGitHubMinter(audience string, httpClient *http.Client) (minter, error) {
+	rawRequestURL := envutils.ActionsIDTokenRequestURL.Get()
+	if len(rawRequestURL) == 0 {
+		return nil, missingCredentialError(envutils.ActionsIDTokenRequestURL.Key)
+	}
+
+	requestURL, err := url.Parse(rawRequestURL)
+	if err != nil {
+		return nil, fmt.Errorf("%s does not hold a valid URL: %w", envutils.ActionsIDTokenRequestURL.Key, err)
+	}
+
+	requestToken := envutils.ActionsIDTokenRequestToken.Get()
+	if len(requestToken) == 0 {
+		return nil, missingCredentialError(envutils.ActionsIDTokenRequestToken.Key)
+	}
+
+	return &githubMinter{
+		requestURL:   requestURL,
+		requestToken: requestToken,
+		audience:     audience,
+		httpClient:   httpClient,
+	}, nil
+}
+
+func (minter *githubMinter) mint(ctx context.Context) (string, error) {
+	// Copied, so that setting the audience does not mutate the URL the minter keeps.
+	endpoint := *minter.requestURL
+	query := endpoint.Query()
+	query.Set("audience", minter.audience)
+	endpoint.RawQuery = query.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get ID token: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+minter.requestToken)
+	request.Header.Set("Accept", "application/json; api-version=2.0")
+
+	response, err := minter.httpClient.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("failed to get ID token: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		// The body is left out: on success it is the ID token itself.
+		return "", fmt.Errorf("failed to get ID token: the token service responded with HTTP %d", response.StatusCode)
+	}
+
+	var body struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, maxTokenResponseSize)).Decode(&body); err != nil {
+		return "", errResponseNotJSON
+	}
+	if len(body.Value) == 0 {
+		return "", errResponseWithoutToken
+	}
+
+	return body.Value, nil
+}

--- a/dynatrace/rest/wif/github_test.go
+++ b/dynatrace/rest/wif/github_test.go
@@ -1,0 +1,175 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wif
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenServiceHandler is the shape of the GitHub Actions token service: it answers with the ID token
+// wrapped in a "value" field.
+func tokenServiceHandler(t *testing.T, respond func(writer http.ResponseWriter, request *http.Request)) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(respond))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func gitHubMinterFor(t *testing.T, requestURL string, audience string) minter {
+	t.Helper()
+
+	t.Setenv(envutils.ActionsIDTokenRequestURL.Key, requestURL)
+	t.Setenv(envutils.ActionsIDTokenRequestToken.Key, "request-token")
+
+	minter, err := newGitHubMinter(audience, http.DefaultClient)
+	require.NoError(t, err)
+
+	return minter
+}
+
+func TestGitHubMinterReturnsTokenFromTokenService(t *testing.T) {
+	server := tokenServiceHandler(t, func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(`{"count":1,"value":"the.id.token"}`))
+	})
+
+	token, err := gitHubMinterFor(t, server.URL, "dynatrace").mint(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "the.id.token", token)
+}
+
+func TestGitHubMinterRequestsConfiguredAudience(t *testing.T) {
+	var audience string
+	server := tokenServiceHandler(t, func(writer http.ResponseWriter, request *http.Request) {
+		audience = request.URL.Query().Get("audience")
+		_, _ = writer.Write([]byte(`{"value":"the.id.token"}`))
+	})
+
+	_, err := gitHubMinterFor(t, server.URL, "https://dynatrace.com").mint(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://dynatrace.com", audience)
+}
+
+func TestGitHubMinterAuthenticatesWithRequestToken(t *testing.T) {
+	var authorization string
+	server := tokenServiceHandler(t, func(writer http.ResponseWriter, request *http.Request) {
+		authorization = request.Header.Get("Authorization")
+		_, _ = writer.Write([]byte(`{"value":"the.id.token"}`))
+	})
+
+	_, err := gitHubMinterFor(t, server.URL, "dynatrace").mint(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer request-token", authorization)
+}
+
+// The URL GitHub injects already carries an api-version parameter.
+func TestGitHubMinterKeepsExistingQueryParameters(t *testing.T) {
+	var query string
+	server := tokenServiceHandler(t, func(writer http.ResponseWriter, request *http.Request) {
+		query = request.URL.RawQuery
+		_, _ = writer.Write([]byte(`{"value":"the.id.token"}`))
+	})
+
+	_, err := gitHubMinterFor(t, server.URL+"/?api-version=2.0", "dynatrace").mint(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "api-version=2.0&audience=dynatrace", query)
+}
+
+// Asserting on the cause rather than the message is what proves the round trip failure is wrapped:
+// swapping the %w for a %v produces an identical string but breaks this.
+func TestGitHubMinterPropagatesCancellation(t *testing.T) {
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := gitHubMinterFor(t, "https://token.service.invalid/", "dynatrace").mint(cancelled)
+
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestGitHubMinterRejectsUnsuccessfulResponse(t *testing.T) {
+	server := tokenServiceHandler(t, func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusForbidden)
+		_, _ = writer.Write([]byte(`{"message":"forbidden"}`))
+	})
+
+	_, err := gitHubMinterFor(t, server.URL, "dynatrace").mint(t.Context())
+
+	assert.EqualError(t, err, "failed to get ID token: the token service responded with HTTP 403")
+}
+
+func TestGitHubMinterRejectsResponseThatIsNotJSON(t *testing.T) {
+	server := tokenServiceHandler(t, func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte("not JSON"))
+	})
+
+	_, err := gitHubMinterFor(t, server.URL, "dynatrace").mint(t.Context())
+
+	assert.ErrorIs(t, err, errResponseNotJSON)
+}
+
+func TestGitHubMinterRejectsResponseWithoutToken(t *testing.T) {
+	server := tokenServiceHandler(t, func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(`{"count":0}`))
+	})
+
+	_, err := gitHubMinterFor(t, server.URL, "dynatrace").mint(t.Context())
+
+	assert.ErrorIs(t, err, errResponseWithoutToken)
+}
+
+// The parse happens once, at construction, so a malformed URL is reported alongside the missing one
+// rather than on every mint. The wrapped cause carries the offending value.
+func TestGitHubMinterRejectsRequestURLThatIsNotAURL(t *testing.T) {
+	t.Setenv(envutils.ActionsIDTokenRequestURL.Key, "://")
+	t.Setenv(envutils.ActionsIDTokenRequestToken.Key, "request-token")
+
+	_, err := newGitHubMinter("dynatrace", http.DefaultClient)
+
+	assert.EqualError(t, err, `ACTIONS_ID_TOKEN_REQUEST_URL does not hold a valid URL: parse "://": missing protocol scheme`)
+}
+
+func TestGitHubMinterRequiresRequestURLVariable(t *testing.T) {
+	t.Setenv(envutils.ActionsIDTokenRequestURL.Key, "")
+	t.Setenv(envutils.ActionsIDTokenRequestToken.Key, "request-token")
+
+	_, err := newGitHubMinter("dynatrace", http.DefaultClient)
+
+	assert.EqualError(t, err, "unable to get ACTIONS_ID_TOKEN_REQUEST_URL environment variable: an OIDC token can only be requested from a GitHub Actions job with `permissions: { id-token: write }`")
+}
+
+func TestGitHubMinterRequiresRequestTokenVariable(t *testing.T) {
+	t.Setenv(envutils.ActionsIDTokenRequestURL.Key, "https://token.service.invalid/")
+	t.Setenv(envutils.ActionsIDTokenRequestToken.Key, "")
+
+	_, err := newGitHubMinter("dynatrace", http.DefaultClient)
+
+	assert.EqualError(t, err, "unable to get ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable: an OIDC token can only be requested from a GitHub Actions job with `permissions: { id-token: write }`")
+}

--- a/dynatrace/rest/wif/http_client.go
+++ b/dynatrace/rest/wif/http_client.go
@@ -1,0 +1,53 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package wif
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/dynatrace/rest/retry"
+)
+
+// Covers the retries too: the client timeout cancels the request context, which also ends the wait
+// between attempts.
+const mintTimeout = 30 * time.Second
+
+// Must not use http.DefaultTransport: the provider mutates that one when DYNATRACE_HTTP_INSECURE is
+// set, and that escape hatch must not disable certificate verification on the call carrying the
+// minting credentials.
+func mintingHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: mintTimeout,
+		Transport: &retry.Transport{
+			Base:        &http.Transport{Proxy: http.ProxyFromEnvironment},
+			MaxRetries:  2,
+			BaseBackoff: 500 * time.Millisecond,
+			MaxBackoff:  5 * time.Second,
+			ShouldRetry: retriableMintFailure,
+		},
+	}
+}
+
+// Wider than the shared default, which stops at 429 and 503.
+func retriableMintFailure(response *http.Response, err error) bool {
+	if err != nil {
+		return true
+	}
+	return response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError
+}

--- a/dynatrace/rest/wif/http_client_test.go
+++ b/dynatrace/rest/wif/http_client_test.go
@@ -1,0 +1,76 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wif
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetriableMintFailureByStatus(t *testing.T) {
+	retriableByStatus := map[int]bool{
+		http.StatusOK:                  false,
+		http.StatusBadRequest:          false,
+		http.StatusUnauthorized:        false,
+		http.StatusForbidden:           false,
+		http.StatusNotFound:            false,
+		http.StatusTooManyRequests:     true,
+		http.StatusInternalServerError: true,
+		http.StatusBadGateway:          true,
+		http.StatusServiceUnavailable:  true,
+		http.StatusGatewayTimeout:      true,
+	}
+
+	for status, retriable := range retriableByStatus {
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			assert.Equal(t, retriable, retriableMintFailure(&http.Response{StatusCode: status}, nil))
+		})
+	}
+}
+
+func TestRetriableMintFailureOnFailedRoundTrip(t *testing.T) {
+	assert.True(t, retriableMintFailure(nil, assert.AnError))
+}
+
+// TestMintingHTTPClientRetriesServerError verifies that retriableMintFailure reaches the transport:
+// HTTP 500 is a status the shared default would have handed back on the first attempt.
+func TestMintingHTTPClientRetriesServerError(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			writer.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	response, err := mintingHTTPClient().Get(server.URL)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, int64(2), requests.Load())
+}

--- a/dynatrace/rest/wif/jwt.go
+++ b/dynatrace/rest/wif/jwt.go
@@ -1,0 +1,63 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package wif
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// header, payload and signature
+const jwtSegmentCount = 3
+
+var (
+	errNotAJWT             = errors.New("the ID token is not a JWT: expected three dot-separated segments")
+	errPayloadNotBase64URL = errors.New("the payload segment of the ID token is not valid base64url")
+	errPayloadNotJSON      = errors.New("the payload segment of the ID token is not valid JSON")
+	errNoExpiryClaim       = errors.New("the ID token has no `exp` claim, so its expiry cannot be determined")
+)
+
+// expiryOf reads the expiry claim out of a JWT without verifying it. No signature check is missing
+// here: the provider is not the relying party for these tokens, the Dynatrace platform is.
+func expiryOf(token string) (time.Time, error) {
+	segments := strings.Split(token, ".")
+	if len(segments) != jwtSegmentCount {
+		return time.Time{}, errNotAJWT
+	}
+
+	// GitHub does not pad, but other encoders do.
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(segments[1], "="))
+	if err != nil {
+		return time.Time{}, errPayloadNotBase64URL
+	}
+
+	var claims struct {
+		Expiry int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, errPayloadNotJSON
+	}
+	if claims.Expiry == 0 {
+		return time.Time{}, errNoExpiryClaim
+	}
+
+	return time.Unix(claims.Expiry, 0), nil
+}

--- a/dynatrace/rest/wif/jwt_test.go
+++ b/dynatrace/rest/wif/jwt_test.go
@@ -1,0 +1,67 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wif
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jwtWithPayload assembles a JWT out of the given raw payload JSON. Its signature segment is not a
+// real signature: nothing in this package verifies it, and supplying a valid one would suggest
+// otherwise.
+func jwtWithPayload(payload string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	return header + "." + base64.RawURLEncoding.EncodeToString([]byte(payload)) + ".not-a-real-signature"
+}
+
+func TestExpiryOfReadsExpiryClaim(t *testing.T) {
+	expiry, err := expiryOf(jwtWithPayload(`{"aud":"dynatrace","exp":1767225600,"iat":1767225000}`))
+
+	require.NoError(t, err)
+	assert.Equal(t, time.Unix(1767225600, 0), expiry)
+}
+
+func TestExpiryOfRejectsTokenThatIsNotAJWT(t *testing.T) {
+	_, err := expiryOf("not-a-jwt")
+
+	assert.ErrorIs(t, err, errNotAJWT)
+}
+
+func TestExpiryOfRejectsPayloadThatIsNotBase64(t *testing.T) {
+	_, err := expiryOf("header.not!valid!base64.signature")
+
+	assert.ErrorIs(t, err, errPayloadNotBase64URL)
+}
+
+func TestExpiryOfRejectsPayloadThatIsNotJSON(t *testing.T) {
+	_, err := expiryOf(jwtWithPayload("this is not JSON"))
+
+	assert.ErrorIs(t, err, errPayloadNotJSON)
+}
+
+func TestExpiryOfRejectsPayloadWithoutExpiryClaim(t *testing.T) {
+	_, err := expiryOf(jwtWithPayload(`{"aud":"dynatrace","iat":1767225000}`))
+
+	assert.ErrorIs(t, err, errNoExpiryClaim)
+}

--- a/dynatrace/rest/wif/minter.go
+++ b/dynatrace/rest/wif/minter.go
@@ -1,0 +1,39 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package wif
+
+import (
+	"context"
+	"net/http"
+)
+
+// Vendors differ in how they authenticate to their own token service, so each implementation
+// discovers and validates its own credentials in its constructor.
+type minter interface {
+	mint(ctx context.Context) (string, error)
+}
+
+// Reaches no network, so missing credentials surface while the provider is configured.
+func newMinter(config Config, httpClient *http.Client) (minter, error) {
+	switch config.Vendor {
+	case VendorGitHub:
+		return newGitHubMinter(config.Audience, httpClient)
+	default:
+		return nil, unsupportedVendorError(config.Vendor)
+	}
+}

--- a/dynatrace/rest/wif/token_source.go
+++ b/dynatrace/rest/wif/token_source.go
@@ -1,0 +1,77 @@
+/**
+* @license
+* Copyright 2026 Dynatrace LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package wif
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// refreshMargin is how long before its stated expiry a token is replaced: wide enough that a token handed
+// out just before it is due cannot expire in flight, and wide enough to absorb a clock differing from
+// the platform's.
+const refreshMargin = 2 * time.Minute
+
+// TokenSourceFor returns a token source for the given configuration. Every mint is bounded by ctx, so
+// ctx has to outlive the requests the source ends up authenticating.
+func TokenSourceFor(ctx context.Context, config Config) (oauth2.TokenSource, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	if len(config.StaticToken) > 0 {
+		// No expiry: reporting one would make oauth2 discard a token the provider cannot re-mint.
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: config.StaticToken}), nil
+	}
+
+	minter, err := newMinter(config, mintingHTTPClient())
+	if err != nil {
+		return nil, err
+	}
+
+	return reusingTokenSource(ctx, minter), nil
+}
+
+func reusingTokenSource(ctx context.Context, minter minter) oauth2.TokenSource {
+	return oauth2.ReuseTokenSourceWithExpiry(nil, &mintingTokenSource{mintContext: ctx, minter: minter}, refreshMargin)
+}
+
+// mintingTokenSource mints on every call; when that is necessary is decided by the source wrapping it.
+type mintingTokenSource struct {
+	// Held rather than passed: oauth2.TokenSource.Token takes no context, and this one must outlive
+	// every request that uses the source.
+	mintContext context.Context
+	minter      minter
+}
+
+func (source *mintingTokenSource) Token() (*oauth2.Token, error) {
+	rawToken, err := source.minter.mint(source.mintContext)
+	if err != nil {
+		return nil, err
+	}
+
+	expiry, err := expiryOf(rawToken)
+	if err != nil {
+		return nil, err
+	}
+
+	// An empty TokenType is what makes oauth2 send this as a bearer token.
+	return &oauth2.Token{AccessToken: rawToken, Expiry: expiry}, nil
+}

--- a/dynatrace/rest/wif/token_source_test.go
+++ b/dynatrace/rest/wif/token_source_test.go
@@ -1,0 +1,234 @@
+//go:build unit
+
+/*
+ * @license
+ * Copyright 2026 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wif
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/terraform-provider-dynatrace/provider/envutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// Running out of prepared tokens is a test error rather than a silent repeat, so that a test
+// claiming a token was reused cannot pass by accident.
+type recordingMinter struct {
+	tokens      []string
+	err         error
+	calls       int
+	lastContext context.Context
+}
+
+func (minter *recordingMinter) mint(ctx context.Context) (string, error) {
+	minter.calls++
+	minter.lastContext = ctx
+	if minter.err != nil {
+		return "", minter.err
+	}
+	if minter.calls > len(minter.tokens) {
+		return "", fmt.Errorf("minter asked for token %d but only %d were prepared", minter.calls, len(minter.tokens))
+	}
+	return minter.tokens[minter.calls-1], nil
+}
+
+func tokenExpiringIn(validity time.Duration) string {
+	return jwtWithPayload(fmt.Sprintf(`{"exp":%d}`, time.Now().Add(validity).Unix()))
+}
+
+// A vendor minter reads these while it is being built.
+func setMintingCredentials(t *testing.T) {
+	t.Helper()
+
+	t.Setenv(envutils.ActionsIDTokenRequestURL.Key, "https://token.service.invalid/")
+	t.Setenv(envutils.ActionsIDTokenRequestToken.Key, "request-token")
+}
+
+func newMintingTokenSource(t *testing.T, minter minter) *mintingTokenSource {
+	return &mintingTokenSource{mintContext: t.Context(), minter: minter}
+}
+
+func TestMintingTokenSourceReturnsMintedToken(t *testing.T) {
+	rawToken := tokenExpiringIn(time.Hour)
+
+	token, err := newMintingTokenSource(t, &recordingMinter{tokens: []string{rawToken}}).Token()
+
+	require.NoError(t, err)
+	assert.Equal(t, rawToken, token.AccessToken)
+}
+
+func TestMintingTokenSourceLeavesTokenTypeEmpty(t *testing.T) {
+	token, err := newMintingTokenSource(t, &recordingMinter{tokens: []string{tokenExpiringIn(time.Hour)}}).Token()
+
+	require.NoError(t, err)
+	assert.Equal(t, "", token.TokenType)
+}
+
+func TestMintingTokenSourceReportsExpiryClaimedByToken(t *testing.T) {
+	expiry := time.Now().Add(time.Hour)
+	rawToken := jwtWithPayload(fmt.Sprintf(`{"exp":%d}`, expiry.Unix()))
+
+	token, err := newMintingTokenSource(t, &recordingMinter{tokens: []string{rawToken}}).Token()
+
+	require.NoError(t, err)
+	assert.Equal(t, time.Unix(expiry.Unix(), 0), token.Expiry)
+}
+
+// A token is minted on every call. Reuse is the job of the source wrapping this one.
+func TestMintingTokenSourceMintsOnEveryCall(t *testing.T) {
+	minter := &recordingMinter{tokens: []string{tokenExpiringIn(time.Hour), tokenExpiringIn(2 * time.Hour)}}
+	source := newMintingTokenSource(t, minter)
+
+	_, err := source.Token()
+	require.NoError(t, err)
+	second, err := source.Token()
+
+	require.NoError(t, err)
+	assert.Equal(t, minter.tokens[1], second.AccessToken)
+	assert.Equal(t, 2, minter.calls)
+}
+
+func TestMintingTokenSourcePropagatesMintingFailure(t *testing.T) {
+	mintErr := errors.New("the token service is unreachable")
+
+	_, err := newMintingTokenSource(t, &recordingMinter{err: mintErr}).Token()
+
+	assert.ErrorIs(t, err, mintErr)
+}
+
+func TestMintingTokenSourceRejectsTokenWithoutExpiry(t *testing.T) {
+	_, err := newMintingTokenSource(t, &recordingMinter{tokens: []string{jwtWithPayload(`{"aud":"dynatrace"}`)}}).Token()
+
+	assert.ErrorIs(t, err, errNoExpiryClaim)
+}
+
+// The cancellation is only a marker, identifying the context the minter was handed.
+func TestMintingTokenSourceMintsWithTheContextItWasGiven(t *testing.T) {
+	minter := &recordingMinter{tokens: []string{tokenExpiringIn(time.Hour)}}
+	cancelledContext, cancel := context.WithCancel(t.Context())
+	cancel()
+	source := &mintingTokenSource{mintContext: cancelledContext, minter: minter}
+
+	_, err := source.Token()
+
+	require.NoError(t, err)
+	assert.ErrorIs(t, minter.lastContext.Err(), context.Canceled)
+}
+
+// Only one token is prepared, so a second trip to the minter fails the test.
+func TestReusingTokenSourceKeepsTokenUntilItIsDue(t *testing.T) {
+	minter := &recordingMinter{tokens: []string{tokenExpiringIn(time.Hour)}}
+	source := reusingTokenSource(t.Context(), minter)
+
+	first, err := source.Token()
+	require.NoError(t, err)
+	second, err := source.Token()
+
+	require.NoError(t, err)
+	assert.Equal(t, first.AccessToken, second.AccessToken)
+	assert.Equal(t, 1, minter.calls)
+}
+
+// A token whose remaining life is shorter than the margin is due the moment it arrives. Were the
+// margin not passed on, oauth2 would apply its ten second default and reuse this one instead.
+func TestReusingTokenSourceReplacesTokenInsideTheRefreshMargin(t *testing.T) {
+	minter := &recordingMinter{tokens: []string{tokenExpiringIn(refreshMargin / 2), tokenExpiringIn(time.Hour)}}
+	source := reusingTokenSource(t.Context(), minter)
+
+	_, err := source.Token()
+	require.NoError(t, err)
+	second, err := source.Token()
+
+	require.NoError(t, err)
+	assert.Equal(t, minter.tokens[1], second.AccessToken)
+	assert.Equal(t, 2, minter.calls)
+}
+
+func TestReusingTokenSourcePropagatesMintingFailure(t *testing.T) {
+	mintErr := errors.New("the token service is unreachable")
+
+	_, err := reusingTokenSource(t.Context(), &recordingMinter{err: mintErr}).Token()
+
+	assert.ErrorIs(t, err, mintErr)
+}
+
+// Handing oauth2 a token without an expiry is what keeps it from discarding a supplied one.
+func TestStaticTokenSourceHandsOutTheSuppliedTokenWithoutExpiry(t *testing.T) {
+	token, err := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "supplied.id.token"}).Token()
+
+	require.NoError(t, err)
+	assert.Equal(t, "supplied.id.token", token.AccessToken)
+	assert.True(t, token.Expiry.IsZero())
+}
+
+func TestTokenSourceForBuildsSourceForVendor(t *testing.T) {
+	setMintingCredentials(t)
+
+	source, err := TokenSourceFor(t.Context(), Config{Vendor: VendorGitHub, Audience: "dynatrace"})
+
+	require.NoError(t, err)
+	assert.NotNil(t, source)
+}
+
+func TestTokenSourceForReportsMissingVendorCredentials(t *testing.T) {
+	t.Setenv(envutils.ActionsIDTokenRequestURL.Key, "")
+	t.Setenv(envutils.ActionsIDTokenRequestToken.Key, "")
+
+	_, err := TokenSourceFor(t.Context(), Config{Vendor: VendorGitHub, Audience: "dynatrace"})
+
+	assert.ErrorIs(t, err, errMissingCredential)
+}
+
+func TestTokenSourceForReturnsSuppliedStaticToken(t *testing.T) {
+	rawToken := jwtWithPayload(`{"exp":1767225600}`)
+
+	source, err := TokenSourceFor(t.Context(), Config{StaticToken: rawToken})
+	require.NoError(t, err)
+
+	token, err := source.Token()
+	require.NoError(t, err)
+	assert.Equal(t, rawToken, token.AccessToken)
+}
+
+// Reporting an expiry would make oauth2 discard the token and leave the request unauthenticated.
+func TestTokenSourceForLeavesSuppliedStaticTokenWithoutExpiry(t *testing.T) {
+	source, err := TokenSourceFor(t.Context(), Config{StaticToken: jwtWithPayload(`{"exp":1767225600}`)})
+	require.NoError(t, err)
+
+	token, err := source.Token()
+	require.NoError(t, err)
+	assert.True(t, token.Expiry.IsZero())
+}
+
+// Without this, an unconfigured setup used to yield a token source handing out an empty bearer token.
+func TestTokenSourceForRejectsUnconfiguredFederation(t *testing.T) {
+	_, err := TokenSourceFor(t.Context(), Config{})
+
+	assert.ErrorIs(t, err, errNotConfigured)
+}
+
+func TestTokenSourceForRejectsInvalidConfiguration(t *testing.T) {
+	_, err := TokenSourceFor(t.Context(), Config{Vendor: VendorGitHub})
+
+	assert.ErrorIs(t, err, errNoAudience)
+}

--- a/provider/envutils/env_vars.go
+++ b/provider/envutils/env_vars.go
@@ -75,6 +75,23 @@ var DTRestDebugLog = StringEnvVar{
 	DefaultValue: "",
 }
 
+// --- Workload Identity Federation ---
+
+// ActionsIDTokenRequestURL is the endpoint a GitHub Actions job asks for an OIDC token. Unlike the
+// variables above it is not set by the user: GitHub injects it into every job holding the
+// id-token: write permission, which is why its absence is reported as a missing permission.
+var ActionsIDTokenRequestURL = StringEnvVar{
+	Key:          "ACTIONS_ID_TOKEN_REQUEST_URL",
+	DefaultValue: "",
+}
+
+// ActionsIDTokenRequestToken authenticates the request to the endpoint above. It is a credential and
+// must never reach a log, an error message or a Terraform diagnostic.
+var ActionsIDTokenRequestToken = StringEnvVar{
+	Key:          "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+	DefaultValue: "",
+}
+
 // --- Settings 2.0 ---
 
 // DTNoRepairInput disables automatic repair of invalid settings input.


### PR DESCRIPTION
#### **Why** this PR?
Preparing WIF support

#### **What** has changed?
Moved `RetryTransport`:
- `dynatrace/rest/retry_transport.go` moved to the leaf package `dynatrace/rest/retry`; `RetryTransport` became `retry.Transport`. `NewContextWithOAuthRetryClient` stayed in `rest`, now in its own `oauth_retry_client.go`.
- `retry.Transport` gained a `ShouldRetry func(*http.Response, error) bool` field, defaulting to `IfTooManyRequestsOrServiceUnavailable` — the previous 429/503-only behaviour.

Added `rest/wif` package containing:
- `jwt` for extracting the expiry from a token
- `config` defines a config containing WIF vendor, audience, and optionally a pre-minted token as a non-refreshable escape hatch for workloads that cannot mint one.
- `validate` for validating a config
- `minter` for defining a minter interface and as entry point for creating minters for different vendors
- `github` implements the OIDC token minter for GitHub
- `http_client` builds the client used to talk to a token service: a `retry.Transport` widened to retry any 5xx and a round trip that never completed, over an explicit `http.Transport` rather than `http.DefaultTransport`.
- `token_source` mints tokens on demand, reads the expiry from the token and lets `oauth2.ReuseTokenSourceWithExpiry` decide when to re-mint. Contains a cache, which is necessary, since every `platform_request` creates its own platform client, but we do not want to create a new token source every time this happens.

- Added two new entries in `env_vars.go` for GitHub Action-provided vars `ActionsIDTokenRequestURL` and `ActionsIDTokenRequestToken`

#### **How** does it do it?

- Sources are cached per `Config.cacheKey()` (vendor + audience) for the life of the process, since a platform client is built per request. A pre-minted token is never cached, so a credential cannot become a key in a process-long map.
- Caching, the two-minute refresh margin and single-flight minting all come from `oauth2.ReuseTokenSourceWithExpiry`; the package only mints and reads the `exp` claim. A pre-minted token becomes an `oauth2.StaticTokenSource` with no expiry, since reporting one would make `oauth2` discard a token that cannot be re-minted.
- `mintingHTTPClient` must not use `http.DefaultTransport`: the provider mutates that one when `DYNATRACE_HTTP_INSECURE` is set, and that escape hatch must not disable certificate verification on the call carrying the minting credentials.
- No signature is verified when reading the `exp` claim, and none is missing — the provider is not the relying party for these tokens, the Dynatrace platform is. The package also imports neither `rest` nor its HTTP logging, since the responses of a token service are the tokens themselves. Error strings name no provider attribute; which attribute sets a value is the provider layer's business.

#### How is it **tested**?
Unit tests 

#### How does it affect **users**?
- No user-facing change. Nothing imports `rest/wif` yet, and no provider attribute or environment variable is read during a plan or apply.
- `retry.Transport` behaves as `RetryTransport` did for existing callers: `ShouldRetry` defaults to the 429/503 check that used to be hardcoded.

**Issue:** PS-49502